### PR TITLE
Docs sync: close v0.2.0, refresh test count + snapshot date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ versions are SemVer.
 
 ## [Unreleased]
 
+### Added
+
+- **Full-app boot smoke test.** `packages/server/src/index.ts` now
+  exports a `makeServer()` factory; `boot.smoke.test.ts` exercises
+  the real plugin load order with an in-memory DB. Catches
+  Fastify-plugin-version mismatches (the exact class of bug that
+  bit v0.2.0's first two release-build attempts). (#55)
+- **Test coverage on previously-untested scene files.** 11 new tests
+  across `simDecor` (all three decoration branches + non-Mesh
+  no-op documentation) and `currentSway` (shader-anchor injection
+  assertions so Three.js include renames don't silently drop sway
+  in the next major). Partial close of #47. (#56)
+- **Operator runbook for the deployed LXC.** `NEXT_STEPS.md` now
+  documents what's running on the Beelink and how to manage it
+  (status, logs, admin-token retrieval, image updates, DB backup,
+  teardown). (#57)
+
+### Changed
+
+- **Test count** across four packages: 146 → 161 (shared 12 /
+  generator 22 / server 70 / client 57).
+
+## [0.2.0] — 2026-04-19
+
+First release after the self-hosted AR migration + a session-long
+audit + hardening cycle. See the full release notes on GitHub:
+<https://github.com/costajohnt/CoralReefAR/releases/tag/v0.2.0>.
+
 ### Changed
 
 - **AR tracker migrated to the self-hosted 8th Wall engine binary.**

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -26,7 +26,7 @@ it edited alongside the work.
 
 ## Deployment
 
-### What's actually running right now (as of 2026-04-19)
+### What's actually running right now (as of 2026-04-21)
 
 - **LXC 300** on the homelab Proxmox host (hostname `homelab`,
   192.168.5.100). Debian 12, 2 CPU / 2 GB RAM / 10 GB disk,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
 - **Client**: TypeScript · Vite · Three.js. AR tracking via the
   self-hosted 8th Wall engine binary (noop fallback for desktop/dev).
   Two-finger pinch + twist for polyp placement.
-- **CI**: lint (Oxlint) · typecheck · build · 145 tests across four
+- **CI**: lint (Oxlint) · typecheck · build · 161 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 
 ## Layout


### PR DESCRIPTION
## Summary
Post-release drift cleanup.

### CHANGELOG
- Renamed the floating [Unreleased] block to **[0.2.0] — 2026-04-19** so it matches the pushed tag + GitHub release
- Opened a fresh [Unreleased] above it covering:
  - #55 full-app boot smoke test + \`makeServer()\` factory
  - #56 test coverage for \`simDecor\` + \`currentSway\`
  - #57 operator runbook for the deployed LXC

### README
- 145 → **161** tests across four packages (post #55/#56)

### NEXT_STEPS
- Snapshot date on "what's actually running" block: 2026-04-19 → 2026-04-21
- Content unchanged — the deployed LXC / NPM proxy / Pi-hole / homepage tile state hasn't drifted since the snapshot

### Verification
Ran a grep sweep for stale test-count claims (\`145 tests\`, \`server 6X\`, \`client 4X\`, specific date refs). Only the three items above needed updates.

## Test plan
- [x] \`pnpm lint\` — 0 errors
- [x] Doc-only change; no test or typecheck impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)