### PR TITLE
Lint (Oxlint) + SECURITY / CONTRIBUTING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Typecheck
         run: pnpm -r typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+## Setup
+
+```sh
+pnpm install
+pnpm -r typecheck   # one round to prime tsc caches
+```
+
+Run the app locally:
+
+```sh
+pnpm --filter @reef/server dev   # http://localhost:8787
+pnpm --filter @reef/client dev   # http://localhost:5173
+```
+
+For desktop dev without a camera / pedestal, open
+`http://localhost:5173/?tracker=noop` — the reef anchors a fixed
+distance in front of the virtual camera.
+
+## Testing
+
+Each package has its own suite. Run them all:
+
+```sh
+pnpm -r test
+```
+
+Or target a package:
+
+```sh
+pnpm --filter @reef/shared test
+pnpm --filter @reef/generator test
+pnpm --filter @reef/server test
+pnpm --filter @reef/client test     # vitest + happy-dom
+```
+
+Server has both route tests (Fastify inject) and integration tests
+against a real `ws` client (see `packages/server/src/ws.integration.test.ts`).
+
+## Test-first, please
+
+New behaviour lands with a test that was written first and seen fail.
+The generator has hash goldens + structural invariants; any intended
+change to mesh output needs the hash rolled in the same commit.
+
+## Lint / typecheck before pushing
+
+```sh
+pnpm lint
+pnpm -r typecheck
+```
+
+CI runs both; the PR can't merge if either fails.
+
+## Commit style
+
+Plain English, present tense, no prefixes like `[feat]`. Leading
+sentence is a summary; wrap body at ~72 chars. Example:
+
+```
+Compact WS broadcast to drop closed clients atomically
+
+Broadcast used to iterate `clients` and call `ws.send` without
+checking `readyState`; a closed socket threw, aborting the loop
+mid-way. Switch to `readyState === WS_OPEN` with a per-client
+try/catch that evicts on throw.
+```
+
+## Opening a PR
+
+- One PR per logical change. Small PRs merge faster.
+- Include a test plan in the description (CI covers typecheck/build/tests;
+  manual verification for UX-affecting changes).
+- CI must be green. `main` is protected and requires the **Build and test**
+  check to pass.
+
+## Questions
+
+Open a discussion or draft PR and tag me. Rough ideas welcome; nothing
+is load-bearing yet.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting
+
+If you find a vulnerability, please **do not open a public issue**. Email
+the maintainer at `jcosta@execonline.com` with:
+
+- A description of the issue
+- Reproduction steps or a proof-of-concept
+- Your assessment of impact (who can do what as a result)
+
+I'll acknowledge within a few days and keep you in the loop on the fix
+and any coordinated disclosure.
+
+## Scope
+
+Relevant threats for this project:
+
+- **Unauthenticated writes**: all POST/DELETE paths should require the
+  right capability. Admin routes are bearer-token gated.
+- **Rate-limit bypass**: one polyp per device per hour is the public
+  contract; deviceHash + per-IP token bucket enforce it.
+- **Resource exhaustion**: WebSocket frames have a 64 KB payload cap;
+  the server soft-hearbeats and evicts silent clients.
+- **Cross-site leaks**: CORS pins the origin via `CORS_ORIGINS`; no
+  secrets are ever rendered into HTML responses.
+
+Out of scope:
+
+- Issues in third-party dependencies (report upstream)
+- Social engineering of the operator's Cloudflare / domain
+- Physical access to the server (self-hosted — assume a trusted LAN)
+
+## Hardening recommendations for operators
+
+- Set `ADMIN_TOKEN` to a long random string (`openssl rand -hex 32`).
+  The startup log warns if unset.
+- Keep `CORS_ORIGINS` restricted to your production hostname. `*` is
+  the dev default; change it in `.env`.
+- Put the service behind Cloudflare Tunnel (recommended) or another
+  reverse proxy. Don't expose `:8787` directly to the internet.
+- Back up `data/reef.db` on a cron; the SQLite `.backup` command is
+  safe against a live writer.

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "dev:server": "pnpm --filter @reef/server dev",
     "dev": "pnpm -r --parallel dev",
     "typecheck": "pnpm -r typecheck",
