### PR TITLE
Playground: AR-free interactive reef + museum screen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ versions are SemVer.
   parameter, letting callers that have already raycast their own
   placement point (e.g. the playground) seed the ghost without
   going through `handleTap()`. AR client behavior unchanged.
-- **Test count** across four packages: 161 → 177 (shared 12 /
-  generator 22 / server 70 / client 73).
+- **Test count** across four packages: 161 → 180 (shared 12 /
+  generator 22 / server 70 / client 76).
 
 ## [0.3.0] — 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,27 @@ versions are SemVer.
 
 ## [Unreleased]
 
-### Planned
+### Added
 
 - **Playground (`playground.html`)** — AR-free interactive reef view:
   orbit camera, click-to-place on a virtual pedestal, full picker +
-  commit flow, WebSocket live updates. Adds `?mode=screen` for a
-  museum-screen auto-orbit variant and `?readonly=1` for browse-only.
-  Reuses `Reef`, `Placement`, `Picker`, `ReefSocket`. Implementation
-  plan in
-  [`docs/superpowers/plans/2026-04-22-playground-virtual-reef.md`](docs/superpowers/plans/2026-04-22-playground-virtual-reef.md).
+  commit flow, WebSocket live updates. `?mode=screen` drives an
+  auto-orbit camera for the eventual museum-screen display;
+  `?readonly=1` is a browse-only mode. `?api=URL` points at any
+  backend. Reuses `Reef`, `Placement`, `Picker`, `ReefSocket` and
+  the existing scene effects (sway, pulse, fish). Four new pure
+  modules under `packages/client/src/playground/` — `scene.ts`,
+  `config.ts`, `autoOrbit.ts`, `interaction.ts` — plus
+  `playground.ts` + `playground.html`.
+
+### Changed
+
+- `Placement.showGhost()` now accepts an optional `positionOverride`
+  parameter, letting callers that have already raycast their own
+  placement point (e.g. the playground) seed the ghost without
+  going through `handleTap()`. AR client behavior unchanged.
+- **Test count** across four packages: 161 → 177 (shared 12 /
+  generator 22 / server 70 / client 73).
 
 ## [0.3.0] — 2026-04-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,11 @@ For desktop dev without a camera / pedestal, open
 `http://localhost:5173/?tracker=noop` — the reef anchors a fixed
 distance in front of the virtual camera.
 
-Better option once the playground ships:
+Or skip AR entirely and use the playground:
 `http://localhost:5173/playground.html?api=http://localhost:8787`.
-It's a proper orbit-camera view with click-to-place and the full
-picker UI — no AR code-paths involved. See
-[`docs/superpowers/plans/2026-04-22-playground-virtual-reef.md`](./docs/superpowers/plans/2026-04-22-playground-virtual-reef.md)
-for the implementation plan.
+Orbit-camera view, click-to-place, full picker UI — no AR
+code-paths involved. Add `?mode=screen` for the auto-orbit
+museum-display variant.
 
 ## Testing
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -6,8 +6,8 @@ it edited alongside the work.
 
 ## Current state
 
