### PR TITLE
Docs: 8th Wall migration + current state snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions are SemVer.
 
 ### Added
 
+- **Live hosting**:
+  - GitHub Pages static demo at <https://jcosta.tech/CoralReefAR/>,
+    HTTPS enforced. `/` is a landing page; `/preview.html` is the
+    procedurally-rendered species grid; `/ar.html` is the AR entry
+    (expects a backend).
+  - Fly.io deploy workflow (`fly.toml` + `.github/workflows/fly-deploy.yml`)
+    is armed. App is provisioned; deploy deferred per operator
+    decision in favor of self-host on Beelink.
 - Admin restore UI: the `/admin` page now shows both live and soft-deleted
   polyps with a per-row Restore button next to Delete.
 - `GET /api/admin/deleted` — bearer-token-gated moderation queue of
@@ -33,11 +41,19 @@ versions are SemVer.
 
 ### Changed
 
-- TypeScript 5.9 → 6.0, better-sqlite3 11 → 12, @fastify/cors 9 → 11,
-  base Docker image node:20-alpine → node:25-alpine.
+- TypeScript 5.9 → 6.0, Vite 5.3 → 7.1, Vitest 2.1 → 4.1, happy-dom
+  15 → 19, better-sqlite3 11 → 12, @fastify/cors 9 → 11, base Docker
+  image node:20-alpine → node:25-alpine,
+  `actions/deploy-pages@v4 → @v5`.
+- **Rate limits are opt-in**: default `RATE_LIMIT_MAX=0` (off). Tests
+  that exercise the 429 path explicitly re-enable. New
+  `READ_RATE_LIMIT_PER_MIN` env var for the per-IP read-side bucket.
+  Tracked for production re-enable in #25.
 - Docker + compose: server container also serves the client bundle via
   `@fastify/static` (`CLIENT_DIST_DIR` env); no more separate web host
   needed.
+- README: rewritten for pitch, not spec. Leads with the visitor
+  experience (NFC tap → AR → shared persistent reef).
 
 ### Fixed
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,11 +120,18 @@ Tips:
   without line-of-sight constraints.
 - Seal tags behind a thin non-metallic plate; metal kills the field.
 
-## 6. Pedestal marker
+## 6. Pedestal marker + AR tracker
 
-The tracking layer needs a printed image as the origin anchor. 8th Wall
-SLAM extends tracking beyond the marker, so visitors only need the
-marker to be in-frame briefly.
+The tracking layer needs a printed image as the origin anchor. 8th
+Wall SLAM extends tracking beyond the marker, so visitors only need
+the marker to be in-frame briefly.
+
+Note: 8th Wall's hosted platform retired Feb 28, 2026. The current
+tracking code targets the retired model; the migration path to
+self-hosted `@8thwall/engine-binary` is tracked in `NEXT_STEPS.md`
+under "AR tracker migration plan". No appKey or account is required
+in the self-hosted model — the engine loads via jsDelivr and runs
+without phoning home.
 
 A placeholder marker lives at `assets/pedestal/marker.svg` — good
 enough for local smoke testing but not for production. See

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,129 +1,177 @@
 # Next Steps
 
