### PR TITLE
Dockerfile: swap corepack for npm (node:25 dropped corepack)

### DIFF
--- a/infra/Dockerfile.server
+++ b/infra/Dockerfile.server
@@ -1,7 +1,7 @@
 FROM node:25-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ sqlite
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN npm install -g pnpm@9.0.0
 
 COPY pnpm-workspace.yaml package.json tsconfig.base.json ./
 COPY packages/shared/package.json packages/shared/
@@ -22,7 +22,7 @@ RUN pnpm --filter @reef/shared build \
 FROM node:25-alpine
 WORKDIR /app
 RUN apk add --no-cache sqlite tini
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN npm install -g pnpm@9.0.0
 
 COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
 COPY --from=builder /app/packages/shared/package.json packages/shared/


### PR DESCRIPTION
## Summary
v0.2.0 release build failed with \`/bin/sh: corepack: not found\` (exit 127) on \`RUN corepack enable && corepack prepare pnpm@9.0.0 --activate\`. Node 25 alpine dropped the bundled corepack.

v0.1.0 was built on node:20 (corepack still bundled) so \`:latest\` in GHCR works. The bump to node:25 in #14 merged but never hit the release workflow until now.

## Fix
Swap to \`npm install -g pnpm@9.0.0\` in both build + runtime stages. Same end state, works on any Node image.

## After merge
Retagging needed — I'll move v0.2.0 to the fix commit so release workflow runs against the working Dockerfile. (Deleting + re-pushing a never-built tag is safe; no image was published with this tag.)

## Test plan
- [x] CI "Build and test" passes
- [ ] Post-merge: re-tag v0.2.0, release workflow goes green, multi-arch image published

🤖 Generated with [Claude Code](https://claude.com/claude-code)