### PR TITLE
Docker smoke: fix /api/stats assertion

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -76,7 +76,7 @@ jobs:
           }
           check /healthz '"ok":true'
           check /api/reef 'polyps'
-          check /api/stats 'count'
+          check /api/stats '"total":'
           check /metrics 'reef_polyps_total'
           check / '<!doctype html'
 


### PR DESCRIPTION
## Summary
First real run of the smoke workflow (manual dispatch on main) caught my wrong assertion on \`/api/stats\` — the endpoint returns \`total\`, not \`count\`. Matching on \`"total":\` instead.

The workflow itself worked as intended: exited non-zero on the mismatch, dumped the actual body for diagnosis. Real validation of the CI, delivered by failing once.

## Test plan
- [x] \`/api/stats\` actual response confirmed as \`{"total":0,"uniqueDevices":0,"firstAt":null,"lastAt":null,"last24h":0,"last7d":0,"bySpecies":{}}\` (from failed run log)
- [x] YAML still valid
- [ ] Post-merge: dispatch Docker smoke again; expect all 5 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)