### PR TITLE
More client tests: net/api + tracking selection

### DIFF
--- a/packages/client/src/net/api.test.ts
+++ b/packages/client/src/net/api.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchReef, submitPolyp, RateLimitError } from './api.js';
+
+function mockFetch(status: number, body: unknown): void {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(
+    typeof body === 'string' ? body : JSON.stringify(body),
+    { status, headers: { 'content-type': 'application/json' } },
+  )));
+}
+
+const validInput = {
+  species: 'branching' as const,
+  seed: 1,
+  colorKey: 'coral-pink',
+  position: [0, 0, 0] as [number, number, number],
+  orientation: [0, 0, 0, 1] as [number, number, number, number],
+  scale: 1,
+};
+
+describe('fetchReef', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('resolves with the parsed reef state on 200', async () => {
+    mockFetch(200, { polyps: [], sim: [], serverTime: 42 });
+    const state = await fetchReef();
+    expect(state).toEqual({ polyps: [], sim: [], serverTime: 42 });
+  });
+
+  test('throws on non-2xx with status in the message', async () => {
+    mockFetch(500, {});
+    await expect(fetchReef()).rejects.toThrowError(/fetchReef 500/);
+  });
+});
+
+describe('submitPolyp', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('resolves with the saved polyp on 201', async () => {
+    mockFetch(201, { id: 7, ...validInput, createdAt: 123 });
+    const saved = await submitPolyp(validInput);
+    expect(saved.id).toBe(7);
+    expect(saved.species).toBe('branching');
+  });
+
+  test('throws RateLimitError with retryAfterMs on 429', async () => {
+    mockFetch(429, { error: 'rate_limited', retryAfterMs: 1234 });
+    const err = await submitPolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfterMs).toBe(1234);
+  });
+
+  test('RateLimitError falls back to 1h when body is missing retryAfterMs', async () => {
+    mockFetch(429, { error: 'rate_limited' });
+    const err = await submitPolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfterMs).toBe(3_600_000);
+  });
+
+  test('RateLimitError falls back to 1h when body is malformed JSON', async () => {
+    mockFetch(429, 'not json');
+    const err = await submitPolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect((err as RateLimitError).retryAfterMs).toBe(3_600_000);
+  });
+
+  test('throws a generic Error on other non-2xx', async () => {
+    mockFetch(400, { error: 'invalid_input' });
+    const err = await submitPolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(RateLimitError);
+    expect((err as Error).message).toContain('400');
+  });
+});

--- a/packages/client/src/tracking/index.test.ts
+++ b/packages/client/src/tracking/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// EightWallProvider.isAvailable() probes globals; stub the import so the
+// `auto` branch selection is deterministic in tests.
+vi.mock('./eightwall.js', () => ({
+  EightWallProvider: class {
+    static isAvailable = vi.fn(() => false);
+    readonly name = 'eightwall' as const;
+    async init(): Promise<void> {}
+    onAnchorFound(): void {}
+    onAnchorLost(): void {}
+    onFrame(): void {}
+    async start(): Promise<void> {}
+    async stop(): Promise<void> {}
+    async destroy(): Promise<void> {}
+  },
+}));
+
+import { EightWallProvider } from './eightwall.js';
+import { readTrackerFromUrl, selectProvider } from './index.js';
+
+describe('readTrackerFromUrl', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('returns the explicit param when set to a known value', () => {
+    vi.stubGlobal('location', { search: '?tracker=noop' });
+    expect(readTrackerFromUrl()).toBe('noop');
+    vi.stubGlobal('location', { search: '?tracker=eightwall' });
+    expect(readTrackerFromUrl()).toBe('eightwall');
+    vi.stubGlobal('location', { search: '?tracker=mindar' });
+    expect(readTrackerFromUrl()).toBe('mindar');
+  });
+
+  test('returns "auto" when the param is missing', () => {
+    vi.stubGlobal('location', { search: '' });
+    expect(readTrackerFromUrl()).toBe('auto');
+  });
+
+  test('returns "auto" when the param has an unknown value', () => {
+    vi.stubGlobal('location', { search: '?tracker=rubbish' });
+    expect(readTrackerFromUrl()).toBe('auto');
+  });
+});
+
+describe('selectProvider', () => {
+  beforeEach(() => {
+    (EightWallProvider.isAvailable as unknown as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  test('honors explicit noop regardless of 8th Wall availability', () => {
+    (EightWallProvider.isAvailable as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const p = selectProvider('noop');
+    expect(p.name).toBe('noop');
+  });
+
+  test('auto prefers EightWall when available', () => {
+    (EightWallProvider.isAvailable as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const p = selectProvider('auto');
+    expect(p.name).toBe('eightwall');
+  });
+
+  test('auto falls back to noop when EightWall is unavailable', () => {
+    (EightWallProvider.isAvailable as unknown as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const p = selectProvider('auto');
+    expect(p.name).toBe('noop');
+  });
+});


### PR DESCRIPTION
## Summary

Client coverage grows from 7 → 20 tests.

**net/api.test.ts** (7)
- \`fetchReef\` resolves on 200, throws with status on non-2xx.
- \`submitPolyp\` resolves on 201; throws \`RateLimitError\` with \`retryAfterMs\` on 429 (payload), falls back to 1h when \`retryAfterMs\` is missing or the body is malformed JSON; throws generic \`Error\` on other non-2xx.

**tracking/index.test.ts** (6)
- \`readTrackerFromUrl\` honors explicit \`eightwall\` / \`mindar\` / \`noop\`; falls back to \`auto\` on missing or unknown values.
- \`selectProvider\` respects explicit selections; \`auto\` prefers EightWall when available, falls back to Noop otherwise.

Uses \`vi.stubGlobal('fetch', ...)\` and \`vi.mock('./eightwall.js', ...)\` so tests are deterministic — no real 8th Wall runtime probes, no network I/O.

## Test plan

- [x] \`pnpm --filter @reef/client test\` — 20 pass
- [x] \`pnpm lint\` / \`pnpm -r typecheck\` clean
- [x] CI \`Build and test\` required by branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)