-    "lint": "pnpm -r lint",
+    "lint": "oxlint packages",
     "test": "pnpm -r test",
     "clean": "pnpm -r exec rm -rf dist node_modules"
   },
   "devDependencies": {
+    "oxlint": "^0.15.0",
     "typescript": "^5.4.0"
   },
   "engines": {

--- a/packages/client/src/timelapse.ts
+++ b/packages/client/src/timelapse.ts
@@ -50,7 +50,10 @@ function render(t: number): void {
 }
 
 function clearReef(): void {
-  for (const child of [...reefGroup.children]) {
+  // Iterate by always pulling the first element so that `reefGroup.remove`
+  // mutating `children` mid-loop doesn't skip entries.
+  while (reefGroup.children.length > 0) {
+    const child = reefGroup.children[0]!;
     reefGroup.remove(child);
     disposeTree(child);
   }

--- a/packages/generator/src/species/bulbous.ts
+++ b/packages/generator/src/species/bulbous.ts
@@ -1,5 +1,4 @@
 import type { RNG } from '../rng.js';
-import type { MeshData } from '../meshdata.js';
 import type { GeneratedPolyp } from '../generate.js';
 import { tintColor, type Rgb } from './_common.js';
 

--- a/packages/generator/src/species/encrusting.ts
+++ b/packages/generator/src/species/encrusting.ts
@@ -1,5 +1,4 @@
 import type { RNG } from '../rng.js';
-import type { MeshData } from '../meshdata.js';
 import type { GeneratedPolyp } from '../generate.js';
 import { tintColor, type Rgb } from './_common.js';
 

--- a/packages/generator/src/species/fan.ts
+++ b/packages/generator/src/species/fan.ts
@@ -1,5 +1,4 @@
 import type { RNG } from '../rng.js';
-import type { MeshData } from '../meshdata.js';
 import type { GeneratedPolyp } from '../generate.js';
 import { tintColor, type Rgb } from './_common.js';
 

--- a/packages/generator/src/species/tube.ts
+++ b/packages/generator/src/species/tube.ts
@@ -1,5 +1,4 @@
 import type { RNG } from '../rng.js';
-import type { MeshData } from '../meshdata.js';
 import type { GeneratedPolyp } from '../generate.js';
 import { tintColor, type Rgb } from './_common.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      oxlint:
+        specifier: ^0.15.0
+        version: 0.15.15
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -443,6 +446,46 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@oxlint/darwin-arm64@0.15.15':
+    resolution: {integrity: sha512-7GOyGM6D36lUhsOvavAVpF72SycPVG0Enunx0bzv8g0+9TklzOSFN3FJlZjLst14VPdZWujZMLgkQC7tOp+Rwg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/darwin-x64@0.15.15':
+    resolution: {integrity: sha512-pbrnYFwMn/fuX0z3IeQ05Nvo/b1zGxjmmWgkrQSDwYHxBxP6NT41hk1pmqkcA+v53xk9wvOa/6vBBI/U30F8Ow==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/linux-arm64-gnu@0.15.15':
+    resolution: {integrity: sha512-QWjG3YVsDlIvDTBUPmtPiyqP34ZQpFJqQh2JO94pBih11lFxQ0IGVMEXDhmW3WdiSFPZSJsZGzWynalM9eg+RA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-arm64-musl@0.15.15':
+    resolution: {integrity: sha512-4W0YsmMSbNzzExOWhk+6zNfmJEmKFqSjFIn8CKLtYFvH8kF6KjoW4/0HNsDNYW5Fz+KOut/2JgkvxAiKH+r0zA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-x64-gnu@0.15.15':
+    resolution: {integrity: sha512-agP3e+eQ6tE5tqN6VI4Uukx2yvjwYFjtrDMcB19J7PmGOaFRwuMuT0sNWK/9guvhuS9aCINNZTi3kEhMy9Qgng==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/linux-x64-musl@0.15.15':
+    resolution: {integrity: sha512-L2qE9NhhUafsJOO4pofLx/0hW5IB0sfJa6bS85q0j+ySaI0f3CxMaAadrZLFSuqHWB3oF18B5yvzaPWsc2ohbQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/win32-arm64@0.15.15':
+    resolution: {integrity: sha512-B7f4VAS/E78n8zy6XZlNeyYOtWTel4BJn/22Ap2yEAlNzO34ot8dGfpLk6MqTUWJrRnARwVBVmc3wRVrsOT5yg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/win32-x64@0.15.15':
+    resolution: {integrity: sha512-ZM9T3/OpaQ3qvrk/VuHO2EQmhNH4cOZdr/b/Ju9VKwBr+ahhqMn3W5srrplWQWxfsb0yd1yBj7iD0jdAps2iLg==}
+    cpu: [x64]
+    os: [win32]
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -974,6 +1017,11 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  oxlint@0.15.15:
+    resolution: {integrity: sha512-oQNc1mAHrrbKiXyKJMGs9VCZfwGfLy7YiQKa4qupi71X/u4xyWqOh36YKXqWOXnmm2y7vfWFpGZlhJPAa9tMqA==}
+    engines: {node: '>=8.*'}
+    hasBin: true
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1533,6 +1581,30 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
+  '@oxlint/darwin-arm64@0.15.15':
+    optional: true
+
+  '@oxlint/darwin-x64@0.15.15':
+    optional: true
+
+  '@oxlint/linux-arm64-gnu@0.15.15':
+    optional: true
+
+  '@oxlint/linux-arm64-musl@0.15.15':
+    optional: true
+
+  '@oxlint/linux-x64-gnu@0.15.15':
+    optional: true
+
+  '@oxlint/linux-x64-musl@0.15.15':
+    optional: true
+
+  '@oxlint/win32-arm64@0.15.15':
+    optional: true
+
+  '@oxlint/win32-x64@0.15.15':
+    optional: true
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -2051,6 +2123,17 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  oxlint@0.15.15:
+    optionalDependencies:
+      '@oxlint/darwin-arm64': 0.15.15
+      '@oxlint/darwin-x64': 0.15.15
+      '@oxlint/linux-arm64-gnu': 0.15.15
+      '@oxlint/linux-arm64-musl': 0.15.15
+      '@oxlint/linux-x64-gnu': 0.15.15
+      '@oxlint/linux-x64-musl': 0.15.15
+      '@oxlint/win32-arm64': 0.15.15
+      '@oxlint/win32-x64': 0.15.15
 
   package-json-from-dist@1.0.1: {}
 


### PR DESCRIPTION
## Summary

- **Oxlint** at the repo root, wired into CI before typecheck. One binary, zero config, ~10 ms to lint 69 files.
- Fixed 5 existing warnings surfaced on the first run: 4 unused \`MeshData\` type imports across species modules, and one iteration-during-mutation pattern in \`timelapse.ts\` rewritten as an explicit first-child pop.
- **SECURITY.md**: threat model + operator hardening, private disclosure email.
- **CONTRIBUTING.md**: setup, test-first workflow, per-package test commands (incl. vitest+happy-dom for client), commit/PR conventions.

## Test plan

- [x] \`pnpm lint\` — 0 warnings, 0 errors
- [x] \`pnpm -r typecheck\` — clean
- [x] \`pnpm -r test\` — 97 pass (12 shared + 22 generator + 56 server + 7 client)
- [x] CI \`Build and test\` required by branch protection; will not merge unless green

🤖 Generated with [Claude Code](https://claude.com/claude-code)