### PR TITLE
Docker :latest smoke test workflow (weekly cron + manual)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,89 @@
+name: Docker smoke
+
+# Pulls the published ghcr image and exercises it. Catches "the container
+# used to work but something in the base image or dependency surface has
+# rotted" between tagged releases. Manual dispatch for ad-hoc checks;
+# weekly cron so regressions surface without someone remembering to look.
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 08:00 UTC. After weekend dep-bump PRs have settled.
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: docker-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Pull ghcr :latest and hit endpoints
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.repository_owner == 'costajohnt' }}
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: docker pull ghcr.io/costajohnt/coralreefar:latest
+
+      - name: Run container
+        run: |
+          docker run -d \
+            --name coralreef-smoke \
+            -p 8787:8787 \
+            -e ADMIN_TOKEN=smoke-test-token \
+            -e CORS_ORIGINS=* \
+            ghcr.io/costajohnt/coralreefar:latest
+
+      - name: Wait for /healthz
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8787/healthz > /dev/null; then
+              echo "healthz up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "healthz never came up"
+          docker logs coralreef-smoke
+          exit 1
+
+      - name: Exercise known endpoints
+        run: |
+          set -euo pipefail
+          check() {
+            local path="$1"
+            local expect="$2"
+            local body
+            body=$(curl -sSf "http://localhost:8787${path}")
+            if ! echo "$body" | grep -q "$expect"; then
+              echo "FAIL ${path}: did not contain '${expect}'"
+              echo "--- body (first 500 chars) ---"
+              echo "${body:0:500}"
+              return 1
+            fi
+            echo "ok  ${path}"
+          }
+          check /healthz '"ok":true'
+          check /api/reef 'polyps'
+          check /api/stats 'count'
+          check /metrics 'reef_polyps_total'
+          check / '<!doctype html'
+
+      - name: Container logs (on failure)
+        if: failure()
+        run: docker logs coralreef-smoke || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f coralreef-smoke || true


### PR DESCRIPTION
## Summary
Catches regressions in the published \`ghcr.io/costajohnt/coralreefar:latest\` image between tagged releases — the kind of "something in the base image or dep surface rotted" bug you only learn about on deploy day without this.

## What it does
- \`workflow_dispatch\` + Monday 08:00 UTC cron (after weekend dep bumps settle)
- Logs into GHCR via \`GITHUB_TOKEN\`, pulls the \`:latest\` image
- Runs detached with \`-e ADMIN_TOKEN=smoke-test-token -e CORS_ORIGINS=*\`
- Polls \`/healthz\` for 30s
- \`curl\` exercises each known public endpoint, greps the body for a known marker:
  - \`/healthz\` → \`"ok":true\`
  - \`/api/reef\` → \`polyps\`
  - \`/api/stats\` → \`count\`
  - \`/metrics\` → \`reef_polyps_total\`
  - \`/\` → \`<!doctype html\` (the SPA)
- On failure, dumps container logs before tearing the container down

## Gating
\`if: github.repository_owner == 'costajohnt'\` — forks don't try to pull an image they can't see.

## Test plan
- [x] YAML syntax validated locally
- [ ] Post-merge: manual-trigger via Actions → Docker smoke → Run workflow to confirm green
- [ ] Next Monday 08:00 UTC: confirm cron fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)