### PR TITLE
Fix: @fastify/cors v11 needs Fastify 5 — pin back to ^9.0.1

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "test": "tsc -p tsconfig.test.json && node --test --test-reporter=spec $(find dist-test -name '*.test.js')"
   },
   "dependencies": {
-    "@fastify/cors": "^11.2.0",
+    "@fastify/cors": "^9.0.1",
     "@fastify/static": "^7.0.4",
     "@fastify/websocket": "^10.0.1",
     "@reef/generator": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
   packages/server:
     dependencies:
       '@fastify/cors':
-        specifier: ^11.2.0
-        version: 11.2.0
+        specifier: ^9.0.1
+        version: 9.0.1
       '@fastify/static':
         specifier: ^7.0.4
         version: 7.0.4
@@ -280,8 +280,8 @@ packages:
   '@fastify/ajv-compiler@3.6.0':
     resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
 
-  '@fastify/cors@11.2.0':
-    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+  '@fastify/cors@9.0.1':
+    resolution: {integrity: sha512-YY9Ho3ovI+QHIL2hW+9X4XqQjXLjJqsU+sMV/xFsxZkE8p3GNnYVFpoOxF7SsP5ZL76gwvbo3V9L+FIekBGU4Q==}
 
   '@fastify/error@3.4.1':
     resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
@@ -726,9 +726,6 @@ packages:
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
 
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
-
   fastify@4.29.1:
     resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
 
@@ -853,6 +850,9 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mnemonist@0.39.6:
+    resolution: {integrity: sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -864,6 +864,9 @@ packages:
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1330,10 +1333,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.18.0)
       fast-uri: 2.4.0
 
-  '@fastify/cors@11.2.0':
+  '@fastify/cors@9.0.1':
     dependencies:
-      fastify-plugin: 5.1.0
-      toad-cache: 3.7.0
+      fastify-plugin: 4.5.1
+      mnemonist: 0.39.6
 
   '@fastify/error@3.4.1': {}
 
@@ -1751,8 +1754,6 @@ snapshots:
 
   fastify-plugin@4.5.1: {}
 
-  fastify-plugin@5.1.0: {}
-
   fastify@4.29.1:
     dependencies:
       '@fastify/ajv-compiler': 3.6.0
@@ -1883,6 +1884,10 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mnemonist@0.39.6:
+    dependencies:
+      obliterator: 2.0.5
+
   nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
@@ -1890,6 +1895,8 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  obliterator@2.0.5: {}
 
   obug@2.1.1: {}
 


### PR DESCRIPTION
## Summary
Discovered when deploying v0.2.0 to the Beelink: container crash-loops with \`FST_ERR_PLUGIN_VERSION_MISMATCH\` — \`@fastify/cors@11\` expects Fastify \`5.x\` but we're on \`4.29.1\`.

Dependabot PR #18 bumped cors 9 → 11 without bumping Fastify. The CI never caught this because test files build fresh Fastify instances per-route (\`admin.test.ts\`, \`reef.test.ts\`, etc.) and don't register cors. Only the app's main boot path (\`index.ts\`) loads cors, and that path isn't exercised in CI.

## Fix
Downgrade \`@fastify/cors\` to the pre-bump \`^9.0.1\`, which is the highest Fastify-4-compatible major. Proper Fastify 4 → 5 migration is a separate task — will file.

## Integration gap
This class of bug (plugin version mismatch) will keep slipping past CI until something boots the full app during tests. The \`ws.integration.test.ts\` does the closest thing but builds its own minimal Fastify instance. A "full server boot" smoke test would have caught this.

Filing as a follow-up tech-debt issue.

## Test plan
- [x] \`pnpm -r test\` — 145 pass
- [x] \`pnpm -r typecheck\` clean
- [ ] Post-merge: retag v0.2.0 → release workflow → LXC redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)