### PR TITLE
CONTRIBUTING: remove incorrect GHCR visibility note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,12 +94,6 @@ git push origin v0.2.0
 Operators who pin to a version get reproducibility; the rest follow
 `:latest`.
 
-**First-time only**: new GHCR packages are created private by default.
-After the first successful release, open
-<https://github.com/users/costajohnt/packages/container/coralreefar/settings>
-and flip visibility to **Public** so operators can `docker pull`
-without a PAT.
-
 ## Questions
 
 Open a discussion or draft PR and tag me. Rough ideas welcome; nothing


### PR DESCRIPTION
Docs-only. The image at `ghcr.io/costajohnt/coralreefar` is already
public and anonymously pullable — my earlier note claiming a manual
settings toggle was needed was wrong. Verified:

    $ curl -s 'https://ghcr.io/token?service=ghcr.io&scope=repository:costajohnt/coralreefar:pull' | jq -r .token | head -c 20
    eyJhbGciOiJSUzI1NiIs...
    $ curl -H "Authorization: Bearer \$TOKEN" https://ghcr.io/v2/costajohnt/coralreefar/tags/list
    {"name":"costajohnt/coralreefar","tags":["0.1.0","0.1","latest"]}

The earlier 401 was GHCR's standard /v2 auth-challenge flow, which
\`docker pull\` satisfies automatically via /token. No operator action
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)