-A checklist of things I (the maintainer) still need to do manually. Claude
-has taken everything as far as it reasonably can from a development
-environment. The remaining items require either external accounts, physical
-hardware, or direct decisions.
+What's done, what's open, and what you (the maintainer) still need to do
+manually. This file is the single source of truth for project state — keep
+it edited alongside the work.
+
+## Current state
+
+- **Main branch CI**: green. 121 tests pass across 4 packages (shared 12 /
+  generator 22 / server 61 / client 26).
+- **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
+  @fastify/cors 11 · node:25-alpine · happy-dom 19 · Oxlint. All fully
+  up-to-date.
+- **Live**: static demo at <https://jcosta.tech/CoralReefAR/> (HTTPS
+  enforced). HTML landing links to the species preview; the AR entry is
+  there too but can't talk to a backend.
+- **Docker image**: `ghcr.io/costajohnt/coralreefar:latest`. Verified
+  locally — `/healthz`, `/`, `/api/reef`, `/metrics`, POST polyp all work.
+  Multi-arch (amd64 + arm64). Auto-published on `vX.Y.Z` tag.
+- **Branch protection** on `main`: CI required, linear history, no
+  force-push. Hook bypass for `costajohnt/*` repos so operator actions
+  flow without per-command approval.
+- **Rate limits**: off by default (tracked in [#25] — flip env vars for
+  production).
 
 ## Deployment
 
-### 1. Stand up the app on Fly.io
+### Primary path: Beelink + Docker Compose
 
-The workflow is armed but gated: it no-ops until `FLY_API_TOKEN` is set as a
-repo secret. Run these commands once, from any machine with `flyctl`
-installed (`brew install flyctl`):
+The original plan stands — self-host on the Beelink running in a Proxmox
+LXC or VM. Runbook is [`INSTALL.md`](./INSTALL.md).
 
 ```sh
-fly auth login
-fly apps create coralreefar --org personal
-fly volumes create reef_data --size 1 --region iad --yes
-fly secrets set \
-  ADMIN_TOKEN="$(openssl rand -hex 32)" \
-  CORS_ORIGINS="https://coralreefar.fly.dev"
-fly tokens create deploy   # copy output
+git clone https://github.com/costajohnt/CoralReefAR.git
+cd CoralReefAR
+cp .env.example .env
+# edit .env: set ADMIN_TOKEN, CORS_ORIGINS, CLOUDFLARE_TUNNEL_TOKEN
+docker compose up -d
+docker compose logs -f server
 ```
 
-Then in the repo settings → Secrets and variables → Actions → "New repository
-secret": name `FLY_API_TOKEN`, value from the `fly tokens create deploy`
-command.
+`docker-compose.yml` references `ghcr.io/costajohnt/coralreefar:latest`,
+so `docker compose pull && docker compose up -d` picks up new versions
+without a local build.
 
-Next push to `main` triggers `.github/workflows/fly-deploy.yml` and the app
-goes live at `https://coralreefar.fly.dev`. Save the `ADMIN_TOKEN` value
-locally — you'll need it to moderate polyps via `/admin`.
+### Alternative: Fly.io (on pause)
 
-### 2. Pedestal marker
+The Fly app is provisioned but blocked on billing:
 
-`assets/pedestal/marker.svg` is a placeholder. For a production install,
-commission or design the real marker image (see `assets/pedestal/README.md`
-for the guidelines — asymmetric, mid-tone, matte, ~150–200 mm printed). Then:
+- App `coralreefar` created.
+- Volume `reef_data` (1 GB, iad) created.
+- Secrets `ADMIN_TOKEN` + `CORS_ORIGINS` staged.
+- `FLY_API_TOKEN` added to the repo secrets so `.github/workflows/fly-deploy.yml` will run on push.
+- **Blocker**: Fly trial orgs need a credit card at
+  <https://fly.io/dashboard/john-costa-307/billing> before the first VM
+  boots. Decided to defer — Beelink/Proxmox is simpler for testing.
 
-- Drop the production image at `assets/pedestal/marker.png` (or similar).
-- Upload it to 8th Wall's image-target dashboard (or compile to a `.mind`
-  file for MindAR).
-- Print matte on heavyweight paper, mount flat and level.
+Nothing to clean up — `fly.toml` and the workflow sit dormant. Come back
+when ready.
+
+## AR tracker migration plan
+
+The existing `packages/client/src/tracking/eightwall.ts` targets the
+**retired** hosted 8th Wall model (cloud-hosted engine + appKey). That
+model shut down Feb 28, 2026. The replacement is 8th Wall's
+self-hosted binary distribution.
+
+### Decision: 8th Wall primary, MindAR fallback
+
+Research (captured in the git log of this PR) found:
+
+- **8th Wall** `@8thwall/engine-binary` — self-hostable, no key, no
+  phone-home. SLAM included. License permits "AR experiences as part of
+  broader deliverables." Attribution required in credits. Niantic
+  Spatial has signaled end-of-binary-maintenance in March 2026; the
+  MIT-licensed parts continue community-driven.
+- **MindAR** `mindar-image-three` — MIT-licensed, dormant since Jan
+  2024, pure marker tracking (no SLAM). Known iOS Safari quirks.
+  Maintainer has self-disclosed tracking-quality limitations.
+
+For a pedestal where visitors physically walk around the marker, SLAM
+is the single biggest driver of perceived quality. 8th Wall is the
+pick. MindAR stays as an offline fallback when 8th Wall's script can't
+load.
+
+### Migration steps (when picked back up)
+
+1. Swap `packages/client/src/tracking/eightwall.ts` from the hosted
+   `apps.8thwall.com/xrweb?appKey=...` pattern to the self-hosted
+   binary. Simplest path: `<script
+   src="https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1/dist/xr.js"
+   data-preload-chunks="slam" async>` injected into
+   `packages/client/index.html`.
+2. Verify the Vite build: the engine is runtime-loaded (not bundled),
+   so no Vite copy step needed with the jsDelivr CDN approach. If we
+   later self-host the engine, translate their webpack
+   `CopyWebpackPlugin` recipe to `vite-plugin-static-copy`.
+3. Finish `packages/client/src/tracking/mindar.ts` as a real
+   implementation: `npm i mind-ar`, import `MindARThree`, wire the
+   anchor callbacks. Watch for the documented ESBuild/Vite deep-import
+   gotcha.
+4. Compile the pedestal marker. 8th Wall wants an image-target file
+   produced via the desktop app in `github.com/8thwall/8thwall/apps/`
+   (post-shutdown workflow). MindAR wants a `.mind` file from
+   <https://hiukim.github.io/mind-ar-js-doc/tools/compile>. Commit
+   both targets under `assets/pedestal/`.
+5. Update `assets/pedestal/README.md` with the new workflow.
+6. Real-device test: print the marker, point an iPhone and an Android
+   at it, confirm anchor stability and the walk-around-the-pedestal
+   path.
+
+Tracking issue: [#28].
+
+### Not to lose sight of
+
+- Niantic Spatial's binary-engine maintenance ends ~March 2026. If a
+  tracker bug surfaces in 2027 you probably can't get it fixed
+  upstream. If long-term zero-dependency maintainability ranks higher
+  than experience quality, flip the decision to MindAR-only. The
+  project is an installation piece that might run 2-3 years, so this
+  is worth a re-think when picking the work back up.
+
+## Testing (what you still need to do)
+
+### 1. Real-device AR smoke test
+
+Print `assets/pedestal/marker.svg` at ~180 mm square, matte paper.
+On an iPhone (Safari) and an Android (Chrome):
+- Load the live site.
+- Confirm tracker picks up the marker within a few seconds under
+  venue lighting.
+- Place a polyp; close the tab; reopen; the polyp persists.
+- In a second tab, admin-delete via `/admin`; the first tab's reef
+  updates live over the WebSocket.
+
+Nothing here has ever been driven through a real camera. The vitest +
+integration tests cover the code but not the physical world.
+
+### 2. Pedestal marker — production version
+
+`assets/pedestal/marker.svg` is a placeholder. Commission the real
+artwork when the design is ready (see
+`assets/pedestal/README.md` for the trackability guidelines).
 
 ### 3. NFC tags
 
-Program an NTAG215 batch with a single NDEF URL record pointing at the live
-host (`https://reef.example.com/` or `https://coralreefar.fly.dev/`). Test
-one tag end-to-end (tap → Safari/Chrome → AR startup) before programming the
-rest.
-
-## Testing
-
-### 4. Real-device AR smoke test
-
-Nothing here has ever been driven through a camera against a printed marker.
-Before shipping to visitors:
-
-- Print a test marker from `assets/pedestal/marker.svg` at ~180 mm square.
-- Open the site on an iPhone (Safari) and an Android (Chrome).
-- Confirm tracking picks up the marker within a few seconds under venue
-  lighting.
-- Place a polyp and confirm it persists (close the tab, reopen, see the
-  polyp).
-- Open a second tab; delete via `/admin`; the first tab's reef should update
-  live.
-
-### 5. Docker smoke test
-
-The GHCR image is green in CI but I never pulled it locally:
-
-```sh
-docker pull ghcr.io/costajohnt/coralreefar:latest
-docker run --rm -p 8787:8787 -e ADMIN_TOKEN=smoketest \
-  ghcr.io/costajohnt/coralreefar:latest &
-sleep 3
-curl http://127.0.0.1:8787/healthz
-```
-
-Expect `{"ok":true,"time":...}`. If the container exits immediately, check
-`docker logs`.
+Program an NTAG215 batch with the live URL. Test one end-to-end (tap
+→ Safari/Chrome → AR startup) before programming the batch.
 
 ## Optional polish
 
-### 6. Branch protection review settings
-
-`main` protection currently requires the `Build and test` check and linear
-history but allows admin bypass. If you ever get a collaborator, toggle
-"Require pull request reviews before merging" in repo settings.
-
-### 7. Node 20 deprecation for `actions/deploy-pages`
-
-The Pages deploy step still uses `actions/deploy-pages@v4` (Node 20).
-GitHub will force Node 24 on 2026-06-02. Dependabot will open the bump PR
-automatically when v5 ships; no action until then.
-
-### 8. CODEOWNERS (if the repo ever has collaborators)
-
-Add `.github/CODEOWNERS` with `* @costajohnt` so every PR auto-requests your
-review. Skip until there's someone else pushing.
-
-### 9. Pitch
-
-The project exists but nobody knows. Options I can't execute:
-
-- Write a short blog post / devlog with screenshots from the static preview
-  and a demo video.
-- Post to HN (`Show HN: …`), /r/programming, the Fastify / Three.js Discords.
-- Submit to "Awesome" lists (awesome-threejs, awesome-ar, etc.).
+- **CODEOWNERS** — only useful when collaborators join.
+- **Branch protection review-required** — same.
+- **Pitch / write-up** — devlog, HN submission, awesome-list PR.
+- **Content moderation beyond admin delete** — if the installation is
+  public and unsupervised, think about report-abuse link or keyword
+  filter on submitted colors or seeds (unlikely attack surface, but).
 
 ## Known limitations
 
-These are intentional or accepted trade-offs — documenting so you remember.
+Carrying forward — these are intentional or accepted:
 
-- **Metrics are in-process only.** `reef_polyps_total` / `reef_ws_clients` /
-  `reef_rate_limited_total` reset on restart. Multi-instance deploys need
-  Prometheus to aggregate across scraped replicas.
-- **Rate limit is coarse.** 1 polyp / device / hour, 60 reads / IP /
-  minute. The device key is `sha256(UA, IP, rotating-salt)`, which a
-  motivated user can circumvent with a VPN + another device. That's
-  accepted given the installation context.
-- **No auth for regular users.** Anyone who loads the page can plant once
-  per window. The moderation path (admin delete + restore) assumes
-  low-volume mid-abuse cleanup, not spam at scale.
-- **8th Wall binary not vendored.** `packages/client/vendor/8thwall/` is
-  `.gitignore`d. If you need to ship the AR path, drop the engine binary
-  there before building the client.
-- **Vitest is pinned at 2.x.** Vitest 4 needs Vite 6. The Vite ecosystem
-  hasn't reached that yet. Dependabot will catch it up.
+- **Metrics are in-process only.** `reef_polyps_total` /
+  `reef_ws_clients` / `reef_rate_limited_total` reset on restart.
+  Multi-instance deploys need Prometheus aggregation.
+- **Rate limiting is off by default.** Intentional for testing; see
+  [#25].
+- **No auth for regular users.** Anyone can plant once per device
+  (or once, period, with limits off). Admin path is the moderation
+  surface.
+- **Vitest 4 + Vite 7** is current; Vitest 4 needed Vite 6+ and we
+  skipped straight to 7. Tests pass; stay alert for Vite 7 ecosystem
+  gaps.
+- **8th Wall binary EOL** — see AR tracker migration plan above.
+
+[#25]: https://github.com/costajohnt/CoralReefAR/issues/25
+[#28]: https://github.com/costajohnt/CoralReefAR/issues/28

--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ pnpm --filter @reef/server test      # DB, routes, rate limit, admin auth, sim
 
 ## Tracker fallback
 
-The default tracker is 8th Wall if `window.XR8` is present, otherwise MindAR stub. Force a specific one with `?tracker=eightwall|mindar|noop`.
+The default tracker is 8th Wall if `window.XR8` is present, otherwise MindAR (stub — see `NEXT_STEPS.md`). Force a specific one with `?tracker=eightwall|mindar|noop`.
 
-The 8th Wall XR engine binary is not vendored in this repo. Place it in `packages/client/vendor/8thwall/` before building for production. The `.gitignore` excludes that directory.
+**Status**: 8th Wall's hosted platform retired Feb 28, 2026. Current `tracking/eightwall.ts` targets the retired model and needs migration to the self-hosted `@8thwall/engine-binary` distribution. Decision is captured + migration plan is written up in [`NEXT_STEPS.md`](./NEXT_STEPS.md). No account, appKey, or phone-home in the new model — the engine loads from jsDelivr and runs entirely client-side.

--- a/assets/pedestal/README.md
+++ b/assets/pedestal/README.md
@@ -29,10 +29,14 @@ A good pedestal marker is:
 1. Produce your artwork (Figma, Inkscape, Illustrator, a photograph of a
    reef, whatever). Export PNG at ≥2048×2048.
 2. Commit it to `assets/pedestal/` (or private bin) as `marker.png`.
-3. Feed it to your tracker. For 8th Wall, that's the image-target upload
-   flow in their dashboard; for MindAR, compile via their CLI to a `.mind`
-   file. Either way the physical print is what matters — the app doesn't
-   ship the marker image itself in production.
+3. Feed it to your tracker. 8th Wall's image-target preprocessing now
+   happens via the desktop app in
+   [github.com/8thwall/8thwall/apps/](https://github.com/8thwall/8thwall)
+   (the hosted dashboard is retired as of Feb 28, 2026). For MindAR,
+   compile via the browser tool at
+   <https://hiukim.github.io/mind-ar-js-doc/tools/compile> to produce
+   a `.mind` file. Either way the physical print is what matters — the
+   app doesn't ship the marker image itself in production.
 4. Print matte on heavyweight paper, mount to the pedestal top.
 
 ## Testing this placeholder


### PR DESCRIPTION
8th Wall's hosted platform retired Feb 28, 2026. Old docs assumed the cloud-hosted + appKey model; updating to reflect the new self-hostable binary distribution.

**Decision captured**: 8th Wall primary (SLAM is the differentiator for a walk-around-the-pedestal scenario), MindAR as offline fallback. Full research writeup and migration plan are in NEXT_STEPS.md → "AR tracker migration plan".

## Changed

- **NEXT_STEPS.md** — rewritten from scratch. Leads with current-state snapshot (CI green, 121 tests, stack versions, live-hosting status). Deployment prioritizes Beelink/Proxmox (user's choice); Fly.io documented as provisioned-but-paused. Six-step AR migration plan. Known limitations carried forward.
- **CHANGELOG.md** — caught up to main: Pages live, Fly armed, the batch of dep bumps (Vite 7, Vitest 4, TS 6, better-sqlite3 12, @fastify/cors 11, node:25-alpine, deploy-pages@v5).
- **INSTALL.md** + **assets/pedestal/README.md** — point at the desktop app in `8thwall/8thwall` for image-target preprocessing instead of the dead dashboard.
- **README.md** — tracker section acknowledges the retired-hosted-model status with a link to the migration plan.

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)