### PR TITLE
Pin 8th Wall engine + test ReefSocket reconnect + requireAdminToken

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -9,8 +9,9 @@
   <!-- 8th Wall self-hosted engine binary. `async` means window.XR8 may not exist
        when the app module runs; EightWallProvider.waitUntilReady covers that race.
        `data-preload-chunks="slam"` prefetches the SLAM worker to avoid a second
-       RTT on first anchor-found. -->
-  <script src="https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1/dist/xr.js" async crossorigin="anonymous" data-preload-chunks="slam"></script>
+       RTT on first anchor-found. Version is pinned (not @1) so a bad minor
+       publish can't hit visitors silently; bump deliberately after smoke-testing. -->
+  <script src="https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1.0.0/dist/xr.js" async crossorigin="anonymous" data-preload-chunks="slam"></script>
 </head>
 <body>
   <div id="landing">

--- a/packages/client/src/net/ws.test.ts
+++ b/packages/client/src/net/ws.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ReefSocket, defaultWsUrl } from './ws.js';
+
+// Minimal WebSocket mock. Tracks registered listeners so tests can fire open /
+// message / close / error to drive ReefSocket through its state machine.
+class FakeWs {
+  readonly listeners = new Map<string, Set<(ev: unknown) => void>>();
+  readonly url: string;
+  readonly closeSpy = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWs.created.push(this);
+  }
+
+  addEventListener(type: string, cb: (ev: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(cb);
+  }
+
+  close(): void {
+    this.closeSpy();
+    // Real WebSockets fire close asynchronously; for test purposes synchronous
+    // is fine and makes assertions deterministic.
+    this.fire('close', {});
+  }
+
+  fire(type: string, ev: unknown): void {
+    this.listeners.get(type)?.forEach((cb) => cb(ev));
+  }
+
+  static created: FakeWs[] = [];
+  static reset(): void {
+    FakeWs.created = [];
+  }
+}
+
+describe('ReefSocket', () => {
+  beforeEach(() => {
+    FakeWs.reset();
+    vi.stubGlobal('WebSocket', FakeWs);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test('connect() opens a WebSocket at the configured url', () => {
+    const s = new ReefSocket('ws://example.test/ws');
+    s.connect();
+
+    expect(FakeWs.created).toHaveLength(1);
+    expect(FakeWs.created[0]!.url).toBe('ws://example.test/ws');
+  });
+
+  test('messages dispatch to every registered handler', () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    const s = new ReefSocket('ws://t');
+    s.on(h1);
+    s.on(h2);
+    s.connect();
+
+    FakeWs.created[0]!.fire('message', { data: JSON.stringify({ type: 'hello', polypCount: 3 }) });
+
+    expect(h1).toHaveBeenCalledWith({ type: 'hello', polypCount: 3 });
+    expect(h2).toHaveBeenCalledWith({ type: 'hello', polypCount: 3 });
+  });
+
+  test('close event schedules a reconnect with exponential backoff', () => {
+    const s = new ReefSocket('ws://t');
+    s.connect();
+    // First drop: retries goes 0 → 1, delay = 1000 * 1.8^0 = 1000.
+    FakeWs.created[0]!.fire('close', {});
+
+    // Not yet — still within the backoff window.
+    vi.advanceTimersByTime(999);
+    expect(FakeWs.created).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(FakeWs.created).toHaveLength(2);
+
+    // Second drop: delay = 1000 * 1.8^1 = 1800.
+    FakeWs.created[1]!.fire('close', {});
+    vi.advanceTimersByTime(1799);
+    expect(FakeWs.created).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(FakeWs.created).toHaveLength(3);
+  });
+
+  test('backoff caps at 30s even after many failures', () => {
+    const s = new ReefSocket('ws://t');
+    s.connect();
+    // Burn through retries without ever succeeding so the formula exceeds 30s.
+    // 1000 * 1.8^8 ≈ 110,200 — well past the cap.
+    for (let i = 0; i < 8; i++) {
+      FakeWs.created[FakeWs.created.length - 1]!.fire('close', {});
+      vi.advanceTimersByTime(30_000);
+    }
+    // 1 initial + 8 reconnects = 9 sockets. Crucially, each reconnect fired
+    // within a 30s window — no run ever needed more than that.
+    expect(FakeWs.created).toHaveLength(9);
+  });
+
+  test('an open event resets retries so the next drop starts from baseline', () => {
+    const s = new ReefSocket('ws://t');
+    s.connect();
+    // Fail a few times to build up retries.
+    FakeWs.created[0]!.fire('close', {});
+    vi.advanceTimersByTime(1000);
+    FakeWs.created[1]!.fire('close', {});
+    vi.advanceTimersByTime(1800);
+    // Now we're on socket index 2. Successfully open it.
+    FakeWs.created[2]!.fire('open', {});
+    // Drop again: next delay should be 1000ms (retries reset to 0), not 3240.
+    FakeWs.created[2]!.fire('close', {});
+    vi.advanceTimersByTime(999);
+    expect(FakeWs.created).toHaveLength(3);
+    vi.advanceTimersByTime(1);
+    expect(FakeWs.created).toHaveLength(4);
+  });
+
+  test('close() on the socket stops reconnects', () => {
+    const s = new ReefSocket('ws://t');
+    s.connect();
+    s.close();
+    // close() invokes ws.close() which fires 'close', which would normally
+    // schedule a reconnect. The `closed` flag must short-circuit that.
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWs.created).toHaveLength(1);
+  });
+});
+
+describe('defaultWsUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('picks wss for https and ws for http', () => {
+    vi.stubGlobal('location', { protocol: 'https:', host: 'reef.example.com' });
+    expect(defaultWsUrl()).toBe('wss://reef.example.com/ws');
+
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+    expect(defaultWsUrl()).toBe('ws://localhost:5173/ws');
+  });
+});

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { config, requireAdminToken } from './config.js';
+
+describe('requireAdminToken', () => {
+  let original: string;
+
+  beforeEach(() => {
+    original = config.adminToken;
+  });
+
+  afterEach(() => {
+    config.adminToken = original;
+  });
+
+  test('returns the token when it is set', () => {
+    config.adminToken = 'test-token-xyz';
+    assert.equal(requireAdminToken(), 'test-token-xyz');
+  });
+
+  test('throws when the token is empty (admin disabled without explicit opt-in)', () => {
+    // Empty-token-disables-admin is a deliberate safety: forgetting to set the
+    // token shouldn't silently leave admin routes open with some default.
+    config.adminToken = '';
+    assert.throws(() => requireAdminToken(), /ADMIN_TOKEN is required/);
+  });
+});


