### PR TITLE
Metrics: reef_rate_limited_total counter

### DIFF
--- a/packages/server/src/metrics-registry.ts
+++ b/packages/server/src/metrics-registry.ts
@@ -1,0 +1,34 @@
+// Tiny in-memory counter registry for Prometheus. Single process only —
+// if the server ever horizontally scales, scrape each instance and let
+// Prometheus sum, or move to a real client library.
+
+export interface CounterSnapshot {
+  readonly name: string;
+  readonly value: number;
+}
+
+class Counters {
+  private readonly values = new Map<string, number>();
+
+  inc(name: string, amount = 1): void {
+    this.values.set(name, (this.values.get(name) ?? 0) + amount);
+  }
+
+  get(name: string): number {
+    return this.values.get(name) ?? 0;
+  }
+
+  // Exposed for tests: zero a counter so bumps in earlier tests don't
+  // leak into later ones. Production code never calls this.
+  reset(name: string): void {
+    this.values.set(name, 0);
+  }
+
+  snapshot(): CounterSnapshot[] {
+    return Array.from(this.values, ([name, value]) => ({ name, value }));
+  }
+}
+
+// Module-level singleton so route handlers can `inc` without plumbing an
+// instance through every route. Explicit state, no magic.
+export const counters = new Counters();

--- a/packages/server/src/routes/metrics.test.ts
+++ b/packages/server/src/routes/metrics.test.ts
@@ -7,6 +7,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { ReefDb } from '../db.js';
 import { Hub } from '../hub.js';
 import { registerMetricsRoutes } from './metrics.js';
+import { counters } from '../metrics-registry.js';
 
 function buildApp(): { app: FastifyInstance; db: ReefDb; hub: Hub } {
   const dir = mkdtempSync(join(tmpdir(), 'reef-metrics-'));
@@ -49,6 +50,25 @@ test('metrics: exposes reef_polyps_total as a gauge', async () => {
     assert.match(body, /^# HELP reef_polyps_total /m);
     assert.match(body, /^# TYPE reef_polyps_total gauge$/m);
     assert.match(body, /^reef_polyps_total 2$/m);
+  } finally {
+    await app.close();
+  }
+});
+
+test('metrics: exposes reef_rate_limited_total as a monotonic counter', async () => {
+  const { app } = buildApp();
+  // Reset the counter since other tests may have bumped it.
+  counters.reset('rate_limited');
+  try {
+    counters.inc('rate_limited');
+    counters.inc('rate_limited');
+    counters.inc('rate_limited');
+    const r = await app.inject({ method: 'GET', url: '/metrics' });
+    assert.equal(r.statusCode, 200);
+    const body = r.payload;
+    assert.match(body, /^# HELP reef_rate_limited_total /m);
+    assert.match(body, /^# TYPE reef_rate_limited_total counter$/m);
+    assert.match(body, /^reef_rate_limited_total 3$/m);
   } finally {
     await app.close();
   }

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { ReefDb } from '../db.js';
 import type { Hub } from '../hub.js';
+import { counters } from '../metrics-registry.js';
 
 // Minimal Prometheus text-format emitter. Any HELP/TYPE line whose value
 // contains `\n` or `\\` would need escaping — we control these strings so no
@@ -19,6 +20,9 @@ export function registerMetricsRoutes(app: FastifyInstance, db: ReefDb, hub: Hub
     return [
       metric('reef_polyps_total', 'Number of live (non-deleted) polyps.', 'gauge', polyps),
       metric('reef_ws_clients', 'Currently connected WebSocket clients.', 'gauge', clients),
+      metric('reef_rate_limited_total',
+        'Requests rejected by the rate limiter since process start.',
+        'counter', counters.get('rate_limited')),
     ].join('');
   });
 }

--- a/packages/server/src/routes/reef.ts
+++ b/packages/server/src/routes/reef.ts
@@ -6,6 +6,7 @@ import { toPublicPolyp } from '../db.js';
 import type { Hub } from '../hub.js';
 import { deviceHash } from '../deviceHash.js';
 import { perIpRateLimit } from '../security.js';
+import { counters } from '../metrics-registry.js';
 
 export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): void {
   const readLimit = perIpRateLimit({ tokensPerInterval: 60, intervalMs: 60_000 });
@@ -13,6 +14,7 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
   app.get('/api/reef', async (req, reply) => {
     const check = readLimit(req.ip || 'unknown');
     if (!check.ok) {
+      counters.inc('rate_limited');
       reply.header('Retry-After', Math.ceil(check.retryAfterMs / 1000));
       return reply.status(429).send({ error: 'rate_limited' });
     }
@@ -37,6 +39,7 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
     const windowStart = Date.now() - config.rateLimitWindowMs;
     const already = db.countByDeviceSince(dh, windowStart);
     if (already >= config.rateLimitMax) {
+      counters.inc('rate_limited');
       const oldest = db.oldestPolypSince(dh, windowStart);
       const retryAfterMs = oldest !== null
         ? Math.max(0, oldest + config.rateLimitWindowMs - Date.now())


### PR DESCRIPTION
## Summary

Adds a Prometheus counter metric \`reef_rate_limited_total\` wired to both 429-return paths:

- \`GET /api/reef\` — per-IP read-side token bucket
- \`POST /api/reef/polyp\` — per-device rate limit

Introduces a small \`metrics-registry.ts\` singleton for in-memory counters. Single-process only — if the server horizontally scales later, scrape each instance and let Prometheus sum.

\`/metrics\` now emits:

\`\`\`
# HELP reef_polyps_total Number of live (non-deleted) polyps.
# TYPE reef_polyps_total gauge
reef_polyps_total <N>
# HELP reef_ws_clients Currently connected WebSocket clients.
# TYPE reef_ws_clients gauge
reef_ws_clients <N>
# HELP reef_rate_limited_total Requests rejected by the rate limiter since process start.
# TYPE reef_rate_limited_total counter
reef_rate_limited_total <N>
\`\`\`

## Test plan

- [x] TDD'd: test ordered RED (module missing) → GREEN (registry + wire).
- [x] \`pnpm --filter @reef/server test\` — 57 pass (new metrics test + existing suite).
- [x] \`pnpm lint\` / \`pnpm -r typecheck\` clean.
- [x] CI \`Build and test\` required by branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)