### PR TITLE
Docs: sync test counts + INSTALL 8th Wall paragraph

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,12 +126,11 @@ The tracking layer needs a printed image as the origin anchor. 8th
 Wall SLAM extends tracking beyond the marker, so visitors only need
 the marker to be in-frame briefly.
 
-Note: 8th Wall's hosted platform retired Feb 28, 2026. The current
-tracking code targets the retired model; the migration path to
-self-hosted `@8thwall/engine-binary` is tracked in `NEXT_STEPS.md`
-under "AR tracker migration plan". No appKey or account is required
-in the self-hosted model — the engine loads via jsDelivr and runs
-without phoning home.
+Note: 8th Wall's hosted platform retired Feb 28, 2026. The client
+now loads the self-hosted `@8thwall/engine-binary@1.0.0` from
+jsDelivr — no appKey, no account, no phone-home. See `NEXT_STEPS.md`
+under "AR tracker" for the engine-EOL window and the operator
+runbook for compiling the pedestal image-target.
 
 A placeholder marker lives at `assets/pedestal/marker.svg` — good
 enough for local smoke testing but not for production. See

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -6,8 +6,8 @@ it edited alongside the work.
 
 ## Current state
 
-- **Main branch CI**: green. 121 tests pass across 4 packages (shared 12 /
-  generator 22 / server 61 / client 26).
+- **Main branch CI**: green. 145 tests pass across 4 packages (shared 12 /
+  generator 22 / server 66 / client 45).
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
   @fastify/cors 11 · node:25-alpine · happy-dom 19 · Oxlint. All fully
   up-to-date.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
 - **Client**: TypeScript · Vite · Three.js. AR tracking via the
   self-hosted 8th Wall engine binary (noop fallback for desktop/dev).
   Two-finger pinch + twist for polyp placement.
-- **CI**: lint (Oxlint) · typecheck · build · 120 tests across four
+- **CI**: lint (Oxlint) · typecheck · build · 145 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 
 ## Layout


### PR DESCRIPTION
## Summary
Docs audit surfaced 3 drift items; all corrected here.

- \`README.md:44\` — 120 → 145 tests across four packages
- \`NEXT_STEPS.md:9\` — 121 → 145 tests; breakdown updated (shared 12 / generator 22 / server 66 / client 45)
- \`INSTALL.md:129\` — paragraph rewritten. Previously claimed "the current tracking code targets the retired model" which hasn't been true since #30 migrated to the self-hosted engine-binary. Also fixes the broken \`"AR tracker migration plan"\` cross-ref (section was renamed to \`"AR tracker"\` in #39).

## Note on ordering vs #40
Test count assumes #40 (audit-fix-bundle) has landed — that PR removes 2 dead config tests. If this PR merges first, main briefly shows "145" while the real count is 147. Self-corrects when #40 lands.

## Test plan
- [x] Ground-truth count verified: \`pnpm -r test\` on audit-fix-bundle = 145

🤖 Generated with [Claude Code](https://claude.com/claude-code)