-- **Main branch CI**: green. 161 tests pass across 4 packages (shared 12 /
-  generator 22 / server 70 / client 57).
+- **Main branch CI**: green. 180 tests pass across 4 packages (shared 12 /
+  generator 22 / server 70 / client 76).
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
   @fastify/cors 9 (pinned — issue #54 tracks Fastify 5 migration) ·
   node:25-alpine · happy-dom 19 · Oxlint.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -179,13 +179,11 @@ Tracking issue: [#28].
 
 ## Operator runbook — exactly what you need to do
 
-### Step 0 — Non-AR testing via the playground (coming soon)
+### Step 0 — Non-AR testing via the playground
 
 Before investing in the marker print + NFC tag + real-device cycle,
-exercise the full reef pipeline without any AR dependencies. A new
-`playground.html` view is planned (see
-[`docs/superpowers/plans/2026-04-22-playground-virtual-reef.md`](./docs/superpowers/plans/2026-04-22-playground-virtual-reef.md))
-that gives you:
+exercise the full reef pipeline without any AR dependencies. The
+`playground.html` view gives you:
 
 - Orbit-camera Three.js view of the reef (mouse-drag rotate, scroll zoom)
 - Click-to-place polyps on a virtual pedestal — same picker UI, same
@@ -194,7 +192,7 @@ that gives you:
   museum-screen display next to the physical pedestal
 - `?readonly=1` — browse-only mode for demo kiosks
 
-URLs (once shipped):
+URLs:
 
 ```
 https://reef.home.local/playground.html           # interactive
@@ -202,8 +200,7 @@ https://reef.home.local/playground.html?mode=screen
 https://reef.home.local/playground.html?readonly=1
 ```
 
-Plus local dev: `pnpm --filter @reef/client dev` then
-`http://localhost:5173/playground.html?api=http://localhost:8787`.
+Local dev: `pnpm --filter @reef/client dev` → `http://localhost:5173/playground.html?api=http://localhost:8787`.
 
 What it **doesn't** test: the 8th Wall engine, camera permissions,
 SLAM tracking, anchor stability, real lighting, the marker print.

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,7 +9,7 @@ A collaborative AR installation where visitors tap an NFC tag, open a web-based 
 - **Liveness:** Simulated currents, background growth, and ambient life. The reef changes visibly even with zero tappers.
 - **Tracking abstraction:** Swappable tracking provider interface so a future provider (WebXR image-tracking, another engine) can slot in without touching app code.
 - **Still $0 ongoing cost.** Everything self-hosted on existing Beelink + Cloudflare Tunnel.
-- **Dual surface (planned):** the installation has both an AR layer (phone tapped to a pedestal) and a non-AR screen layer (`playground.html`) that shows the reef growing from a fixed orbit viewpoint on a wall-mounted display. Same backend, same sim loop, same geometry — two ways to experience the same living reef. Detailed plan in [`docs/superpowers/plans/2026-04-22-playground-virtual-reef.md`](./docs/superpowers/plans/2026-04-22-playground-virtual-reef.md).
+- **Dual surface:** the installation has both an AR layer (phone tapped to a pedestal) and a non-AR screen layer (`playground.html`) that shows the reef growing from a fixed orbit viewpoint on a wall-mounted display. Same backend, same sim loop, same geometry — two ways to experience the same living reef.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
   - **Playground** (`playground.html`) — AR-free orbit-camera view
     with click-to-place, for iterating without marker/phone. Adds
     `?mode=screen` for a fixed museum-display variant.
-- **CI**: lint (Oxlint) · typecheck · build · 177 tests across four
+- **CI**: lint (Oxlint) · typecheck · build · 180 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 
 The playground ships as of v0.4.0.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
     marker tracking, two-finger pinch + twist placement on phone.
   - **Playground** (`playground.html`) — AR-free orbit-camera view
     with click-to-place, for iterating without marker/phone. Adds
-    `?mode=screen` for a fixed museum-display variant. Planned —
-    implementation in `docs/superpowers/plans/2026-04-22-playground-virtual-reef.md`.
-- **CI**: lint (Oxlint) · typecheck · build · 161 tests across four
+    `?mode=screen` for a fixed museum-display variant.
+- **CI**: lint (Oxlint) · typecheck · build · 177 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
+
+The playground ships as of v0.4.0.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
 - **CI**: lint (Oxlint) · typecheck · build · 180 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 
-The playground ships as of v0.4.0.
-
 ## Layout
 
 ```

--- a/packages/client/playground.html
+++ b/packages/client/playground.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#0b1d2a" />
+  <title>Coral Reef — Playground</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+  <style>
+    body { margin: 0; background: #02111d; overflow: hidden; }
+    #gl { display: block; width: 100vw; height: 100vh; }
+    #mode-badge {
+      position: fixed; top: 12px; left: 12px; padding: 4px 8px;
+      font: 500 11px/1 system-ui, sans-serif; color: #9ab;
+      background: rgba(0,0,0,0.35); border-radius: 3px;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="gl"></canvas>
+  <div id="mode-badge"></div>
+  <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
+    <div class="picker-row" role="group" aria-label="Species">
+      <button type="button" data-species="branching">Branching</button>
+      <button type="button" data-species="bulbous">Bulbous</button>
+      <button type="button" data-species="fan">Fan</button>
+      <button type="button" data-species="tube">Tube</button>
+      <button type="button" data-species="encrusting">Encrusting</button>
+    </div>
+    <div id="colors" class="picker-row" role="group" aria-label="Color"></div>
+    <div class="picker-actions">
+      <button id="rerollBtn" type="button" disabled aria-label="Regenerate shape">Reroll shape</button>
+      <button id="cancelBtn" type="button" disabled aria-label="Cancel placement">Cancel</button>
+    </div>
+    <button id="growBtn" type="button" disabled>Grow it</button>
+    <p id="hint" aria-live="polite">Click the pedestal to place your polyp.</p>
+  </div>
+  <script type="module" src="/src/playground.ts"></script>
+</body>
+</html>

--- a/packages/client/src/placement.test.ts
+++ b/packages/client/src/placement.test.ts
@@ -96,3 +96,24 @@ describe('Placement.reset', () => {
     expect(placement.getLast()).toBeNull();
   });
 });
+
+describe('Placement.showGhost positionOverride', () => {
+  test('showGhost with positionOverride seeds lastResult without needing handleTap first', () => {
+    const anchor = new Group();
+    const camera = new PerspectiveCamera(60, 1, 0.01, 30);
+    const placement = new Placement(makeFakeReef(), camera, anchor);
+
+    // Precondition: no lastResult until handleTap (or override) runs.
+    expect(placement.getLast()).toBeNull();
+
+    const override = new Vector3(0.03, 0, 0.02);
+    placement.showGhost('branching', 1234, 'coral-pink', override);
+
+    const r = placement.getLast();
+    expect(r).not.toBeNull();
+    expect(r!.position.x).toBeCloseTo(0.03, 6);
+    expect(r!.position.z).toBeCloseTo(0.02, 6);
+    expect(r!.normal.y).toBeCloseTo(1, 6);
+    expect(r!.scale).toBe(1);
+  });
+});

--- a/packages/client/src/placement.ts
+++ b/packages/client/src/placement.ts
@@ -70,7 +70,20 @@ export class Placement {
     return this.lastResult;
   }
 
-  showGhost(species: Species, seed: number, colorKey: string): void {
+  showGhost(species: Species, seed: number, colorKey: string, positionOverride?: Vector3): void {
+    // When positionOverride is provided (e.g. by the playground's own
+    // raycast helper), seed a fresh PlacementResult so the ghost renders
+    // at that point even though handleTap() was never called. Preserves
+    // existing AR-client callers that rely on handleTap populating
+    // lastResult first.
+    if (positionOverride) {
+      this.lastResult = {
+        position: positionOverride.clone(),
+        normal: new Vector3(0, 1, 0),
+        orientation: new Quaternion(),
+        scale: 1,
+      };
+    }
     this.clearGhost();
     const gen = generatePolyp({ species, seed, colorKey });
     const m = polypMesh(gen.mesh);

--- a/packages/client/src/playground.test.ts
+++ b/packages/client/src/playground.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// We don't run the full playground entry in test — it calls WebGL and fetch.
+// Instead, verify the module imports without throwing and the config parser
+// + scene factory work together as expected.
+describe('playground module', () => {
+  test('config + scene + autoOrbit + interaction all importable together', async () => {
+    const [config, scene, autoOrbit, interaction] = await Promise.all([
+      import('./playground/config.js'),
+      import('./playground/scene.js'),
+      import('./playground/autoOrbit.js'),
+      import('./playground/interaction.js'),
+    ]);
+    expect(typeof config.readPlaygroundConfig).toBe('function');
+    expect(typeof scene.createPedestal).toBe('function');
+    expect(typeof autoOrbit.computeOrbitPose).toBe('function');
+    expect(typeof interaction.computePlacementFromClick).toBe('function');
+  });
+
+  test('readPlaygroundConfig + createPedestal produce a valid pair', async () => {
+    const { readPlaygroundConfig } = await import('./playground/config.js');
+    const { createPedestal } = await import('./playground/scene.js');
+    vi.stubGlobal('location', { search: '?mode=screen' });
+    expect(readPlaygroundConfig().mode).toBe('screen');
+    expect(createPedestal()).toBeTruthy();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/client/src/playground.ts
+++ b/packages/client/src/playground.ts
@@ -1,0 +1,45 @@
+import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { installLighting } from './scene/lighting.js';
+import { createPedestal } from './playground/scene.js';
+import { readPlaygroundConfig } from './playground/config.js';
+
+const config = readPlaygroundConfig();
+const canvas = document.getElementById('gl') as HTMLCanvasElement;
+const modeBadge = document.getElementById('mode-badge')!;
+modeBadge.textContent = `${config.mode}${config.readonly ? ' · readonly' : ''}`;
+
+const renderer = new WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+renderer.setClearColor(0x02111d, 1);
+
+const scene = new Scene();
+installLighting(scene);
+scene.add(createPedestal());
+
+const camera = new PerspectiveCamera(50, 1, 0.01, 20);
+camera.position.set(0.45, 0.2, 0);
+camera.lookAt(0, 0, 0);
+
+const controls = new OrbitControls(camera, canvas);
+controls.target.set(0, 0, 0);
+controls.minDistance = 0.2;
+controls.maxDistance = 1.2;
+controls.maxPolarAngle = Math.PI / 2 - 0.05;  // don't orbit below the floor
+controls.enableDamping = true;
+
+function resize(): void {
+  const w = window.innerWidth, h = window.innerHeight;
+  renderer.setSize(w, h, false);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function loop(): void {
+  controls.update();
+  renderer.render(scene, camera);
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);

--- a/packages/client/src/playground.ts
+++ b/packages/client/src/playground.ts
@@ -1,4 +1,4 @@
-import { PerspectiveCamera, Scene, WebGLRenderer, type Mesh } from 'three';
+import { PerspectiveCamera, Scene, WebGLRenderer, Vector2, type Mesh } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { PublicPolyp } from '@reef/shared';
 import { installLighting } from './scene/lighting.js';
@@ -6,10 +6,13 @@ import { installSway } from './scene/currentSway.js';
 import { installPulse } from './scene/pulse.js';
 import { Reef } from './scene/reef.js';
 import { FishSchool } from './sim/fish.js';
-import { fetchReef } from './net/api.js';
+import { fetchReef, submitPolyp, RateLimitError } from './net/api.js';
 import { ReefSocket, defaultWsUrl } from './net/ws.js';
 import { createPedestal } from './playground/scene.js';
 import { readPlaygroundConfig } from './playground/config.js';
+import { Placement } from './placement.js';
+import { Picker } from './ui/picker.js';
+import { computePlacementFromClick } from './playground/interaction.js';
 
 const SWAY_INSTALLED = Symbol('sway-installed');
 const PULSE_INSTALLED = Symbol('pulse-installed');
@@ -45,6 +48,85 @@ controls.minDistance = 0.2;
 controls.maxDistance = 1.2;
 controls.maxPolarAngle = Math.PI / 2 - 0.05;
 controls.enableDamping = true;
+
+const placement = new Placement(reef, camera, reef.anchor);
+const pickerRoot = document.getElementById('picker')!;
+const picker = new Picker(pickerRoot);
+const hintEl = document.getElementById('hint')!;
+
+let currentSeed = Math.floor(Math.random() * 0xffffffff);
+
+if (config.mode === 'interactive') {
+  picker.show();
+  canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const ndc = new Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -(((e.clientY - rect.top) / rect.height) * 2 - 1),
+    );
+    const hit = computePlacementFromClick(ndc, camera);
+    if (!hit) {
+      hintEl.textContent = 'Click on the pedestal top to place your polyp.';
+      return;
+    }
+    currentSeed = Math.floor(Math.random() * 0xffffffff);
+    const s = picker.get();
+    placement.showGhost(s.species, currentSeed, s.colorKey, hit);
+    picker.setCommittable(true);
+    hintEl.textContent = 'Happy with it? Click Grow.';
+  });
+
+  picker.onChange(({ species, colorKey }) => {
+    if (placement.getLast()) placement.updateGhost(species, currentSeed, colorKey);
+  });
+
+  picker.onReroll(() => {
+    if (!placement.getLast()) return;
+    currentSeed = Math.floor(Math.random() * 0xffffffff);
+    const s = picker.get();
+    placement.updateGhost(s.species, currentSeed, s.colorKey);
+  });
+
+  picker.onCancel(() => {
+    placement.reset();
+    picker.setCommittable(false);
+  });
+
+  picker.onCommit(async () => {
+    if (config.readonly) {
+      hintEl.textContent = 'Readonly mode — Grow is disabled.';
+      return;
+    }
+    const r = placement.getLast();
+    if (!r) return;
+    const s = picker.get();
+    picker.setSubmitting(true);
+    try {
+      const saved = await submitPolyp({
+        species: s.species,
+        seed: currentSeed,
+        colorKey: s.colorKey,
+        position: [r.position.x, r.position.y, r.position.z],
+        orientation: [r.orientation.x, r.orientation.y, r.orientation.z, r.orientation.w],
+        scale: r.scale,
+      });
+      placement.reset();
+      reef.addPolyp(saved, true);
+      installEffectsOnNewMeshes();
+      picker.setSubmitting(false);
+      picker.setCommittable(false);
+      hintEl.textContent = 'Grown. Click another spot to plant again.';
+    } catch (e) {
+      picker.setSubmitting(false);
+      if (e instanceof RateLimitError) {
+        hintEl.textContent = `Rate limit — try again in ${Math.ceil(e.retryAfterMs / 1000)}s.`;
+      } else {
+        hintEl.textContent = 'Server rejected the polyp. Check the console.';
+        console.error(e);
+      }
+    }
+  });
+}
 
 function installEffectsOnNewMeshes(): void {
   for (const obj of reef.all()) {

--- a/packages/client/src/playground.ts
+++ b/packages/client/src/playground.ts
@@ -13,6 +13,7 @@ import { readPlaygroundConfig } from './playground/config.js';
 import { Placement } from './placement.js';
 import { Picker } from './ui/picker.js';
 import { computePlacementFromClick } from './playground/interaction.js';
+import { computeOrbitPose } from './playground/autoOrbit.js';
 
 const SWAY_INSTALLED = Symbol('sway-installed');
 const PULSE_INSTALLED = Symbol('pulse-installed');
@@ -128,6 +129,13 @@ if (config.mode === 'interactive') {
   });
 }
 
+if (config.mode === 'screen') {
+  // Hide the picker and take over camera movement.
+  picker.hide();
+  (document.getElementById('picker') as HTMLElement).classList.add('hidden');
+  controls.enabled = false;
+}
+
 function installEffectsOnNewMeshes(): void {
   for (const obj of reef.all()) {
     const m = obj as Mesh;
@@ -195,7 +203,15 @@ function loop(t: number): void {
   swayClock.value = t / 1000;
   fish.update(dt);
   reef.animateGrowth(t);
-  controls.update();
+
+  if (config.mode === 'screen') {
+    const pose = computeOrbitPose(t / 1000);
+    camera.position.copy(pose.position);
+    camera.lookAt(pose.target);
+  } else {
+    controls.update();
+  }
+
   renderer.render(scene, camera);
   requestAnimationFrame(loop);
 }

--- a/packages/client/src/playground.ts
+++ b/packages/client/src/playground.ts
@@ -1,8 +1,18 @@
-import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import { PerspectiveCamera, Scene, WebGLRenderer, type Mesh } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { PublicPolyp } from '@reef/shared';
 import { installLighting } from './scene/lighting.js';
+import { installSway } from './scene/currentSway.js';
+import { installPulse } from './scene/pulse.js';
+import { Reef } from './scene/reef.js';
+import { FishSchool } from './sim/fish.js';
+import { fetchReef } from './net/api.js';
+import { ReefSocket, defaultWsUrl } from './net/ws.js';
 import { createPedestal } from './playground/scene.js';
 import { readPlaygroundConfig } from './playground/config.js';
+
+const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
 
 const config = readPlaygroundConfig();
 const canvas = document.getElementById('gl') as HTMLCanvasElement;
@@ -17,6 +27,14 @@ const scene = new Scene();
 installLighting(scene);
 scene.add(createPedestal());
 
+const reef = new Reef();
+scene.add(reef.anchor);
+
+const fish = new FishSchool();
+reef.anchor.add(fish.points);
+
+const swayClock = { value: 0 };
+
 const camera = new PerspectiveCamera(50, 1, 0.01, 20);
 camera.position.set(0.45, 0.2, 0);
 camera.lookAt(0, 0, 0);
@@ -25,8 +43,59 @@ const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 0, 0);
 controls.minDistance = 0.2;
 controls.maxDistance = 1.2;
-controls.maxPolarAngle = Math.PI / 2 - 0.05;  // don't orbit below the floor
+controls.maxPolarAngle = Math.PI / 2 - 0.05;
 controls.enableDamping = true;
+
+function installEffectsOnNewMeshes(): void {
+  for (const obj of reef.all()) {
+    const m = obj as Mesh;
+    if (!m.isMesh) continue;
+    const flags = m.userData as Record<PropertyKey, unknown>;
+    if (!flags[SWAY_INSTALLED]) {
+      installSway(m, swayClock);
+      flags[SWAY_INSTALLED] = true;
+    }
+    if (!flags[PULSE_INSTALLED]) {
+      const polyp = m.userData.polyp as PublicPolyp | undefined;
+      if (polyp) {
+        installPulse(m, swayClock, polyp.seed);
+        flags[PULSE_INSTALLED] = true;
+      }
+    }
+  }
+}
+
+async function loadInitial(): Promise<void> {
+  try {
+    const state = await fetchReef();
+    for (const p of state.polyps) reef.addPolyp(p, false);
+    for (const d of state.sim) reef.applySim(d);
+    installEffectsOnNewMeshes();
+  } catch (e) {
+    console.error('Failed to load reef', e);
+  }
+}
+
+// Build the WebSocket URL. If config.apiBase is set (dev override), swap the
+// protocol + host onto the default path. Otherwise use same-origin default.
+function buildWsUrl(): string {
+  if (!config.apiBase) return defaultWsUrl();
+  const u = new URL(config.apiBase);
+  const proto = u.protocol === 'https:' ? 'wss' : 'ws';
+  return `${proto}://${u.host}/ws`;
+}
+
+const socket = new ReefSocket(buildWsUrl());
+socket.on((msg) => {
+  if (msg.type === 'polyp_added' && !reef.hasPolyp(msg.polyp.id)) {
+    reef.addPolyp(msg.polyp, true);
+    installEffectsOnNewMeshes();
+  } else if (msg.type === 'polyp_removed') {
+    reef.removePolyp(msg.id);
+  } else if (msg.type === 'sim_update') {
+    for (const d of msg.updates) reef.applySim(d);
+  }
+});
 
 function resize(): void {
   const w = window.innerWidth, h = window.innerHeight;
@@ -37,9 +106,18 @@ function resize(): void {
 window.addEventListener('resize', resize);
 resize();
 
-function loop(): void {
+let lastT = 0;
+function loop(t: number): void {
+  const dt = Math.min(0.05, (t - lastT) / 1000 || 0.016);
+  lastT = t;
+  swayClock.value = t / 1000;
+  fish.update(dt);
+  reef.animateGrowth(t);
   controls.update();
   renderer.render(scene, camera);
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);
+
+void loadInitial();
+socket.connect();

--- a/packages/client/src/playground/autoOrbit.test.ts
+++ b/packages/client/src/playground/autoOrbit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  AUTO_ORBIT_PERIOD_SEC,
+  AUTO_ORBIT_RADIUS,
+  AUTO_ORBIT_HEIGHT,
+  computeOrbitPose,
+} from './autoOrbit.js';
+
+describe('computeOrbitPose', () => {
+  test('at t=0 the camera is on the +x axis at configured radius + height', () => {
+    const pose = computeOrbitPose(0);
+    expect(pose.position.x).toBeCloseTo(AUTO_ORBIT_RADIUS, 5);
+    expect(pose.position.z).toBeCloseTo(0, 5);
+    expect(pose.position.y).toBeCloseTo(AUTO_ORBIT_HEIGHT, 5);
+  });
+
+  test('after a full period the pose returns to the t=0 pose', () => {
+    const a = computeOrbitPose(0);
+    const b = computeOrbitPose(AUTO_ORBIT_PERIOD_SEC);
+    expect(b.position.x).toBeCloseTo(a.position.x, 5);
+    expect(b.position.y).toBeCloseTo(a.position.y, 5);
+    expect(b.position.z).toBeCloseTo(a.position.z, 5);
+  });
+
+  test('at quarter period the camera is on the +z axis (90° rotated)', () => {
+    const pose = computeOrbitPose(AUTO_ORBIT_PERIOD_SEC / 4);
+    expect(pose.position.x).toBeCloseTo(0, 4);
+    expect(pose.position.z).toBeCloseTo(AUTO_ORBIT_RADIUS, 4);
+  });
+
+  test('target is always the origin (reef anchor location)', () => {
+    for (const t of [0, 1, 10, 100]) {
+      const pose = computeOrbitPose(t);
+      expect(pose.target.x).toBe(0);
+      expect(pose.target.y).toBe(0);
+      expect(pose.target.z).toBe(0);
+    }
+  });
+});

--- a/packages/client/src/playground/autoOrbit.ts
+++ b/packages/client/src/playground/autoOrbit.ts
@@ -1,0 +1,30 @@
+import { Vector3 } from 'three';
+
+// Slow enough that the viewer perceives motion as ambient, not animated.
+// 60s per full revolution feels right for a museum screen next to a pedestal.
+export const AUTO_ORBIT_PERIOD_SEC = 60;
+export const AUTO_ORBIT_RADIUS = 0.45;   // 45 cm from origin
+export const AUTO_ORBIT_HEIGHT = 0.20;   // 20 cm above the reef floor
+
+export interface OrbitPose {
+  position: Vector3;
+  target: Vector3;
+}
+
+/**
+ * Pure math for the screen-mode auto-orbit camera. Given a time in seconds,
+ * returns a camera position orbiting the reef at a fixed height, plus a
+ * target at the origin.
+ */
+export function computeOrbitPose(clockSec: number): OrbitPose {
+  const omega = (2 * Math.PI) / AUTO_ORBIT_PERIOD_SEC;
+  const theta = clockSec * omega;
+  return {
+    position: new Vector3(
+      Math.cos(theta) * AUTO_ORBIT_RADIUS,
+      AUTO_ORBIT_HEIGHT,
+      Math.sin(theta) * AUTO_ORBIT_RADIUS,
+    ),
+    target: new Vector3(0, 0, 0),
+  };
+}

--- a/packages/client/src/playground/config.test.ts
+++ b/packages/client/src/playground/config.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readPlaygroundConfig } from './config.js';
+
+describe('readPlaygroundConfig', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('defaults: interactive mode, not readonly, apiBase empty (same origin)', () => {
+    vi.stubGlobal('location', { search: '' });
+    expect(readPlaygroundConfig()).toEqual({
+      mode: 'interactive',
+      readonly: false,
+      apiBase: '',
+    });
+  });
+
+  test('?mode=screen → screen mode (auto-orbit, no picker)', () => {
+    vi.stubGlobal('location', { search: '?mode=screen' });
+    expect(readPlaygroundConfig().mode).toBe('screen');
+  });
+
+  test('?readonly=1 → readonly flag true', () => {
+    vi.stubGlobal('location', { search: '?readonly=1' });
+    expect(readPlaygroundConfig().readonly).toBe(true);
+  });
+
+  test('?api=http://localhost:8787 → apiBase set', () => {
+    vi.stubGlobal('location', { search: '?api=http://localhost:8787' });
+    expect(readPlaygroundConfig().apiBase).toBe('http://localhost:8787');
+  });
+
+  test('unknown mode falls back to interactive', () => {
+    vi.stubGlobal('location', { search: '?mode=rubbish' });
+    expect(readPlaygroundConfig().mode).toBe('interactive');
+  });
+
+  test('combined: mode=screen + api override', () => {
+    vi.stubGlobal('location', { search: '?mode=screen&api=http://reef.example' });
+    const c = readPlaygroundConfig();
+    expect(c.mode).toBe('screen');
+    expect(c.apiBase).toBe('http://reef.example');
+  });
+});

--- a/packages/client/src/playground/config.ts
+++ b/packages/client/src/playground/config.ts
@@ -1,0 +1,17 @@
+export type PlaygroundMode = 'interactive' | 'screen';
+
+export interface PlaygroundConfig {
+  mode: PlaygroundMode;
+  readonly: boolean;
+  /** Empty string = same origin. Otherwise a URL like `http://localhost:8787`. */
+  apiBase: string;
+}
+
+export function readPlaygroundConfig(): PlaygroundConfig {
+  const params = new URLSearchParams(globalThis.location?.search ?? '');
+  const rawMode = params.get('mode');
+  const mode: PlaygroundMode = rawMode === 'screen' ? 'screen' : 'interactive';
+  const readonly = params.get('readonly') === '1';
+  const apiBase = params.get('api') ?? '';
+  return { mode, readonly, apiBase };
+}

--- a/packages/client/src/playground/interaction.test.ts
+++ b/packages/client/src/playground/interaction.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { PerspectiveCamera, Vector2 } from 'three';
+import { computePlacementFromClick } from './interaction.js';
+
+function makeCamera(): PerspectiveCamera {
+  const cam = new PerspectiveCamera(60, 1, 0.01, 20);
+  cam.position.set(0, 0.3, 0.4);
+  cam.lookAt(0, 0, 0);
+  cam.updateMatrixWorld();
+  return cam;
+}
+
+describe('computePlacementFromClick', () => {
+  test('click at screen center with a camera above-and-behind hits the pedestal plane near origin', () => {
+    const cam = makeCamera();
+    const ndc = new Vector2(0, 0);
+    const result = computePlacementFromClick(ndc, cam);
+    expect(result).not.toBeNull();
+    expect(result!.y).toBeCloseTo(0, 4);
+    expect(Math.hypot(result!.x, result!.z)).toBeLessThan(0.5);
+  });
+
+  test('click at top edge of screen (ndc y=1) misses the pedestal plane, returns null', () => {
+    const cam = makeCamera();
+    const ndc = new Vector2(0, 0.95);
+    const result = computePlacementFromClick(ndc, cam);
+    if (result !== null) {
+      expect(Math.hypot(result.x, result.z)).toBeGreaterThan(0.12);
+    }
+  });
+
+  test('clicks outside the pedestal radius clamp to null', () => {
+    const cam = makeCamera();
+    const ndc = new Vector2(0.8, -0.5);
+    const result = computePlacementFromClick(ndc, cam, 0.12);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/client/src/playground/interaction.ts
+++ b/packages/client/src/playground/interaction.ts
@@ -1,0 +1,23 @@
+import { Plane, PerspectiveCamera, Raycaster, Vector2, Vector3 } from 'three';
+
+const PEDESTAL_PLANE = new Plane(new Vector3(0, 1, 0), 0);  // y=0, normal up
+
+/**
+ * Cast a ray from the camera through an NDC click point onto the pedestal's
+ * y=0 plane. Returns the local-space hit point, or null if the ray misses
+ * the plane or the hit falls outside `maxRadius`.
+ */
+export function computePlacementFromClick(
+  ndc: Vector2,
+  camera: PerspectiveCamera,
+  maxRadius = 0.12,
+): Vector3 | null {
+  const ray = new Raycaster();
+  ray.setFromCamera(ndc, camera);
+  const hit = new Vector3();
+  const intersected = ray.ray.intersectPlane(PEDESTAL_PLANE, hit);
+  if (!intersected) return null;
+  const r = Math.hypot(hit.x, hit.z);
+  if (r > maxRadius) return null;
+  return hit;
+}

--- a/packages/client/src/playground/scene.test.ts
+++ b/packages/client/src/playground/scene.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { CylinderGeometry, Mesh, MeshStandardMaterial } from 'three';
+import { createPedestal } from './scene.js';
+
+describe('createPedestal', () => {
+  test('returns a Mesh with a CylinderGeometry', () => {
+    const p = createPedestal();
+    expect(p).toBeInstanceOf(Mesh);
+    expect(p.geometry).toBeInstanceOf(CylinderGeometry);
+  });
+
+  test('material is a matte MeshStandardMaterial (no self-illumination to compete with the reef pulse)', () => {
+    const mat = createPedestal().material as MeshStandardMaterial;
+    expect(mat).toBeInstanceOf(MeshStandardMaterial);
+    expect(mat.roughness).toBeGreaterThan(0.7);
+    expect(mat.metalness).toBeLessThan(0.1);
+    expect(mat.emissiveIntensity ?? 0).toBeLessThan(0.01);
+  });
+
+  test('pedestal top sits at y=0 so Reef geometry grows from the origin', () => {
+    const p = createPedestal();
+    const geom = p.geometry as CylinderGeometry;
+    const halfHeight = geom.parameters.height / 2;
+    expect(p.position.y + halfHeight).toBeCloseTo(0, 4);
+  });
+});

--- a/packages/client/src/playground/scene.ts
+++ b/packages/client/src/playground/scene.ts
@@ -1,0 +1,28 @@
+import { CylinderGeometry, Mesh, MeshStandardMaterial } from 'three';
+
+/**
+ * Virtual pedestal mesh. The reef's anchor sits at world origin (no AR
+ * tracker to provide a pose), so the pedestal is positioned so its top face
+ * lands exactly at y=0 — polyps grow "up" from the pedestal surface.
+ *
+ * Matte, low-saturation color so the coral pulse doesn't have to compete
+ * with a flashy base.
+ */
+const PEDESTAL_RADIUS = 0.12;
+const PEDESTAL_HEIGHT = 0.04;
+const PEDESTAL_COLOR = 0x2a3a4a;
+
+export function createPedestal(): Mesh {
+  const geom = new CylinderGeometry(PEDESTAL_RADIUS, PEDESTAL_RADIUS, PEDESTAL_HEIGHT, 48);
+  const mat = new MeshStandardMaterial({
+    color: PEDESTAL_COLOR,
+    roughness: 0.9,
+    metalness: 0.02,
+    emissiveIntensity: 0,
+  });
+  const mesh = new Mesh(geom, mat);
+  // Top face at y=0 so Reef geometry (which lives in positive-y local space)
+  // grows from the pedestal surface.
+  mesh.position.y = -PEDESTAL_HEIGHT / 2;
+  return mesh;
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         main: resolve(import.meta.dirname, 'index.html'),
         preview: resolve(import.meta.dirname, 'preview.html'),
         timelapse: resolve(import.meta.dirname, 'timelapse.html'),
+        playground: resolve(import.meta.dirname, 'playground.html'),
       },
       output: {
         // Pull Three.js into its own vendor chunk so all three HTML entries

--- a/scripts/build-pages-index.sh
+++ b/scripts/build-pages-index.sh
@@ -39,6 +39,8 @@ cat > "$DIST/index.html" <<'HTML'
   <ul>
     <li><a href="preview.html">Species preview</a> — orbit-camera grid of all five procedurally-generated coral species. No server needed.</li>
     <li><a href="ar.html">AR app</a> — will fail to load the reef (no backend on Pages) but shows the startup screen.</li>
+    <li><a href="playground.html">Playground</a> — interactive reef (no AR needed, works against any deployed backend)</li>
+    <li><a href="playground.html?mode=screen">Screen view</a> — auto-orbit camera, demo-ready</li>
     <li><a href="https://github.com/costajohnt/CoralReefAR">Source + runbook</a></li>
     <li><a href="https://github.com/costajohnt/CoralReefAR/pkgs/container/coralreefar">Docker image on GHCR</a></li>
   </ul>


### PR DESCRIPTION
## Summary
Implements the plan from `docs/superpowers/plans/2026-04-22-playground-virtual-reef.md` — a new `playground.html` Vite entry that:

- **Interactive mode** (default) — orbit-camera Three.js view of the reef + click-to-place on a virtual pedestal + full picker UI + WebSocket live updates. Plant polyps against any backend with no AR code paths involved.
- **Screen mode** (`?mode=screen`) — auto-orbit camera, no UI, pure display. Intended for a future wall-mounted monitor next to the physical pedestal showing the reef's current state.
- **Readonly mode** (`?readonly=1`) — picker visible but Grow disabled. For demo kiosks.
- **API override** (`?api=http://...`) — point at any backend (local dev, LXC, Fly).

## 13 commits, 12 planned tasks + 1 doc fixup

1. Virtual pedestal mesh (`scene.ts`) + 3 tests
2. URL config parser (`config.ts`) + 6 tests
3. Auto-orbit pure math (`autoOrbit.ts`) + 4 tests
4. Click-to-place raycast (`interaction.ts`) + 3 tests
5. HTML shell + minimal entry with orbit camera
6. Reef load + WebSocket live-update subscription
7. Click-to-place + Picker + commit flow (includes extending `Placement.showGhost` with optional `positionOverride` parameter + test)
8. Screen mode auto-orbit branch
9. Pages landing links to both playground modes
10. Boot smoke test (2 tests for module wiring)
11. Documentation updates (README, NEXT_STEPS, CONTRIBUTING, PLAN, CHANGELOG)
12. Final verify + this PR
13. Doc fixup (test count, premature v-tag reference)

## API surface change
`Placement.showGhost(species, seed, colorKey, positionOverride?: Vector3)` — the new fourth parameter is optional; existing AR-client callers are unchanged. When a raycast helper has already determined the placement point (e.g. the playground's `computePlacementFromClick`), `showGhost` seeds `lastResult` directly instead of requiring `handleTap()` to run.

## Test plan
- [x] `pnpm -r test` — **180 pass** (12 shared + 22 generator + 76 client + 70 server). Was 161 (+19 new).
- [x] `pnpm -r typecheck` clean
- [x] `pnpm lint` — 0 errors, 0 warnings (91 files)
- [x] `pnpm --filter @reef/client build` — success, `dist/playground.html` + assets generated
- [x] Self-review of branch diff + cross-cutting code review by a subagent (flagged two doc drift items, both addressed in commit `49ee74b`)
- [ ] Post-merge: tag v0.4.0, release workflow builds fresh image, redeploy LXC. Then real browser smoke test: `https://reef.home.local/playground.html` interactive + `?mode=screen`.

## Issues closed or advanced
- Closes: none directly
- Advances: the "Step 0 non-AR testing" workflow in NEXT_STEPS

## Review workflow
Built with superpowers subagent-driven development: fresh implementer subagent per task, per-task spec + quality review, final cross-cutting review on the whole branch. Review findings incorporated before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)