### PR TITLE
Fly deploy: manual-only while paused

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,8 +1,9 @@
 name: Fly deploy
 
+# Manual-only while Fly is paused (trial org needs a credit card; see
+# NEXT_STEPS.md). Restore `push: branches: [main]` below once billing is
+# resolved and you want main pushes to auto-deploy.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -50,13 +50,16 @@ The Fly app is provisioned but blocked on billing:
 - App `coralreefar` created.
 - Volume `reef_data` (1 GB, iad) created.
 - Secrets `ADMIN_TOKEN` + `CORS_ORIGINS` staged.
-- `FLY_API_TOKEN` added to the repo secrets so `.github/workflows/fly-deploy.yml` will run on push.
+- `FLY_API_TOKEN` added to the repo secrets so the workflow is ready to
+  go when billing unblocks.
 - **Blocker**: Fly trial orgs need a credit card at
   <https://fly.io/dashboard/john-costa-307/billing> before the first VM
   boots. Decided to defer — Beelink/Proxmox is simpler for testing.
 
-Nothing to clean up — `fly.toml` and the workflow sit dormant. Come back
-when ready.
+`.github/workflows/fly-deploy.yml` is gated to `workflow_dispatch` only
+while paused, so main-pushes don't paint the repo red on every merge.
+To resume auto-deploy after billing is resolved, add back the
+`push: branches: [main]` trigger. Nothing else to clean up.
 
 ## AR tracker
 


### PR DESCRIPTION
## Summary
- The workflow's \`[ -z "\$FLY_API_TOKEN" ]\` guard never fires because the secret is set — billing is the blocker, not a missing token. Every push to main was failing Fly deploy with a 422 and masking any future real failures.
- Drop the \`push: branches: [main]\` trigger; keep \`workflow_dispatch\` so you can still fire it by hand. Restore the push trigger after billing unblocks.
- NEXT_STEPS.md updated to reflect the gating.

## Test plan
- [x] YAML syntax valid (GitHub parses on push; CI "Build and test" will run for this PR)
- [ ] Confirm after merge: the next push to main does **not** start a Fly deploy run
- [ ] Confirm manual trigger still works: Actions → Fly deploy → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)