### PR TITLE
Docs: CHANGELOG + NEXT_STEPS + Pages HTTPS URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely;
+versions are SemVer.
+
+## [Unreleased]
+
+### Added
+
+- Admin restore UI: the `/admin` page now shows both live and soft-deleted
+  polyps with a per-row Restore button next to Delete.
+- `GET /api/admin/deleted` — bearer-token-gated moderation queue of
+  soft-deleted polyps.
+- `POST /api/admin/polyp/:id/restore` returns a three-way result:
+  `200` with the public polyp on restore, `409 Conflict` for
+  `already_live`, `404` for `not_found`. Lets the UI tell "no such
+  polyp" apart from "nothing to restore."
+- Prometheus `reef_rate_limited_total` counter wired to both 429 paths.
+- Two-finger pinch + twist gestures on the placement ghost.
+- Three.js vendor chunk (client bundle — one shared `three-*.js` across
+  all HTML entries).
+- Full happy-dom + Vitest harness on the client (`pnpm --filter
+  @reef/client test`), 26 tests across picker / net-api / tracker
+  selection / placement.
+- Mesh-invariant tests per species (catches NaN / Inf / index-OOB /
+  non-unit normals that the hash goldens couldn't).
+- Live hosting:
+  - GitHub Pages static demo at https://jcosta.tech/CoralReefAR/
+  - Fly.io deploy workflow (`fly.toml` + `.github/workflows/fly-deploy.yml`)
+    using the published GHCR image.
+- Dependabot configured for weekly Actions / npm / Docker updates.
+
+### Changed
+
+- TypeScript 5.9 → 6.0, better-sqlite3 11 → 12, @fastify/cors 9 → 11,
+  base Docker image node:20-alpine → node:25-alpine.
+- Docker + compose: server container also serves the client bundle via
+  `@fastify/static` (`CLIENT_DIST_DIR` env); no more separate web host
+  needed.
+
+### Fixed
+
+- Non-unit normals in the `branching` species (Gram-Schmidt was missing
+  from the near-vertical-axis `else` branch). Visible as subtle shading
+  artefacts; the new mesh-invariant tests caught it.
+- Quaternion drift during sustained two-finger twists — `.normalize()`
+  after every `multiply()` in `Placement.applyGesture`.
+- `restorePolyp` UPDATE+SELECT race: wrapped in a better-sqlite3
+  transaction so a concurrent soft-delete can't slip between the two
+  statements.
+- `ws.ts` dispatch: JSON parse and handler invocation split into
+  separate try/catches so a handler throw doesn't get classified as a
+  "malformed frame" and vanish.
+- `loadInitial` failure surfaced via always-visible `#status` (with
+  `aria-live`), not the still-hidden `#hint`.
+
+## [0.1.0] — 2026-04-18
+
+First tagged release after splitting CoralReefAR into its own repo.
+
+### Added
+
+- pnpm monorepo: `packages/{shared,generator,server,client}`.
+- Server: Fastify + better-sqlite3 + WebSocket hub + hourly sim + daily
+  snapshot; rate limit; admin soft-delete; `/healthz`.
+- Client: Vite + Three.js AR app; 8th Wall / MindAR / noop tracking;
+  placement raycast; ghost preview; species/color picker; reroll /
+  cancel / submit-in-flight UX.
+- Generator: deterministic procedural polyps across five species.
+- CI: typecheck / build / tests; minimum-scope `GITHUB_TOKEN`;
+  15-min timeout.
+- Release workflow: builds and publishes multi-arch Docker image to
+  GHCR on `vX.Y.Z` tag push.
+- 97 tests at release (12 shared + 22 generator + 56 server + 7
+  client); server integration tests against a real `ws` client.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,129 @@
+# Next Steps
+
+A checklist of things I (the maintainer) still need to do manually. Claude
+has taken everything as far as it reasonably can from a development
+environment. The remaining items require either external accounts, physical
+hardware, or direct decisions.
+
+## Deployment
+
+### 1. Stand up the app on Fly.io
+
+The workflow is armed but gated: it no-ops until `FLY_API_TOKEN` is set as a
+repo secret. Run these commands once, from any machine with `flyctl`
+installed (`brew install flyctl`):
+
+```sh
+fly auth login
+fly apps create coralreefar --org personal
+fly volumes create reef_data --size 1 --region iad --yes
+fly secrets set \
+  ADMIN_TOKEN="$(openssl rand -hex 32)" \
+  CORS_ORIGINS="https://coralreefar.fly.dev"
+fly tokens create deploy   # copy output
+```
+
+Then in the repo settings → Secrets and variables → Actions → "New repository
+secret": name `FLY_API_TOKEN`, value from the `fly tokens create deploy`
+command.
+
+Next push to `main` triggers `.github/workflows/fly-deploy.yml` and the app
+goes live at `https://coralreefar.fly.dev`. Save the `ADMIN_TOKEN` value
+locally — you'll need it to moderate polyps via `/admin`.
+
+### 2. Pedestal marker
+
+`assets/pedestal/marker.svg` is a placeholder. For a production install,
+commission or design the real marker image (see `assets/pedestal/README.md`
+for the guidelines — asymmetric, mid-tone, matte, ~150–200 mm printed). Then:
+
+- Drop the production image at `assets/pedestal/marker.png` (or similar).
+- Upload it to 8th Wall's image-target dashboard (or compile to a `.mind`
+  file for MindAR).
+- Print matte on heavyweight paper, mount flat and level.
+
+### 3. NFC tags
+
+Program an NTAG215 batch with a single NDEF URL record pointing at the live
+host (`https://reef.example.com/` or `https://coralreefar.fly.dev/`). Test
+one tag end-to-end (tap → Safari/Chrome → AR startup) before programming the
+rest.
+
+## Testing
+
+### 4. Real-device AR smoke test
+
+Nothing here has ever been driven through a camera against a printed marker.
+Before shipping to visitors:
+
+- Print a test marker from `assets/pedestal/marker.svg` at ~180 mm square.
+- Open the site on an iPhone (Safari) and an Android (Chrome).
+- Confirm tracking picks up the marker within a few seconds under venue
+  lighting.
+- Place a polyp and confirm it persists (close the tab, reopen, see the
+  polyp).
+- Open a second tab; delete via `/admin`; the first tab's reef should update
+  live.
+
+### 5. Docker smoke test
+
+The GHCR image is green in CI but I never pulled it locally:
+
+```sh
+docker pull ghcr.io/costajohnt/coralreefar:latest
+docker run --rm -p 8787:8787 -e ADMIN_TOKEN=smoketest \
+  ghcr.io/costajohnt/coralreefar:latest &
+sleep 3
+curl http://127.0.0.1:8787/healthz
+```
+
+Expect `{"ok":true,"time":...}`. If the container exits immediately, check
+`docker logs`.
+
+## Optional polish
+
+### 6. Branch protection review settings
+
+`main` protection currently requires the `Build and test` check and linear
+history but allows admin bypass. If you ever get a collaborator, toggle
+"Require pull request reviews before merging" in repo settings.
+
+### 7. Node 20 deprecation for `actions/deploy-pages`
+
+The Pages deploy step still uses `actions/deploy-pages@v4` (Node 20).
+GitHub will force Node 24 on 2026-06-02. Dependabot will open the bump PR
+automatically when v5 ships; no action until then.
+
+### 8. CODEOWNERS (if the repo ever has collaborators)
+
+Add `.github/CODEOWNERS` with `* @costajohnt` so every PR auto-requests your
+review. Skip until there's someone else pushing.
+
+### 9. Pitch
+
+The project exists but nobody knows. Options I can't execute:
+
+- Write a short blog post / devlog with screenshots from the static preview
+  and a demo video.
+- Post to HN (`Show HN: …`), /r/programming, the Fastify / Three.js Discords.
+- Submit to "Awesome" lists (awesome-threejs, awesome-ar, etc.).
+
+## Known limitations
+
+These are intentional or accepted trade-offs — documenting so you remember.
+
+- **Metrics are in-process only.** `reef_polyps_total` / `reef_ws_clients` /
+  `reef_rate_limited_total` reset on restart. Multi-instance deploys need
+  Prometheus to aggregate across scraped replicas.
+- **Rate limit is coarse.** 1 polyp / device / hour, 60 reads / IP /
+  minute. The device key is `sha256(UA, IP, rotating-salt)`, which a
+  motivated user can circumvent with a VPN + another device. That's
+  accepted given the installation context.
+- **No auth for regular users.** Anyone who loads the page can plant once
+  per window. The moderation path (admin delete + restore) assumes
+  low-volume mid-abuse cleanup, not spam at scale.
+- **8th Wall binary not vendored.** `packages/client/vendor/8thwall/` is
+  `.gitignore`d. If you need to ship the AR path, drop the engine binary
+  there before building the client.
+- **Vitest is pinned at 2.x.** Vitest 4 needs Vite 6. The Vite ecosystem
+  hasn't reached that yet. Dependabot will catch it up.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-hosted, persistent, collaborative AR coral reef. See `PLAN.md` for the full
 
 **Live demos**
 
-- [Static species preview](https://costajohnt.github.io/CoralReefAR/preview.html) — orbit-camera grid of all five procedurally-generated coral species, no server needed.
+- [Static species preview](https://jcosta.tech/CoralReefAR/preview.html) — orbit-camera grid of all five procedurally-generated coral species, no server needed.
 - Full app: run the Docker image locally (`docker compose up -d`) or deploy to [Fly.io](#flyio) / your own host.
 
 ## Layout


### PR DESCRIPTION
Docs-only finalization.

- **CHANGELOG.md** following Keep-a-Changelog. One \`[Unreleased]\` section covering every merge since v0.1.0 + the v0.1.0 entry itself so cutting v0.2 is drop-and-rename.
- **NEXT_STEPS.md** — checklist of items I (the maintainer) still need to do manually, grouped by Deployment / Testing / Optional polish / Known limitations. See the file for the full list; highlights: Fly.io \`FLY_API_TOKEN\` setup, real-device AR smoke test, production pedestal marker, NFC tag programming.
- **README**: Pages demo link updated to https://jcosta.tech/CoralReefAR/ now that HTTPS enforcement is on (enabled via API earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)