### PR TITLE
Translucent + pulsating emissive coral

### DIFF
--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -3,6 +3,7 @@ import { computeGestureFrame, type PublicPolyp, type Mat4Like, type TouchPair } 
 import { Reef } from './scene/reef.js';
 import { installLighting } from './scene/lighting.js';
 import { installSway } from './scene/currentSway.js';
+import { installPulse } from './scene/pulse.js';
 import { FishSchool } from './sim/fish.js';
 import { Placement } from './placement.js';
 import { Picker } from './ui/picker.js';
@@ -20,6 +21,7 @@ export interface AppOptions {
 }
 
 const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
 
 export class App {
   private readonly scene = new Scene();
@@ -150,9 +152,17 @@ export class App {
       const m = obj as Mesh;
       if (!m.isMesh) continue;
       const flags = m.userData as Record<PropertyKey, unknown>;
-      if (flags[SWAY_INSTALLED]) continue;
-      installSway(m, this.swayClock);
-      flags[SWAY_INSTALLED] = true;
+      if (!flags[SWAY_INSTALLED]) {
+        installSway(m, this.swayClock);
+        flags[SWAY_INSTALLED] = true;
+      }
+      if (!flags[PULSE_INSTALLED]) {
+        const polyp = m.userData.polyp as PublicPolyp | undefined;
+        if (polyp) {
+          installPulse(m, this.swayClock, polyp.seed);
+          flags[PULSE_INSTALLED] = true;
+        }
+      }
     }
   }
 

--- a/packages/client/src/scene/meshAdapter.test.ts
+++ b/packages/client/src/scene/meshAdapter.test.ts
@@ -70,4 +70,15 @@ describe('polypMesh', () => {
     expect(mat.roughness).toBeCloseTo(0.7);
     expect(mat.metalness).toBeCloseTo(0.05);
   });
+
+  test('material is translucent with a baseline emissive glow', () => {
+    const mat = polypMesh(fixtureMesh()).material as MeshStandardMaterial;
+
+    expect(mat.transparent).toBe(true);
+    expect(mat.opacity).toBeCloseTo(0.85);
+    // White emissive so it reads as self-illuminated without tinting vertex
+    // colors. installPulse later rides on top of this baseline.
+    expect(mat.emissive.getHex()).toBe(0xffffff);
+    expect(mat.emissiveIntensity).toBeCloseTo(0.2);
+  });
 });

--- a/packages/client/src/scene/meshAdapter.ts
+++ b/packages/client/src/scene/meshAdapter.ts
@@ -17,6 +17,15 @@ export function polypMesh(mesh: MeshData): Mesh {
     vertexColors: true,
     roughness: 0.7,
     metalness: 0.05,
+    // Subtle wet/gelatinous translucency. Kept above 0.8 so clustered polyps
+    // don't produce obvious draw-order glitches even with depthWrite still on.
+    transparent: true,
+    opacity: 0.85,
+    // Baseline self-illumination. installPulse modulates emissiveIntensity
+    // per polyp on a slow sine for a breathing/bioluminescent effect; the
+    // baseline here is what the coral looks like mid-breath.
+    emissive: 0xffffff,
+    emissiveIntensity: 0.2,
   });
   return new Mesh(geometry, material);
 }

--- a/packages/client/src/scene/pulse.test.ts
+++ b/packages/client/src/scene/pulse.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { AMPLITUDE, BASELINE, PERIOD_SEC, pulseIntensity } from './pulse.js';
+
+describe('pulseIntensity', () => {
+  test('at t=0 with seed=0 the phase is 0 and intensity equals baseline', () => {
+    expect(pulseIntensity(0, 0)).toBeCloseTo(BASELINE);
+  });
+
+  test('stays inside [baseline - amplitude, baseline + amplitude]', () => {
+    // Sweep a range of times + seeds; sine is bounded so this should always hold.
+    for (let seed = 0; seed < 0xffffffff; seed += 0x11111111) {
+      for (let t = 0; t < 20; t += 0.1) {
+        const v = pulseIntensity(t, seed);
+        expect(v).toBeGreaterThanOrEqual(BASELINE - AMPLITUDE - 1e-9);
+        expect(v).toBeLessThanOrEqual(BASELINE + AMPLITUDE + 1e-9);
+      }
+    }
+  });
+
+  test('different seeds produce different phases at the same instant', () => {
+    // Two seeds 180° apart on the unit circle should produce mirrored values
+    // around the baseline at the same t.
+    const seedA = 0;
+    const seedB = 0x7fffffff; // ≈ 0.5 of max → phase ≈ π
+    const a = pulseIntensity(1, seedA);
+    const b = pulseIntensity(1, seedB);
+    // Sum lands at ≈ 2 * baseline because sin(x) + sin(x + π) = 0.
+    expect(a + b).toBeCloseTo(2 * BASELINE, 2);
+  });
+
+  test('completes a full cycle over PERIOD_SEC seconds', () => {
+    const seed = 0;
+    const start = pulseIntensity(0, seed);
+    const oneCycle = pulseIntensity(PERIOD_SEC, seed);
+    expect(oneCycle).toBeCloseTo(start, 6);
+  });
+
+  test('quarter-period advance equals amplitude offset for seed=0', () => {
+    // sin(0 + π/2) = 1, so after a quarter period we should be at the peak.
+    const peak = pulseIntensity(PERIOD_SEC / 4, 0);
+    expect(peak).toBeCloseTo(BASELINE + AMPLITUDE, 6);
+  });
+});

