### PR TITLE
Release automation: publish Docker image to GHCR on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/Dockerfile.server
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Release"
+            echo ""
+            echo "Tags pushed:"
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,25 @@ try/catch that evicts on throw.
 - CI must be green. `main` is protected and requires the **Build and test**
   check to pass.
 
+## Releasing
+
+Tagging a commit on `main` with `vX.Y.Z` triggers
+`.github/workflows/release.yml`, which builds the server image for
+linux/amd64 + linux/arm64 and publishes to
+`ghcr.io/costajohnt/coralreefar` with three tags:
+
+- `vX.Y.Z`
+- `X.Y` (minor)
+- `latest`
+
+```sh
+git tag -a v0.2.0 -m "v0.2.0: brief release note"
+git push origin v0.2.0
+```
+
+Operators who pin to a version get reproducibility; the rest follow
+`:latest`.
+
 ## Questions
 
 Open a discussion or draft PR and tag me. Rough ideas welcome; nothing

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,8 +54,25 @@ Alternatives if you want the client on a CDN edge:
 
 ## 3. Bring the stack up
 
+Two options — pick one:
+
+**Pre-built image (recommended for production):**
+
 ```sh
+docker compose pull
 docker compose up -d
+docker compose logs -f server
+```
+
+Compose pulls `ghcr.io/costajohnt/coralreefar:latest`. Pin to a
+specific version for reproducibility — edit `docker-compose.yml` and
+replace `:latest` with `:vX.Y.Z`. Released versions appear at
+<https://github.com/costajohnt/CoralReefAR/pkgs/container/coralreefar>.
+
+**Build from source (local dev or un-released changes):**
+
+```sh
+docker compose up -d --build
 docker compose logs -f server
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 services:
   server:
+    # Pre-built image from GHCR. Switch to `image:`/`build:` according to
+    # your workflow: `docker compose up -d` pulls; `docker compose up -d
+    # --build` uses the local Dockerfile. Tag `latest` follows main;
+    # pin to `vX.Y.Z` in production.
+    image: ghcr.io/costajohnt/coralreefar:latest
     build:
       context: .
       dockerfile: infra/Dockerfile.server


### PR DESCRIPTION
## Summary

On \`vX.Y.Z\` tag push, a new \`Release\` workflow builds the server Docker image via Buildx for \`linux/amd64\` + \`linux/arm64\` and publishes it to \`ghcr.io/costajohnt/coralreefar\` tagged \`vX.Y.Z\`, \`X.Y\`, and \`latest\`.

\`docker-compose.yml\` now references the published image by default (with \`build:\` retained so \`--build\` still works for local changes). \`INSTALL.md\` documents both paths. \`CONTRIBUTING.md\` has a Releasing section with the exact tag commands.

## Test plan

- [x] \`pnpm lint\` / \`pnpm -r typecheck\` clean
- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"\` parses the workflow
- [x] CI \`Build and test\` required by branch protection
- [ ] After merge: tag \`v0.1.0\` and confirm the Release workflow fires and pushes the image to GHCR (manual, after merge)

## Note

The release workflow uses \`GITHUB_TOKEN\` with \`packages: write\`, which is automatic — no secret configuration needed. First push may require the repository to make its packages public separately (via the package settings page on GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)