### PR TITLE
Hosting: GitHub Pages demo + Fly.io deploy

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,40 @@
+name: Fly deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: fly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Gated: only runs when the operator has wired FLY_API_TOKEN. Without it
+    # the job no-ops so main commits don't turn the repo red for unrelated
+    # contributors.
+    if: ${{ github.repository_owner == 'costajohnt' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          if [ -z "${FLY_API_TOKEN}" ]; then
+            echo "Skipping: FLY_API_TOKEN not set. See fly.toml for setup."
+            exit 0
+          fi
+          flyctl deploy --remote-only --image ghcr.io/costajohnt/coralreefar:latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build static bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build client
+        run: pnpm --filter @reef/shared build && pnpm --filter @reef/generator build && pnpm --filter @reef/client build
+
+      - name: Assemble Pages bundle
+        run: bash scripts/build-pages-index.sh
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/client/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Self-hosted, persistent, collaborative AR coral reef. See `PLAN.md` for the full spec.
 
+**Live demos**
+
+- [Static species preview](https://costajohnt.github.io/CoralReefAR/preview.html) — orbit-camera grid of all five procedurally-generated coral species, no server needed.
+- Full app: run the Docker image locally (`docker compose up -d`) or deploy to [Fly.io](#flyio) / your own host.
+
 ## Layout
 
 ```
@@ -27,11 +32,13 @@ The client proxies `/api` and `/ws` to the server in dev.
 
 For desktop testing (no camera or tracker), use `?tracker=noop` — the reef anchors a fixed distance in front of the camera.
 
-## Production (Beelink)
+## Production
 
-1. Copy `.env.example` to `.env` and fill in `ADMIN_TOKEN` and `CLOUDFLARE_TUNNEL_TOKEN`.
-2. Build the client once (`pnpm --filter @reef/client build`) and serve it via a static host (or add a Fastify static plugin).
-3. `docker compose up -d` on the Beelink.
+See `INSTALL.md` for the full runbook. Three paths:
+
+- **Self-hosted Beelink + Cloudflare Tunnel** (the original deploy target). Free ongoing cost, requires hardware.
+- **Fly.io** — `fly.toml` is checked in. One-time: `fly apps create coralreefar`, create a `reef_data` volume, set `ADMIN_TOKEN` + `CORS_ORIGINS` secrets, add a `FLY_API_TOKEN` repo secret. Then every push to main triggers `.github/workflows/fly-deploy.yml`. ~$5/mo for a shared-1x VM.
+- **GitHub Pages** (static-only) — `.github/workflows/pages.yml` builds the client and publishes the preview. No backend → no placement persistence, just the generator demo.
 
 ## Seeding the reef
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,52 @@
+# Fly.io deployment for the CoralReefAR server.
+#
+# One-time setup (operator):
+#   1. brew install flyctl (or equivalent)
+#   2. fly auth login
+#   3. fly apps create coralreefar --org personal
+#   4. fly volumes create reef_data --size 1 --region iad --yes
+#   5. fly secrets set ADMIN_TOKEN="$(openssl rand -hex 32)"
+#   6. fly secrets set CORS_ORIGINS="https://coralreefar.fly.dev"
+#   7. In GitHub: repo settings → secrets → add FLY_API_TOKEN
+#      (value from `fly tokens create deploy`)
+#   8. Push to main — .github/workflows/fly-deploy.yml does the rest.
+
+app = "coralreefar"
+primary_region = "iad"
+
+[build]
+  # Use the image we already publish to GHCR instead of rebuilding on Fly.
+  image = "ghcr.io/costajohnt/coralreefar:latest"
+
+[env]
+  PORT = "8787"
+  HOST = "0.0.0.0"
+  DB_PATH = "/data/reef.db"
+  NODE_ENV = "production"
+  CLIENT_DIST_DIR = "/app/packages/client/dist"
+  RATE_LIMIT_WINDOW_MS = "3600000"
+  RATE_LIMIT_MAX = "1"
+
+[[mounts]]
+  source = "reef_data"
+  destination = "/data"
+
+[http_service]
+  internal_port = 8787
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/healthz"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/scripts/build-pages-index.sh
+++ b/scripts/build-pages-index.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# Rewrites packages/client/dist so GitHub Pages gets a sensible landing.
+# The AR app needs a backend, so we can't host it statically — only the
+# offline dev pages (preview.html, timelapse.html) work without a server.
+# We swap the default index.html for a small landing page and move the
+# original AR-app index.html aside so curious visitors can still reach it.
+
+DIST=packages/client/dist
+
+if [ ! -d "$DIST" ]; then
+  echo "error: $DIST does not exist — run the client build first" >&2
+  exit 1
+fi
+
+mv "$DIST/index.html" "$DIST/ar.html"
+cat > "$DIST/index.html" <<'HTML'
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>CoralReefAR — static preview</title>
+  <style>
+    body { margin: 0; background: #02111d; color: #eef; font-family: system-ui, sans-serif; padding: 2rem; }
+    h1 { font-size: 1.6rem; margin: 0 0 0.4rem; }
+    p { color: #9ab; max-width: 38rem; line-height: 1.5; }
+    a { color: #2ec4b6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    ul { line-height: 1.9; }
+  </style>
+</head>
+<body>
+  <h1>CoralReefAR</h1>
+  <p>Static demo of the procedural reef client. The main AR app requires
+    a backend (camera feed, WebSocket, SQLite), so only the offline dev
+    pages work here.</p>
+  <ul>
+    <li><a href="preview.html">Species preview</a> — orbit-camera grid of all five procedurally-generated coral species. No server needed.</li>
+    <li><a href="ar.html">AR app</a> — will fail to load the reef (no backend on Pages) but shows the startup screen.</li>
+    <li><a href="https://github.com/costajohnt/CoralReefAR">Source + runbook</a></li>
+    <li><a href="https://github.com/costajohnt/CoralReefAR/pkgs/container/coralreefar">Docker image on GHCR</a></li>
+  </ul>
+</body>
+</html>
+HTML
+
+echo "rewrote $DIST/index.html and moved original to $DIST/ar.html"


### PR DESCRIPTION
## Summary

Two deployment paths for the project.

### GitHub Pages (static demo)
- \`.github/workflows/pages.yml\` — on every push to main, builds the client and publishes to Pages.
- \`scripts/build-pages-index.sh\` — drops a landing page at \`/\` pointing at the species preview. The real AR app needs a backend, so static Pages only surfaces the procedural coral grid.
- **URL after first deploy**: https://costajohnt.github.io/CoralReefAR/

### Fly.io (full deploy)
- \`fly.toml\` — shared-1x VM, 1 GB \`reef_data\` volume mounted at \`/data\`, Fastify-static serves the bundled client. Uses the existing \`ghcr.io/costajohnt/coralreefar:latest\` image.
- \`.github/workflows/fly-deploy.yml\` — on main push, deploys if \`FLY_API_TOKEN\` is set; no-ops for forks.
- **One-time operator setup** (documented in \`fly.toml\` header): create the app, create the volume, set secrets, add \`FLY_API_TOKEN\` to repo secrets.

README gains a "Live demos" section and a three-bullet Production section (Beelink / Fly / Pages).

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/pages.yml')); yaml.safe_load(open('.github/workflows/fly-deploy.yml'))\"\` parses.
- [x] \`bash scripts/build-pages-index.sh\` ran locally after a client build and produced \`dist/index.html\` (landing) + \`dist/ar.html\` (original AR).
- [ ] Post-merge: Pages workflow runs and publishes. You'll need to enable Pages in repo settings (Source: GitHub Actions).
- [ ] Post-merge: Fly workflow runs; will skip gracefully until \`FLY_API_TOKEN\` is added.

## Operator setup for Fly

1. \`brew install flyctl\` · \`fly auth login\`
2. \`fly apps create coralreefar --org personal\`
3. \`fly volumes create reef_data --size 1 --region iad --yes\`
4. \`fly secrets set ADMIN_TOKEN=\"\$(openssl rand -hex 32)\" CORS_ORIGINS=\"https://coralreefar.fly.dev\"\`
5. \`fly tokens create deploy\` → paste into GitHub repo secrets as \`FLY_API_TOKEN\`
6. Next push to main triggers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)