### PR TITLE
Disable rate limits by default while in testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,11 @@ services:
       - PORT=8787
       - DB_PATH=/data/reef.db
       - ADMIN_TOKEN=${ADMIN_TOKEN:?set ADMIN_TOKEN in .env}
-      - RATE_LIMIT_WINDOW_MS=3600000
-      - RATE_LIMIT_MAX=1
+      # Rate limits are opt-in and default off while the project is in
+      # testing. Uncomment to re-enable for production.
+      # - RATE_LIMIT_WINDOW_MS=3600000
+      # - RATE_LIMIT_MAX=1
+      # - READ_RATE_LIMIT_PER_MIN=60
 
   tunnel:
     image: cloudflare/cloudflared:latest

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -4,7 +4,13 @@ export const config = {
   dbPath: process.env.DB_PATH ?? './data/reef.db',
   adminToken: process.env.ADMIN_TOKEN ?? '',
   rateLimitWindowMs: Number(process.env.RATE_LIMIT_WINDOW_MS ?? 3_600_000),
-  rateLimitMax: Number(process.env.RATE_LIMIT_MAX ?? 1),
+  // 0 = disabled. Default off while the project is in testing; before
+  // productionalizing set RATE_LIMIT_MAX to something like 1. Follow-up
+  // tracked in the repo issue list.
+  rateLimitMax: Number(process.env.RATE_LIMIT_MAX ?? 0),
+  // 0 = disabled. Default off; set READ_RATE_LIMIT_PER_MIN=60 (or similar)
+  // to re-enable the per-IP read-side token bucket.
+  readRateLimitPerMin: Number(process.env.READ_RATE_LIMIT_PER_MIN ?? 0),
   simIntervalMs: Number(process.env.SIM_INTERVAL_MS ?? 3_600_000),
   snapshotIntervalMs: Number(process.env.SNAPSHOT_INTERVAL_MS ?? 86_400_000),
   corsOrigins: (process.env.CORS_ORIGINS ?? '*').split(',').map((s) => s.trim()),

--- a/packages/server/src/routes/reef.test.ts
+++ b/packages/server/src/routes/reef.test.ts
@@ -7,6 +7,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { ReefDb } from '../db.js';
 import { Hub } from '../hub.js';
 import { registerReefRoutes } from './reef.js';
+import { config } from '../config.js';
 
 function buildApp(): { app: FastifyInstance; db: ReefDb; hub: Hub } {
   const dir = mkdtempSync(join(tmpdir(), 'reef-rt-'));
@@ -78,15 +79,42 @@ test('POST /api/reef/polyp rejects out-of-bounds position', async () => {
   await app.close();
 });
 
-test('POST /api/reef/polyp returns 429 with retryAfterMs on rate limit', async () => {
-  const { app } = buildApp();
-  await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
-  const r = await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
-  assert.equal(r.statusCode, 429);
-  const body = r.json() as { error: string; retryAfterMs: number };
-  assert.equal(body.error, 'rate_limited');
-  assert.ok(body.retryAfterMs > 0);
-  assert.ok(body.retryAfterMs <= 3_600_000);
-  assert.ok(r.headers['retry-after']);
-  await app.close();
+test('POST /api/reef/polyp returns 429 with retryAfterMs when RATE_LIMIT_MAX enabled', async () => {
+  // Rate limits are disabled by default; this test turns the write-side
+  // limit on to exercise the 429 path, then restores.
+  const savedMax = config.rateLimitMax;
+  config.rateLimitMax = 1;
+  try {
+    const { app } = buildApp();
+    await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
+    const r = await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
+    assert.equal(r.statusCode, 429);
+    const body = r.json() as { error: string; retryAfterMs: number };
+    assert.equal(body.error, 'rate_limited');
+    assert.ok(body.retryAfterMs > 0);
+    assert.ok(body.retryAfterMs <= 3_600_000);
+    assert.ok(r.headers['retry-after']);
+    await app.close();
+  } finally {
+    config.rateLimitMax = savedMax;
+  }
+});
+
+test('POST /api/reef/polyp accepts unlimited requests when rate limit is off (default)', async () => {
+  const savedMax = config.rateLimitMax;
+  config.rateLimitMax = 0;
+  try {
+    const { app } = buildApp();
+    for (let i = 0; i < 5; i++) {
+      const r = await app.inject({
+        method: 'POST', url: '/api/reef/polyp',
+        headers: { 'user-agent': `test-ua-${i}` },
+        payload: { ...valid, seed: 100 + i },
+      });
+      assert.equal(r.statusCode, 201, `request ${i} should succeed, got ${r.statusCode}`);
+    }
+    await app.close();
+  } finally {
+    config.rateLimitMax = savedMax;
+  }
 });

--- a/packages/server/src/routes/reef.ts
+++ b/packages/server/src/routes/reef.ts
@@ -9,14 +9,20 @@ import { perIpRateLimit } from '../security.js';
 import { counters } from '../metrics-registry.js';
 
 export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): void {
-  const readLimit = perIpRateLimit({ tokensPerInterval: 60, intervalMs: 60_000 });
+  // Rate limits are opt-in. Default off while the project is in testing;
+  // set READ_RATE_LIMIT_PER_MIN / RATE_LIMIT_MAX env vars to re-enable.
+  const readLimit = config.readRateLimitPerMin > 0
+    ? perIpRateLimit({ tokensPerInterval: config.readRateLimitPerMin, intervalMs: 60_000 })
+    : null;
 
   app.get('/api/reef', async (req, reply) => {
-    const check = readLimit(req.ip || 'unknown');
-    if (!check.ok) {
-      counters.inc('rate_limited');
-      reply.header('Retry-After', Math.ceil(check.retryAfterMs / 1000));
-      return reply.status(429).send({ error: 'rate_limited' });
+    if (readLimit) {
+      const check = readLimit(req.ip || 'unknown');
+      if (!check.ok) {
+        counters.inc('rate_limited');
+        reply.header('Retry-After', Math.ceil(check.retryAfterMs / 1000));
+        return reply.status(429).send({ error: 'rate_limited' });
+      }
     }
     const state: ReefState = {
       polyps: db.listPublicPolyps(),
@@ -38,7 +44,7 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
 
     const windowStart = Date.now() - config.rateLimitWindowMs;
     const already = db.countByDeviceSince(dh, windowStart);
-    if (already >= config.rateLimitMax) {
+    if (config.rateLimitMax > 0 && already >= config.rateLimitMax) {
       counters.inc('rate_limited');
       const oldest = db.oldestPolypSince(dh, windowStart);
       const retryAfterMs = oldest !== null


### PR DESCRIPTION
Pre-production testing needs to not fight the rate limiter. Switches both limits to opt-in via env:

- \`RATE_LIMIT_MAX\` (per-device write limit): default 1 → 0 (off).
- \`READ_RATE_LIMIT_PER_MIN\` (new env var, per-IP read bucket): default off. Wraps the existing \`perIpRateLimit\` token bucket.

Route logic skips the check when the env var is 0 / unset. Wiring stays in place so flipping the envs for production re-enables without code changes. Tracked for productionalization in #25.

## Test plan

- [x] Existing 429 test now sets \`config.rateLimitMax = 1\` explicitly in \`try { ... } finally { restore }\`, still passes.
- [x] New test asserts 5 sequential posts succeed with defaults off.
- [x] 61 server tests pass, 120 workspace-wide.
- [x] \`pnpm lint\` / \`pnpm -r typecheck\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)