--- a/packages/client/src/scene/pulse.ts
+++ b/packages/client/src/scene/pulse.ts
@@ -1,0 +1,29 @@
+import type { Mesh, MeshStandardMaterial } from 'three';
+
+// Slow breathing. ±AMPLITUDE around BASELINE with a PERIOD_SEC cycle so the
+// reef reads as alive without drawing attention away from the geometry.
+export const BASELINE = 0.2;
+export const AMPLITUDE = 0.15;
+export const PERIOD_SEC = 4;
+
+/**
+ * Pure emissive-intensity sample for a polyp at a given clock time. Exported
+ * so the pulse math can be unit-tested without a Three.js renderer.
+ */
+export function pulseIntensity(clockSec: number, seed: number): number {
+  const phase = ((seed >>> 0) / 0xffffffff) * Math.PI * 2;
+  const omega = (2 * Math.PI) / PERIOD_SEC;
+  return BASELINE + AMPLITUDE * Math.sin(clockSec * omega + phase);
+}
+
+/**
+ * Binds emissiveIntensity to a shared clock so each polyp pulses on its own
+ * phase (derived from its seed). Assumes the mesh's material is a
+ * MeshStandardMaterial (what polypMesh produces).
+ */
+export function installPulse(mesh: Mesh, clock: { value: number }, seed: number): void {
+  const mat = mesh.material as MeshStandardMaterial;
+  mesh.onBeforeRender = (): void => {
+    mat.emissiveIntensity = pulseIntensity(clock.value, seed);
+  };
+}


### PR DESCRIPTION
## Summary
Coral now reads as alive rather than static gallery geometry: subtle translucency + a slow per-polyp emissive breathing effect.

## What changed
- **\`scene/meshAdapter.ts\` material tuning**
  - \`transparent: true\`, \`opacity: 0.85\` — wet/gelatinous softening. Stays above 0.8 so clustered polyps don't produce obvious draw-order glitches with depthWrite still on.
  - \`emissive: 0xffffff\`, \`emissiveIntensity: 0.2\` — white so the vertex colors read as themselves, not tinted. This is the mid-breath baseline.
- **\`scene/pulse.ts\` (new)**
  - Pure \`pulseIntensity(clockSec, seed)\`: \`BASELINE + AMPLITUDE * sin(ω·t + phase(seed))\` with \`PERIOD_SEC=4\`, \`BASELINE=0.2\`, \`AMPLITUDE=0.15\`. Phase derived from the polyp's seed so a reef of 100 polyps ripples asynchronously instead of in lockstep.
  - \`installPulse(mesh, clock, seed)\` wires \`onBeforeRender\` to update \`emissiveIntensity\`.
- **\`app.ts\`**: \`installSwayOnNewMeshes\` also installs pulse, guarded by its own \`PULSE_INSTALLED\` symbol on userData.

## Tuning knobs
Three constants at the top of \`pulse.ts\` — \`BASELINE\`, \`AMPLITUDE\`, \`PERIOD_SEC\`. Bump \`AMPLITUDE\` to 0.4 + drop opacity to 0.7 + shorten period to 2s if you want it pushed toward abstract/surreal. Current tuning leans subtly bioluminescent.

## Test plan
- [x] \`pnpm --filter @reef/client test\` — 38 pass (was 32)
- [x] \`pnpm --filter @reef/client typecheck\` clean
- [x] \`pnpm --filter @reef/client build\` — main.js 20.26 → 20.59 kB
- [x] \`oxlint\` — 0 errors
- [ ] Visual preview: \`pnpm --filter @reef/client dev\`, then \`/preview.html\` to see the species grid breathing

🤖 Generated with [Claude Code](https://claude.com/claude-code)