### PR DESCRIPTION
## Summary
Three related improvements bundled: pin the supply-chain dependency, then cover two load-bearing files that were untested.

### Pin \`@8thwall/engine-binary\` to \`1.0.0\`
jsDelivr was resolving \`@1\` to whatever the latest 1.x publish was. A bad minor on the upstream side would hit visitors silently. Pin explicitly; bump deliberately after smoke-testing.

### Test \`ReefSocket\` reconnect (packages/client/src/net/ws.test.ts)
7 tests with a FakeWs WebSocket mock and vitest fake timers:
- connect opens a WebSocket at the configured url
- incoming messages dispatch to every registered handler
- close event schedules reconnect with \`1000 * 1.8^n\` backoff
- backoff caps at 30s no matter how many retries accumulate
- an open event resets retries so the next drop starts from 1s
- \`close()\` on the socket short-circuits the reconnect loop
- \`defaultWsUrl\` picks wss for https, ws for http

### Test \`requireAdminToken\` (packages/server/src/config.test.ts)
- returns the value when set
- throws when empty — proves the "empty = admin disabled" safety stays load-bearing

## Test plan
- [x] \`pnpm -r test\` — 141 pass (was 132). Client 39 (was 32), server 68 (was 66)
- [x] \`pnpm -r typecheck\` clean
- [x] \`oxlint\` on new files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)