### PR TITLE
Boot smoke test: catch plugin-version-mismatch at build time

### DIFF
--- a/packages/server/src/boot.smoke.test.ts
+++ b/packages/server/src/boot.smoke.test.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from 'node:assert';
+import { after, test } from 'node:test';
+import { makeServer } from './index.js';
+
+// Boot smoke test: register every plugin + route against a real Fastify
+// instance, in the real load order, with an in-memory DB. Catches
+// plugin-version-mismatch bugs (e.g. a cors plugin major that requires a
+// newer Fastify than we ship) that route-level tests miss because they
+// build minimal Fastify instances per-suite.
+
+test('smoke: full app boots with the real plugin load order', async () => {
+  const { app } = await makeServer({
+    dbPath: ':memory:',
+    adminToken: '',
+    corsOrigins: ['*'],
+    clientDistDir: undefined,
+    logger: false,
+  });
+  after(async () => { await app.close(); });
+
+  const healthz = await app.inject({ method: 'GET', url: '/healthz' });
+  assert.equal(healthz.statusCode, 200);
+  const body = JSON.parse(healthz.body) as { ok: boolean; time: number };
+  assert.equal(body.ok, true);
+  assert.equal(typeof body.time, 'number');
+});
+
+test('smoke: DB migrations ran (API/reef serves an empty-state payload)', async () => {
+  const { app } = await makeServer({
+    dbPath: ':memory:',
+    adminToken: '',
+    corsOrigins: ['*'],
+    clientDistDir: undefined,
+    logger: false,
+  });
+  after(async () => { await app.close(); });
+
+  const res = await app.inject({ method: 'GET', url: '/api/reef' });
+  assert.equal(res.statusCode, 200);
+  const state = JSON.parse(res.body) as { polyps: unknown[]; sim: unknown[] };
+  assert.deepEqual(state.polyps, []);
+  assert.deepEqual(state.sim, []);
+});
+
+test('smoke: explicit CORS_ORIGINS list binds without throwing', async () => {
+  // Second CORS path — the `origin: string[]` branch, distinct from `origin: true`
+  // that the wildcard test uses. Covers both sides of the config.ts split.
+  const { app } = await makeServer({
+    dbPath: ':memory:',
+    adminToken: '',
+    corsOrigins: ['https://a.example', 'https://b.example'],
+    clientDistDir: undefined,
+    logger: false,
+  });
+  after(async () => { await app.close(); });
+
+  const res = await app.inject({ method: 'GET', url: '/healthz' });
+  assert.equal(res.statusCode, 200);
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,10 @@
-import Fastify from 'fastify';
+import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import websocket from '@fastify/websocket';
 import fastifyStatic from '@fastify/static';
 import { resolve as resolvePath } from 'node:path';
 import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { config } from './config.js';
 import { ReefDb } from './db.js';
 import { Hub } from './hub.js';
@@ -15,21 +16,48 @@ import { registerMetricsRoutes } from './routes/metrics.js';
 import { SimWorker, SnapshotWorker } from './sim.js';
 import { installSecurityHeaders } from './security.js';
 
-async function main(): Promise<void> {
-  const db = new ReefDb(config.dbPath);
+export interface MakeServerOptions {
+  dbPath?: string;
+  adminToken?: string;
+  corsOrigins?: string[];
+  clientDistDir?: string | undefined;
+  logger?: boolean;
+}
+
+export interface MakeServerResult {
+  app: FastifyInstance;
+  db: ReefDb;
+  hub: Hub;
+}
+
+/**
+ * Build the Fastify app with all plugins + routes registered. Does NOT
+ * start the sim/snapshot workers, the heartbeat, or listen on a port — main()
+ * does that. This split lets tests exercise the real plugin load order
+ * (where a Fastify-plugin-version mismatch would throw) without the noise
+ * of workers + network binding.
+ */
+export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServerResult> {
+  const dbPath = opts.dbPath ?? config.dbPath;
+  const adminToken = opts.adminToken ?? config.adminToken;
+  const corsOriginsList = opts.corsOrigins ?? config.corsOrigins;
+  const clientDistDir = opts.clientDistDir ?? config.clientDistDir;
+  const useLogger = opts.logger ?? true;
+
+  const db = new ReefDb(dbPath);
   const hub = new Hub();
 
   // 8 KB fits the largest valid polyp (schema-bounded). Fastify's 1 MB
   // default lets unauthenticated callers make Zod walk a megabyte before
   // rejecting.
-  const app = Fastify({ logger: true, trustProxy: true, bodyLimit: 8192 });
+  const app = Fastify({ logger: useLogger, trustProxy: true, bodyLimit: 8192 });
   const corsOrigin: boolean | string[] =
-    config.corsOrigins.length === 1 && config.corsOrigins[0] === '*' ? true : config.corsOrigins;
+    corsOriginsList.length === 1 && corsOriginsList[0] === '*' ? true : corsOriginsList;
   await app.register(cors, { origin: corsOrigin });
   await app.register(websocket, { options: { maxPayload: 64 * 1024 } });
   installSecurityHeaders(app);
 
-  if (!config.adminToken) {
+  if (!adminToken) {
     app.log.warn('ADMIN_TOKEN is not set — admin endpoints will reject all requests');
   }
 
@@ -44,8 +72,8 @@ async function main(): Promise<void> {
   // Optional static hosting: serves the built Vite bundle out of the same
   // container so a single-host deploy doesn't need a separate nginx sidecar.
   // Unset in dev so the Vite dev server keeps handling the frontend.
-  if (config.clientDistDir) {
-    const root = resolvePath(config.clientDistDir);
+  if (clientDistDir) {
+    const root = resolvePath(clientDistDir);
     if (!existsSync(root)) {
       app.log.warn({ root }, 'CLIENT_DIST_DIR is set but does not exist — skipping static hosting');
     } else {
@@ -72,6 +100,12 @@ async function main(): Promise<void> {
     }));
   });
 
+  return { app, db, hub };
+}
+
+async function main(): Promise<void> {
+  const { app, db, hub } = await makeServer();
+
   const sim = new SimWorker(db, hub, config.simIntervalMs);
   sim.start();
   const snapshots = new SnapshotWorker(db, config.snapshotIntervalMs);
@@ -92,7 +126,13 @@ async function main(): Promise<void> {
   app.log.info({ port: config.port }, 'reef server listening');
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run main() when this module is the entrypoint — not when imported by
+// a test file. Without this, importing `makeServer` from the smoke test would
+// also boot the full server on the real port.
+const isEntrypoint = process.argv[1] === fileURLToPath(import.meta.url);
+if (isEntrypoint) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Refactors \`packages/server/src/index.ts\` to export a \`makeServer()\` factory; \`main()\` is a thin wrapper that calls \`makeServer\` then starts workers + listens. The real Fastify instance, with its full plugin load order, is now constructible from test code.

Would have caught PR #52's plugin-version-mismatch bug (cors v11 needed Fastify 5; we're on 4.29) at CI time instead of on first container boot.

## Why the existing tests didn't catch it
Every route-level test file builds a fresh \`Fastify()\` instance and registers only the routes under test — none of them register the CORS plugin or the full set together. The \`FST_ERR_PLUGIN_VERSION_MISMATCH\` crash only fires during full plugin boot, which no test path exercised.

## What the new test covers
Three cases in \`boot.smoke.test.ts\`:
1. **Full app boots with the real plugin load order** — constructs via \`makeServer\`, hits \`/healthz\`
2. **DB migrations ran** — hits \`/api/reef\`, confirms empty state payload
3. **Explicit CORS list path** — second \`makeServer\` call with \`corsOrigins: ['https://a.example', 'https://b.example']\` to cover the non-wildcard branch

## Entrypoint gate
Added \`import.meta.url === fileURLToPath(process.argv[1])\` check so \`main()\` only runs when \`node dist/index.js\` is the entrypoint. Without that, importing \`makeServer\` from a test would also boot the full server on the real port.

## Closes
Issue #53.

## Test plan
- [x] \`pnpm -r test\` — 148 pass across 4 packages (was 145)
- [x] \`pnpm -r typecheck\` clean
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)