### PR TITLE
restorePolyp: three-way discriminated result

### DIFF
--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -45,6 +45,33 @@ test('DB: softDeletePolyp returns false for unknown id', () => {
   assert.equal(db.softDeletePolyp(999), false);
 });
 
+test('DB: restorePolyp returns { status: "unknown" } for id that was never inserted', () => {
+  const db = freshDb();
+  const result = db.restorePolyp(999);
+  assert.equal(result.status, 'unknown');
+});
+
+test('DB: restorePolyp returns { status: "already_live" } for a row that was never deleted', () => {
+  const db = freshDb();
+  const p = db.insertPolyp(basePolyp());
+  const result = db.restorePolyp(p.id);
+  assert.equal(result.status, 'already_live');
+});
+
+test('DB: restorePolyp returns { status: "restored", polyp } after a soft-delete', () => {
+  const db = freshDb();
+  const p = db.insertPolyp(basePolyp());
+  db.softDeletePolyp(p.id);
+  const result = db.restorePolyp(p.id);
+  assert.equal(result.status, 'restored');
+  if (result.status === 'restored') {
+    assert.equal(result.polyp.id, p.id);
+    assert.equal(result.polyp.species, 'branching');
+    assert.ok(!('deviceHash' in result.polyp));
+  }
+  assert.equal(db.listPublicPolyps().length, 1);
+});
+
 test('DB: countByDeviceSince counts within window', () => {
   const db = freshDb();
   const now = Date.now();

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -150,18 +150,26 @@ export class ReefDb {
     return (this.stmt.listDeletedPolyps.all() as PolypRow[]).map(rowToPublicPolyp);
   }
 
-  // Un-sets the deleted flag. Returns the public polyp if a previously
-  // soft-deleted polyp was restored, or null if the row is unknown or was
-  // already live.
-  restorePolyp(id: number): PublicPolyp | null {
+  // Un-sets the deleted flag. Returns a discriminated union so callers can
+  // distinguish "no such polyp" from "already live" — both map to 404 at the
+  // HTTP layer today, but 409 Conflict for already_live is an option and
+  // audit logs should record which case happened.
+  restorePolyp(id: number): RestoreResult {
     // Atomic UPDATE+SELECT — prevents a concurrent softDeletePolyp(id) from
     // slipping between the two statements and causing us to broadcast a
     // polyp_added for a row that's actually still-deleted.
-    let result: PublicPolyp | null = null;
+    let result: RestoreResult = { status: 'unknown' };
     this.db.transaction(() => {
-      if (this.stmt.restore.run(id).changes === 0) return;
+      if (this.stmt.restore.run(id).changes === 0) {
+        // Either the row doesn't exist or it's already live. Peek to find out.
+        const row = this.stmt.getPolypById.get(id) as PolypRow | undefined;
+        result = row ? { status: 'already_live' } : { status: 'unknown' };
+        return;
+      }
       const row = this.stmt.getPolypById.get(id) as PolypRow | undefined;
-      result = row ? rowToPublicPolyp(row) : null;
+      if (row) result = { status: 'restored', polyp: rowToPublicPolyp(row) };
+      // Extremely unlikely: UPDATE said 1 row changed but SELECT can't find it.
+      // Leave result as the default 'unknown' so the caller sends a 404.
     })();
     return result;
   }
@@ -230,6 +238,11 @@ export class ReefDb {
     return this.stmt.getSnapshot.get(id) as { id: number; takenAt: number; polypCount: number; stateJson: string } | undefined;
   }
 }
+
+export type RestoreResult =
+  | { status: 'restored'; polyp: PublicPolyp }
+  | { status: 'already_live' }
+  | { status: 'unknown' };
 
 export function rowToPublicPolyp(r: PolypRow): PublicPolyp {
   return {

--- a/packages/server/src/routes/admin.test.ts
+++ b/packages/server/src/routes/admin.test.ts
@@ -121,7 +121,7 @@ test('admin: POST restore for unknown id returns 404', async () => {
   await app.close();
 });
 
-test('admin: POST restore for a live (never-deleted) polyp returns 404', async () => {
+test('admin: POST restore for a live (never-deleted) polyp returns 409 already_live', async () => {
   const { app } = buildApp();
   config.adminToken = 'token-abc';
   await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
@@ -129,7 +129,8 @@ test('admin: POST restore for a live (never-deleted) polyp returns 404', async (
     method: 'POST', url: '/api/admin/polyp/1/restore',
     headers: { authorization: 'Bearer token-abc' },
   });
-  assert.equal(r.statusCode, 404);
+  assert.equal(r.statusCode, 409);
+  assert.equal(r.json().error, 'already_live');
   await app.close();
 });
 

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -60,14 +60,22 @@ export function registerAdminRoutes(app: FastifyInstance, db: ReefDb, hub: Hub):
   app.post<{ Params: { id: string } }>('/api/admin/polyp/:id/restore', async (req, reply) => {
     const id = authorizeAndParseId(req, reply);
     if (id === null) return reply;
-    const pub = db.restorePolyp(id);
-    if (!pub) return reply.status(404).send({ error: 'not_found' });
+    const result = db.restorePolyp(id);
+    if (result.status === 'unknown') {
+      return reply.status(404).send({ error: 'not_found' });
+    }
+    if (result.status === 'already_live') {
+      // 409 Conflict — restore is a no-op because the polyp is already live.
+      // Distinct from 404 so an admin UI can say "already live" instead of
+      // the ambiguous "not found".
+      return reply.status(409).send({ error: 'already_live' });
+    }
     try {
-      hub.broadcast({ type: 'polyp_added', polyp: pub });
+      hub.broadcast({ type: 'polyp_added', polyp: result.polyp });
     } catch (err) {
       req.log.warn({ err, id }, 'hub broadcast failed after restore');
     }
-    return pub;
+    return result.polyp;
   });
 
   // The admin page itself is a static HTML shell with no secrets; it prompts
@@ -147,7 +155,9 @@ async function del(id) {
 }
 async function restore(id) {
   const r = await authFetch('/api/admin/polyp/' + encodeURIComponent(id) + '/restore', { method: 'POST' });
-  if (!r || !r.ok) { alert('restore failed: ' + (r ? r.status : 'no token')); return; }
+  if (!r) { alert('paste token first'); return; }
+  if (r.status === 409) { alert('already live'); load(); return; }
+  if (!r.ok) { alert('restore failed: ' + r.status); return; }
   load();
 }
 $('loadBtn').addEventListener('click', load);


### PR DESCRIPTION
## Summary

\`ReefDb.restorePolyp\` used to return \`PublicPolyp | null\`, collapsing "id unknown" and "already live" into the same signal. The route emitted a 404 for both, so the admin UI couldn't tell "no such polyp" apart from "nothing to restore."

New contract:

\`\`\`ts
type RestoreResult =
  | { status: 'restored'; polyp: PublicPolyp }
  | { status: 'already_live' }
  | { status: 'unknown' };
\`\`\`

| Status | HTTP | Body |
|---|---|---|
| \`unknown\` | 404 | \`{ error: 'not_found' }\` (unchanged) |
| \`already_live\` | **409 Conflict** | \`{ error: 'already_live' }\` (new) |
| \`restored\` | 200 | public polyp JSON (unchanged) |

Admin HTML shows "already live" for 409 and reloads so the operator sees the correct Live/Deleted split.

## Test plan

- [x] 3 new DB tests (one per status), TDD'd.
- [x] Existing admin test for live-polyp updated 404 → 409.
- [x] \`pnpm lint\` / \`pnpm -r typecheck\` clean.
- [x] \`pnpm --filter @reef/server test\` — 60 pass.
- [x] CI required by branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)