### PR TITLE
Dependabot: weekly npm + actions + docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to current versions — catches Node 20→24
+  # deprecations and minor-version action fixes as they ship.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: [dependencies, ci]
+    commit-message:
+      prefix: ci
+      include: scope
+
+  # Single pnpm workspace — Dependabot's npm ecosystem reads pnpm-lock.yaml
+  # at the root and proposes updates across all packages.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+    commit-message:
+      prefix: deps
+      include: scope
+    # Batch patch + minor bumps together to keep PR noise down; majors still
+    # get their own PR so they're easy to review.
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        update-types: [patch, minor]
+
+  # Dockerfile base image updates (alpine / node base).
+  - package-ecosystem: docker
+    directory: /infra
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    labels: [dependencies, docker]
+    commit-message:
+      prefix: docker


### PR DESCRIPTION
## Summary

Weekly Monday dependency PRs across three ecosystems:

- **GitHub Actions** (\`/.github/workflows/\`) — catches future action majors (e.g. \`docker/*\` Node-24 bumps).
- **npm** (\`/\`) — reads \`pnpm-lock.yaml\` at the root and covers every workspace package. Patch + minor batched into one PR per week; majors land individually for review.
- **Docker** (\`/infra/\`) — base-image bumps for \`Dockerfile.server\`.

PR cap: 5 per ecosystem per week (2 for docker). Commit-message prefixes (\`ci:\`, \`deps:\`, \`docker:\`) keep the log scannable.

## Test plan

- [x] YAML parses: \`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\`
- [x] \`pnpm lint\` clean
- [ ] Post-merge: first Dependabot run will pick up the config within ~24h; expected to open 1–3 PRs on its first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)