### PR TITLE
Test coverage: meshAdapter + deviceHash

### DIFF
--- a/packages/client/src/scene/meshAdapter.test.ts
+++ b/packages/client/src/scene/meshAdapter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import { BufferAttribute, MeshStandardMaterial } from 'three';
+import type { MeshData } from '@reef/generator';
+import { polypMesh, toGeometry } from './meshAdapter.js';
+
+// Minimal valid mesh: single triangle. Enough to verify attribute wiring
+// and stride without leaning on the full generator.
+function fixtureMesh(): MeshData {
+  return {
+    positions: new Float32Array([
+      0, 0, 0,
+      1, 0, 0,
+      0, 1, 0,
+    ]),
+    normals: new Float32Array([
+      0, 0, 1,
+      0, 0, 1,
+      0, 0, 1,
+    ]),
+    colors: new Float32Array([
+      1, 0, 0,
+      0, 1, 0,
+      0, 0, 1,
+    ]),
+    indices: new Uint32Array([0, 1, 2]),
+  };
+}
+
+describe('toGeometry', () => {
+  test('wires position, normal, color with itemSize 3 and correct counts', () => {
+    const m = fixtureMesh();
+    const g = toGeometry(m);
+
+    const pos = g.getAttribute('position') as BufferAttribute;
+    const nrm = g.getAttribute('normal') as BufferAttribute;
+    const col = g.getAttribute('color') as BufferAttribute;
+
+    expect(pos.itemSize).toBe(3);
+    expect(nrm.itemSize).toBe(3);
+    expect(col.itemSize).toBe(3);
+    expect(pos.count).toBe(3);
+    expect(nrm.count).toBe(3);
+    expect(col.count).toBe(3);
+    expect(pos.array).toBe(m.positions);
+  });
+
+  test('preserves index buffer and computes a bounding sphere', () => {
+    const m = fixtureMesh();
+    const g = toGeometry(m);
+
+    const idx = g.getIndex();
+    expect(idx).not.toBeNull();
+    expect(idx!.count).toBe(3);
+    expect(idx!.array).toBe(m.indices);
+    expect(g.boundingSphere).not.toBeNull();
+    expect(g.boundingSphere!.radius).toBeGreaterThan(0);
+  });
+});
+
+describe('polypMesh', () => {
+  test('builds a Mesh with a StandardMaterial that uses vertex colors', () => {
+    const mesh = polypMesh(fixtureMesh());
+
+    expect(mesh.geometry.getAttribute('position').count).toBe(3);
+    const mat = mesh.material as MeshStandardMaterial;
+    expect(mat).toBeInstanceOf(MeshStandardMaterial);
+    expect(mat.vertexColors).toBe(true);
+    // PBR values that give the coral its matte-wet-rock look; guard so a
+    // future tweak is at least conscious.
+    expect(mat.roughness).toBeCloseTo(0.7);
+    expect(mat.metalness).toBeCloseTo(0.05);
+  });
+});

--- a/packages/server/src/deviceHash.test.ts
+++ b/packages/server/src/deviceHash.test.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { deviceHash } from './deviceHash.js';
+
+describe('deviceHash', () => {
+  let realNow: () => number;
+
+  beforeEach(() => {
+    realNow = Date.now;
+  });
+
+  afterEach(() => {
+    Date.now = realNow;
+  });
+
+  test('stable within the same bucket for identical inputs', () => {
+    Date.now = () => 1_000_500;
+    const windowMs = 1000;
+    const a = deviceHash('Mozilla/5.0', '1.2.3.4', windowMs);
+    const b = deviceHash('Mozilla/5.0', '1.2.3.4', windowMs);
+    assert.equal(a, b);
+  });
+
+  test('different user agents produce different hashes in the same bucket', () => {
+    Date.now = () => 2_000_500;
+    const windowMs = 1000;
+    const a = deviceHash('UA-A', '1.2.3.4', windowMs);
+    const b = deviceHash('UA-B', '1.2.3.4', windowMs);
+    assert.notEqual(a, b);
+  });
+
+  test('different IPs produce different hashes in the same bucket', () => {
+    Date.now = () => 3_000_500;
+    const windowMs = 1000;
+    const a = deviceHash('UA', '1.2.3.4', windowMs);
+    const b = deviceHash('UA', '5.6.7.8', windowMs);
+    assert.notEqual(a, b);
+  });
+
+  test('crossing a bucket boundary rolls the salt', () => {
+    const windowMs = 1000;
+    Date.now = () => 4_000_500;
+    const inBucket = deviceHash('UA', 'IP', windowMs);
+    // Step past the next bucket boundary — same UA/IP, different salt.
+    Date.now = () => 4_001_500;
+    const nextBucket = deviceHash('UA', 'IP', windowMs);
+    assert.notEqual(inBucket, nextBucket);
+  });
+
+  test('produces a hex-encoded SHA-256 digest (64 chars)', () => {
+    Date.now = () => 5_000_500;
+    const out = deviceHash('UA', 'IP', 1000);
+    assert.equal(out.length, 64);
+    assert.match(out, /^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary
Two load-bearing files that were untested:

- **\`packages/client/src/scene/meshAdapter.ts\`** — the \`MeshData\` → \`BufferGeometry\` translation every rendered polyp goes through. Wrong \`itemSize\`, missing attribute, or dropped index buffer would quietly break all rendered geometry. 3 tests cover attribute stride/count, index buffer + bounding sphere, and material wiring (\`vertexColors\`, PBR values).
- **\`packages/server/src/deviceHash.ts\`** — per-device identity for rate limiting. The salt rotates on a bucket cadence driven by \`Date.now()\`; subtle temporal logic that'd silently break if the bucket math changes. 5 tests cover same-bucket stability, UA/IP sensitivity, bucket-boundary salt rotation, and digest format.

## Test plan
- [x] \`pnpm -r test\` — 132 pass across 4 packages (was 124)
  - shared 12, generator 22, client 32 (was 29), server 66 (was 61)
- [x] \`pnpm -r typecheck\` clean
- [x] \`oxlint\` on new files — 0 errors

## Files
- \`packages/client/src/scene/meshAdapter.test.ts\` (new, 3 tests)
- \`packages/server/src/deviceHash.test.ts\` (new, 5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)