### PR TITLE
Plan: tree mode + research-doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versions are SemVer.
 
 ## [Unreleased]
 
+### Planned
+
+- **Tree mode (`tree.html`)** — a third client surface for a
+  fractal branching-coral web. Visitors attach small composable
+  pieces to each other's exposed tips, growing a structure over
+  days. Avatar-bioluminescent styling: bloom post-processing,
+  vivid palette (magenta / cyan / violet / lime / orange), no
+  translucency. Five variants (forked / trident / starburst / claw
+  / wishbone) with 1-4 attach slots each. Separate reef in the DB
+  (`tree_polyps` table, `/api/tree/*`, `/ws/tree`), seeded with a
+  random Starburst at install so visitors always have something to
+  branch off. Implementation plan in
+  [`docs/superpowers/plans/2026-04-22-tree-mode.md`](docs/superpowers/plans/2026-04-22-tree-mode.md).
+
+## [0.4.0] — 2026-04-22
+
+Playground — AR-free interactive reef view + museum screen mode.
+Full release notes:
+<https://github.com/costajohnt/CoralReefAR/releases/tag/v0.4.0>.
+
 ### Added
 
 - **Playground (`playground.html`)** — AR-free interactive reef view:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ Orbit-camera view, click-to-place, full picker UI — no AR
 code-paths involved. Add `?mode=screen` for the auto-orbit
 museum-display variant.
 
+Once the tree-mode surface ships (planned in
+[`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md)):
+`http://localhost:5173/tree.html?api=http://localhost:8787`. A
+different reef — fractal branching-coral web with Avatar-bioluminescent
+styling. Click attach-point orbs on existing pieces to build outward.
+
 ## Testing
 
 Each package has its own suite. Run them all:

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -4,10 +4,25 @@ What's done, what's open, and what you (the maintainer) still need to do
 manually. This file is the single source of truth for project state — keep
 it edited alongside the work.
 
+Related docs:
+- [`docs/DECISIONS.md`](docs/DECISIONS.md) — why the code looks how it
+  looks (running log of architectural choices + rationales)
+- [`docs/superpowers/plans/`](docs/superpowers/plans/) — TDD
+  implementation plans for active features
+- [`CHANGELOG.md`](CHANGELOG.md) — version history
+- [`INSTALL.md`](INSTALL.md) — operator deploy runbook
+- [`PLAN.md`](PLAN.md) — original project concept (v2)
+
 ## Current state
 
 - **Main branch CI**: green. 180 tests pass across 4 packages (shared 12 /
   generator 22 / server 70 / client 76).
+- **Deployed version**: v0.4.0 live on the Beelink LXC at
+  `https://reef.home.local/`. Three surfaces available:
+  `index.html` (AR, phone), `playground.html` (orbit camera, desktop),
+  `playground.html?mode=screen` (auto-orbit, museum display).
+- **Planned next**: tree mode (third surface) — implementation plan
+  merged (#72), execution pending.
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
   @fastify/cors 9 (pinned — issue #54 tracks Fastify 5 migration) ·
   node:25-alpine · happy-dom 19 · Oxlint.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -179,6 +179,32 @@ Tracking issue: [#28].
 
 ## Operator runbook — exactly what you need to do
 
+### Step 0.5 — Tree mode testing (coming soon)
+
+A new third surface, `tree.html`, is planned — see
+[`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md).
+Different from the landscape playground: visitors attach small
+composable branch pieces to each other's exposed tips, growing a
+fractal coral web. Avatar-bioluminescent styling (bloom, vivid
+palette, no translucency). Separate reef in the DB — doesn't share
+polyps with the landscape view.
+
+Usage (once shipped):
+
+```
+https://reef.home.local/tree.html              # interactive
+https://reef.home.local/tree.html?mode=screen  # auto-orbit demo view
+https://reef.home.local/tree.html?readonly=1   # browse-only
+```
+
+The tree's pedestal is auto-seeded with one Starburst piece at
+install time, so visitors always have something to branch off
+(the first visitor's experience isn't an empty stage).
+
+Phase 2 of the plan: once the tree's visuals feel right, migrate the
+AR client to read from the tree data so visitors at the pedestal see
+the same fractal reef growing in AR that the wall screen shows.
+
 ### Step 0 — Non-AR testing via the playground
 
 Before investing in the marker print + NFC tag + real-device cycle,

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,6 +10,7 @@ A collaborative AR installation where visitors tap an NFC tag, open a web-based 
 - **Tracking abstraction:** Swappable tracking provider interface so a future provider (WebXR image-tracking, another engine) can slot in without touching app code.
 - **Still $0 ongoing cost.** Everything self-hosted on existing Beelink + Cloudflare Tunnel.
 - **Dual surface:** the installation has both an AR layer (phone tapped to a pedestal) and a non-AR screen layer (`playground.html`) that shows the reef growing from a fixed orbit viewpoint on a wall-mounted display. Same backend, same sim loop, same geometry — two ways to experience the same living reef.
+- **Third surface (planned — tree mode):** a third entry (`tree.html`) for a different reef — a fractal branching-coral web where visitors attach small composable pieces to each other's exposed tips. Avatar-bioluminescent styling (bloom post-processing, vivid palette). Separate reef in the DB. Concept fully specified in [`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md). Phase 2 migrates the AR client to read the tree data so the pedestal AR view shows the same growing fractal structure the wall screen shows.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,20 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
 - **pnpm monorepo**: `shared / generator / server / client`.
 - **Server**: TypeScript · Fastify · better-sqlite3 · `ws` via
   `@fastify/websocket`. Zero external services.
-- **Client**: TypeScript · Vite · Three.js. Two surfaces share one
-  backend:
+- **Client**: TypeScript · Vite · Three.js. Multiple surfaces share
+  one backend:
   - **AR** (`index.html`) — self-hosted 8th Wall engine binary, pedestal
     marker tracking, two-finger pinch + twist placement on phone.
+    Renders the landscape reef.
   - **Playground** (`playground.html`) — AR-free orbit-camera view
-    with click-to-place, for iterating without marker/phone. Adds
-    `?mode=screen` for a fixed museum-display variant.
+    with click-to-place, for iterating without marker/phone. Renders
+    the landscape reef. `?mode=screen` variant for a fixed
+    museum-display.
+  - **Tree** (`tree.html`) — a different reef. Fractal branching-coral
+    web built by attaching small composable pieces to each other's
+    tips. Avatar-bioluminescent styling (bloom post-processing, vivid
+    palette). Planned — implementation in
+    [`docs/superpowers/plans/2026-04-22-tree-mode.md`](docs/superpowers/plans/2026-04-22-tree-mode.md).
 - **CI**: lint (Oxlint) · typecheck · build · 180 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,350 @@
+# Design Decisions
+
+Running log of significant architectural and design choices made
+during CoralReefAR development. Each entry captures the decision,
+the context that forced it, the rationale, and the trade-offs
+accepted. For current state see
+[`NEXT_STEPS.md`](../NEXT_STEPS.md). For implementation detail see
+[`docs/superpowers/plans/`](superpowers/plans/). For version
+history see [`CHANGELOG.md`](../CHANGELOG.md).
+
+---
+
+## 2026-04-19 — Migrate from retired hosted 8th Wall to self-hosted engine binary
+
+**Context:** 8th Wall's hosted platform (`apps.8thwall.com/xrweb?appKey=…`)
+was retired Feb 28, 2026. The existing `tracking/eightwall.ts` depended
+on the cloud-hosted engine + app key pattern.
+
+**Options considered:**
+1. Self-host `@8thwall/engine-binary` (their post-shutdown distribution)
+2. Replace with MindAR (open-source, pure marker tracking)
+3. Dual-provider with runtime fallback
+
+**Decision:** Self-host `@8thwall/engine-binary`. Drop MindAR entirely
+— it was only ever a stub and would require significant architectural
+surgery to become a working fallback (MindARThree owns its own
+renderer/scene/camera, conflicting with our existing stack).
+
+**Rationale:**
+- SLAM is the single biggest driver of perceived AR quality; 8th Wall
+  has it, MindAR doesn't
+- Self-hosted means no phone-home, no appKey, no account — aligns
+  with the $0-ongoing-cost goal
+- Niantic Spatial signaled binary-engine maintenance ends ~March 2026
+  with existing self-hosted projects working through Feb 28, 2027 —
+  2-3 year runway is acceptable for an installation piece
+
+**Trade-offs accepted:**
+- If a tracker bug surfaces after upstream EOL, we probably can't get
+  it fixed
+- Single point of failure on engine availability
+
+**Artifacts:** PR #30, version pin to `1.0.0` in PR #34.
+
+---
+
+## 2026-04-19 — Fly deploy gated to manual-only while paused
+
+**Context:** Fly.io trial orgs require a credit card before any VM
+runs. Decided to defer in favor of Beelink/Proxmox. But
+`.github/workflows/fly-deploy.yml` was triggering on every push to
+`main`, failing red, and masking any future real Fly failure.
+
+**Decision:** Drop the `push: branches: [main]` trigger. Keep
+`workflow_dispatch` for manual invocation. Document the restore
+path in NEXT_STEPS so flipping it back is one line.
+
+**Rationale:** Fail-closed default is better than persistent red CI
+that everyone learns to ignore. The deploy pipeline should either
+work silently or not run.
+
+**Trade-offs accepted:** Resuming Fly deploys requires a manual
+edit to the workflow file.
+
+**Artifacts:** PR #31.
+
+---
+
+## 2026-04-21 — Fastify 4 → 5 migration
+
+**Context:** PR #52 (reverting `@fastify/cors` 11 → 9) was a bandage
+— the real answer was upgrading Fastify itself. Other plugin bumps
+(`@fastify/websocket` 11, `@fastify/static` 8) were also blocked on
+Fastify 5.
+
+**Decision:** Migrate Fastify 4.29 → 5.8.5, unpin cors back to 11,
+bump websocket 10 → 11, bump static 7 → 8. Bundle as one PR.
+
+**Rationale:**
+- Unpinning cors + bumping websocket + bumping fastify are
+  interlocked — none of them work alone
+- The boot smoke test added in PR #55 validates the full plugin
+  load order, so we have regression coverage
+- Fastify 4 is LTS until mid-2026; migrating early means breathing
+  room on future plugin bumps
+
+**Trade-offs accepted:** Fastify 5 breaking changes had to be
+audited; happily, our usage didn't touch any of the removed APIs
+(`schemaErrorFormatter`, route `constraints`, decorate-with-options,
+`exposeHeadRoutes`). Zero code changes needed.
+
+**Artifacts:** PR #69, issue #54.
+
+---
+
+## 2026-04-22 — Playground as a second surface (not a replacement)
+
+**Context:** Testing the AR experience requires a printed marker, a
+phone with camera permissions, museum-like lighting, and SLAM
+tracking to all cooperate. That's a 20-minute setup for each
+iteration. Development velocity was tied to physical-world access.
+
+**Decision:** Ship `playground.html` as a third Vite entry
+alongside `index.html` (AR) and `preview.html` / `timelapse.html`.
+Orbit-camera Three.js view with click-to-place on a virtual
+pedestal. Reuses `Reef`, `Placement`, `Picker`, `ReefSocket`, and
+all scene effects. Adds `?mode=screen` auto-orbit variant for the
+eventual museum-wall display.
+
+**Rationale:**
+- Same backend, same data, same sim loop — just a different view
+- Dev cycle drops from 20 minutes to 2 seconds (edit + refresh)
+- The `?mode=screen` variant doubles as a real installation
+  artifact (wall-mounted monitor next to the pedestal)
+- Extending `Placement.showGhost` with an optional
+  `positionOverride` parameter was the only invasive change, and
+  it's backwards-compatible
+
+**Trade-offs accepted:**
+- Two surfaces to maintain; the playground can't fully substitute
+  for AR testing (no camera, no SLAM, no marker)
+- Playground is desktop-mouse-only; touch is deferred
+
+**Artifacts:** PR #71, v0.4.0 release, deployed to LXC 300.
+
+---
+
+## 2026-04-22 — Tree mode as a different reef (not a new view of the same reef)
+
+**Context:** The user wanted visitors to build on each other's pieces
+— existing polyps exposing attach points where new polyps connect.
+Initial sketches proposed extending the landscape `Reef` with a
+`parentId` field so all polyps could be either root-on-pedestal or
+child-of-parent.
+
+**Options considered:**
+1. Single polyp table, `parent_id` nullable — one reef with both
+   modes possible
+2. Separate `tree_polyps` table, distinct routes + WS namespace —
+   two independent reefs
+3. Fork the whole codebase into a new repo
+
+**Decision:** Option 2 — separate table, separate routes
+(`/api/tree/*`), separate WebSocket hub (`/ws/tree`).
+
+**Rationale:**
+- Different schema (tree needs `parent_id` + `attach_index`;
+  landscape doesn't; forcing nulls everywhere is ugly)
+- Different placement model (tree: raycast against attach-point
+  orbs; landscape: raycast against a pedestal plane)
+- Different visual aesthetic (Avatar-bioluminescent vs
+  subtly-reef-realistic)
+- Different growth pattern (web of children vs scatter of
+  independent pieces)
+- Mixing both in one table invites accidental display of one in
+  the other's UI
+
+**Trade-offs accepted:**
+- Duplicated server routes (`/api/reef/*` and `/api/tree/*`)
+- Two hubs to maintain
+- No single "grand unified reef" view (if you want that later, it's
+  a join)
+
+**Artifacts:** Plan at
+[`docs/superpowers/plans/2026-04-22-tree-mode.md`](superpowers/plans/2026-04-22-tree-mode.md).
+
+---
+
+## 2026-04-22 — Fractal web, not coral tree with a trunk
+
+**Context:** Initial framing was "pieces build on pieces like a
+tree." The user clarified the vision: not a tree with a trunk, but
+a **fractal branching-coral web** — no dominant axis, no visible
+root. The installation's endpoint is a dense structure that
+potentially fills a room through AR after a week of visitor
+contributions.
+
+**Decision:**
+- Every variant follows the same "base + N tips" shape grammar —
+  interchangeable, every piece attaches to every other piece
+- Five variants chosen to actively break verticality: Forked (2
+  tips), Trident (3), Starburst (4), Claw (bends 60° off the parent),
+  Wishbone (two long horizontal curves)
+- Auto-seed a Starburst at the origin on install so the very first
+  visitor already has 4 attach points radiating in 4 directions —
+  no one piece becomes "the trunk"
+
+**Rationale:** The "trunk" framing suggested vertical growth and a
+hierarchy. "Fractal web" is horizontal as much as vertical,
+self-similar at every scale, and has no single dominant piece.
+Starburst as the seed drives immediate multi-directional spread.
+
+**Trade-offs accepted:**
+- More geometrically complex than a single-tip branch; AABB
+  collision becomes more important because branches cross in 3D
+  space
+- Visitors don't get to plant the very first piece — an
+  install-time seed plays that role
+
+**Artifacts:** Plan doc.
+
+---
+
+## 2026-04-22 — Avatar-bioluminescent aesthetic for tree mode
+
+**Context:** The current landscape reef uses subtle translucency
+(opacity 0.85) with low emissive (intensity 0.2, white). The user
+wants tree mode to read as **surreal and fluorescent** — closer to
+Pandora's bioluminescent flora than wet coral.
+
+**Decision:**
+- Opacity 1.0 (fully opaque — fluorescent things don't look
+  translucent)
+- `emissive: material.color` (glow color-matches the surface color,
+  not a generic white)
+- `emissiveIntensity: 1.0` (was 0.2)
+- `UnrealBloomPass` post-processing (threshold ~0.4, strength ~1.2,
+  radius ~0.6) — this is the single biggest lever; turns emissive
+  into visible halos
+- Vivid palette (magenta, cyan, violet, lime, orange) — high
+  saturation, mid-to-high brightness
+- Pulse + sway retained but amplitude bumped to match higher
+  baseline
+
+**Rationale:** Bloom is *the* technique for glow-as-light-emission.
+Without it, emissive just brightens the surface. With it, bright
+pixels leak halos into surrounding dark pixels — which is how every
+Avatar shot works.
+
+**Trade-offs accepted:**
+- Bloom costs 2-4ms/frame on modern GPUs — trivial for desktop
+  screen view, potentially rough for phone AR (which is why this
+  aesthetic is scoped to tree mode, not the existing AR client)
+- Fully-opaque pieces lose the "wet-gelatinous" quality the
+  landscape reef has; intentional — different reefs have different
+  moods
+
+**Artifacts:** Plan doc, Task 15 (material preset) + Task 21 (scene
+with bloom composer).
+
+---
+
+## 2026-04-22 — Tree mode Phase 1 → Phase 2 staging
+
+**Context:** Ideal endpoint is that the **AR client** reads the same
+tree data as the screen views — pedestal becomes a portal into the
+same fractal web the wall monitor shows. But getting tree mode
+looking right has its own iteration cycle, and mixing that iteration
+with AR device testing would slow both.
+
+**Decision:**
+- **Phase 1 (in the current plan):** tree mode ships as a browser
+  surface (`tree.html`) with its own data. Landscape reef stays
+  intact. AR client still shows landscape.
+- **Phase 2 (deferred):** once tree-mode visuals feel right, migrate
+  the AR client to read tree data. Landscape mode becomes vestigial
+  or retires.
+
+**Rationale:**
+- Fast iteration: every tree-mode tweak is `pnpm --filter @reef/client
+  dev` + refresh
+- Derisks visuals before touching AR
+- Phase 2 is a small change (swap the data source in `app.ts`) once
+  tree mode proves out
+
+**Trade-offs accepted:**
+- Two working reefs in the DB during Phase 1 (landscape and tree,
+  side by side)
+- An interim "the AR pedestal shows one reef but the wall monitor
+  shows another" state
+
+**Artifacts:** Plan doc, staging note in PLAN.md.
+
+---
+
+## 2026-04-22 — AABB collision for tree placements (MVP)
+
+**Context:** "Two branches shouldn't occupy the same space" —
+explicit user requirement for realism. Full mesh-intersection
+collision is expensive; bounding-box collision is fast and
+approximate.
+
+**Decision:** Client-side AABB-vs-AABB check on placement. Reject
+a placement if the new piece's world-space bounding box would
+intersect any existing piece's bounding box.
+
+**Rationale:**
+- `Three.Box3.intersectsBox` is a one-line fast check
+- For the installation's expected size (50-200 pieces), even naive
+  all-pairs AABB is trivial
+- Client-side for MVP because immediate UX feedback is more
+  important than defense-in-depth at this stage
+
+**Trade-offs accepted:**
+- Thin branches that spatially avoid bounding-box overlap but
+  visually cross will pass the check
+- No server-side protection against a scripted POST bypass;
+  deferred to a follow-up issue
+- If the visual result looks messy in practice, escalate to
+  capsule-vs-capsule
+
+**Artifacts:** Plan doc, Task 19 (collision helper) + Task 20
+(placement integration).
+
+---
+
+## 2026-04-22 — Leaf-only delete for tree mode
+
+**Context:** What happens when an admin deletes a piece in the
+middle of a tree? Options: cascade (delete children too), orphan
+(show floating pieces), or refuse (require bottom-up deletion).
+
+**Decision:** Refuse deletion of any piece with live children. The
+admin must delete leaves first, then walk up.
+
+**Rationale:**
+- Zero orphans, ever — the tree stays structurally honest
+- Makes moderation deliberate — you can't accidentally wipe out a
+  dozen visitors' contributions by clicking "delete" on a root
+- Simplest behavior to explain to the admin UI
+
+**Trade-offs accepted:**
+- Deleting a deeply-nested piece requires multiple admin actions
+- No bulk-delete-a-subtree flow (deferred; could add with
+  confirmation UI later)
+
+**Artifacts:** Plan doc, TreeDb spec.
+
+---
+
+## Format for new entries
+
+```markdown
+## YYYY-MM-DD — One-line decision summary
+
+**Context:** What made this a decision (the problem, the forcing
+function, the observation that needed action).
+
+**Decision:** The concrete choice.
+
+**Rationale:** Why this option over the others.
+
+**Trade-offs accepted:** What we gave up by choosing this.
+
+**Artifacts:** Links to PRs, plans, issues, commits.
+```
+
+Keep entries terse. The log is a **reference**, not prose — scan
+quickly, understand why the code looks how it looks. Don't
+editorialize.

--- a/docs/superpowers/plans/2026-04-22-tree-mode.md
+++ b/docs/superpowers/plans/2026-04-22-tree-mode.md
@@ -1,0 +1,1776 @@
+# Tree Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a third surface for CoralReefAR — a fractal branching-coral web where visitors attach small composable pieces to each other, growing a structure over days/weeks. Distinct data model (parent/child tree), distinct visuals (Avatar-bioluminescent), distinct generator (5 branch variants, not 5 species). New `tree.html` Vite entry at the client; new `tree_polyps` table + `/api/tree/*` routes + `/ws/tree` on the server. Landscape mode + AR client stay untouched.
+
+**Architecture:**
+
+- **Data flow**: `tree.html` page → `tree.ts` entry → Three.js scene with bloom post-processing + auto-seeded pedestal → click an attach-point orb → picker → `POST /api/tree/polyp` with `{parentId, attachIndex, variant, seed, colorKey}` → server validates parent + attach + collision → inserts into `tree_polyps` → broadcasts via `/ws/tree` → all connected tree clients add the new piece → ghost resolves into a real piece growing from the attach point.
+- **Visual language**: every piece follows the same "base + N tips" grammar so pieces are interchangeable. No dominant trunk. Five variants (Forked, Trident, Starburst, Claw, Wishbone) with 1-4 exposed tips each. Avatar-bioluminescent styling — opacity 1.0, emissive = vertex color at intensity ~1.0, `UnrealBloomPass` post-processing, vivid palette (magenta, cyan, violet, lime, orange).
+- **Collision** (client-side for MVP): AABB-vs-AABB rejection — a new piece that would overlap any existing piece's bounding box is rejected at click time with a user-visible hint.
+- **Root seed**: server startup inserts one Starburst at the pedestal origin if the tree is empty, so visitors always see something to branch off.
+- **Delete policy**: leaf-only. Admin can delete a piece iff it has no children. No orphans.
+
+**Tech Stack:** TypeScript 6 · Vite 7 · Vitest 4 · Three.js 0.184 (`UnrealBloomPass`, `EffectComposer` from `three/addons/`) · Fastify 5 · better-sqlite3 12. No new dependencies.
+
+---
+
+## File Structure
+
+### New files
+
+**Shared:**
+- `packages/shared/src/tree/types.ts` — `TreeVariant`, `TreePolyp`, `AttachPoint` interfaces
+- `packages/shared/src/tree/schema.ts` — Zod schemas for tree API payloads
+- `packages/shared/src/tree/ws.ts` — WebSocket message types for the tree hub
+
+**Server:**
+- `packages/server/migrations/003_tree_polyps.sql` — new table + indexes
+- `packages/server/src/tree/db.ts` — `TreeDb` class: CRUD with parent/attach/leaf-only validation
+- `packages/server/src/tree/routes.ts` — `registerTreeRoutes(app, db, hub)`
+- `packages/server/src/tree/seed.ts` — `seedRootIfEmpty(db)` called once at boot
+- `packages/server/src/tree/db.test.ts`
+- `packages/server/src/tree/routes.test.ts`
+- `packages/server/src/tree/seed.test.ts`
+
+**Generator:**
+- `packages/generator/src/tree/variant.ts` — shared variant-module shape + attach-point metadata type
+- `packages/generator/src/tree/variants/forked.ts`
+- `packages/generator/src/tree/variants/trident.ts`
+- `packages/generator/src/tree/variants/starburst.ts`
+- `packages/generator/src/tree/variants/claw.ts`
+- `packages/generator/src/tree/variants/wishbone.ts`
+- `packages/generator/src/tree/index.ts` — `generateTreeVariant({variant, seed, colorKey}): { mesh, attachPoints, boundingBox }`
+- `packages/generator/src/tree/index.test.ts`
+- Per-variant mesh-invariant tests
+
+**Client:**
+- `packages/client/tree.html` — shell with canvas, picker, mode badge, tree-admin link
+- `packages/client/src/tree.ts` — entry point (scene, bloom, reef, socket, click handler, picker, commit)
+- `packages/client/src/tree/scene.ts` — pedestal + lighting + bloom composer setup
+- `packages/client/src/tree/material.ts` — Avatar-aesthetic material preset (emissive=color, opacity 1.0)
+- `packages/client/src/tree/indicators.ts` — glowing attach-point orbs (one per unused attach point on all pieces)
+- `packages/client/src/tree/placement.ts` — attach-point raycast + commit helper (separate from landscape `Placement`)
+- `packages/client/src/tree/collision.ts` — pure AABB-vs-AABB overlap check
+- `packages/client/src/tree/config.ts` — URL-param parser (mode, readonly, api)
+- `packages/client/src/tree/reef.ts` — `TreeReef` class (tree-aware polyp registry; mirrors `Reef` for tree semantics)
+- `packages/client/src/tree/api.ts` — `fetchTree()`, `submitTreePolyp()`, `TreeSocket`
+- `packages/client/src/tree/variants.ts` — client-side wrapper that generates Three.js mesh + surfaces attach points for a variant
+- Per-file `.test.ts` siblings for every pure module
+
+### Modified files
+- `packages/client/vite.config.ts` — add `tree` to `rollupOptions.input`
+- `packages/server/src/index.ts` — register tree routes + `/ws/tree` hub; call `seedRootIfEmpty` at boot
+- `scripts/build-pages-index.sh` — add tree-mode links to the Pages landing
+- Docs (README, NEXT_STEPS, CONTRIBUTING, PLAN, CHANGELOG) — announce tree as shipped
+
+### Unchanged (but consumed)
+- `packages/client/src/scene/lighting.ts` — reused
+- `packages/client/src/scene/currentSway.ts` — reused (amplitude per-piece adjusted via the material)
+- `packages/client/src/scene/pulse.ts` — reused (baseline/amplitude bumped via config)
+- `packages/client/src/ui/picker.ts` — reused but parameterized by variant list
+- `packages/server/src/hub.ts` — reused (two instances: `hubLandscape` + `hubTree`)
+- `packages/server/src/db.ts` — unchanged (landscape polyps untouched)
+
+---
+
+## Attach-point grammar (reference)
+
+Every variant's local-space mesh exposes N **attach points**, each with a position (Vector3) and a surface normal (Vector3). A child piece's base aligns to the parent's attach-point position, oriented so the child's local +Y points along the parent's attach-point normal. Slots are **consumed on use** — once a child claims attach index `k`, that slot is gone forever for that parent.
+
+| Variant | Tips | Character |
+|---|---|---|
+| **Forked** | 2 | Y-split at ~0.6 height, tips diverge ~30° from vertical |
+| **Trident** | 3 | Three spikes fanning out from a single node at ~45° from center |
+| **Starburst** | 4 | Four short radiating tips from a dense central hub, tips in +X / −X / +Z / −Z |
+| **Claw** | 2 | Single trunk that bends ~60° off vertical, splits at the tip |
+| **Wishbone** | 2 | Two long curved tips diverging horizontally from a common base |
+
+Root seed is a Starburst, placed at world origin with the pedestal normal (up) as its orientation.
+
+---
+
+## Task 1: Shared types + Zod schemas
+
+**Files:**
+- Create: `packages/shared/src/tree/types.ts`
+- Create: `packages/shared/src/tree/schema.ts`
+- Create: `packages/shared/src/tree/ws.ts`
+- Create: `packages/shared/src/tree/types.test.ts`
+- Create: `packages/shared/src/tree/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/shared/src/tree/schema.test.ts
+import { describe, expect, test } from 'vitest';
+import { TreePolypInputSchema, TreeVariantSchema } from './schema.js';
+
+describe('TreeVariantSchema', () => {
+  test('accepts the five variants', () => {
+    for (const v of ['forked', 'trident', 'starburst', 'claw', 'wishbone']) {
+      expect(TreeVariantSchema.safeParse(v).success).toBe(true);
+    }
+  });
+  test('rejects unknown variants', () => {
+    expect(TreeVariantSchema.safeParse('rubbish').success).toBe(false);
+    expect(TreeVariantSchema.safeParse('branching').success).toBe(false);
+  });
+});
+
+describe('TreePolypInputSchema', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  test('accepts a well-formed payload', () => {
+    expect(TreePolypInputSchema.safeParse(valid).success).toBe(true);
+  });
+  test('allows parentId=null for root pieces', () => {
+    const root = { ...valid, parentId: null };
+    expect(TreePolypInputSchema.safeParse(root).success).toBe(true);
+  });
+  test('rejects negative or non-integer attachIndex', () => {
+    expect(TreePolypInputSchema.safeParse({ ...valid, attachIndex: -1 }).success).toBe(false);
+    expect(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 1.5 }).success).toBe(false);
+  });
+  test('rejects attachIndex >= 4 (max tips per variant is 4, starburst)', () => {
+    expect(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 4 }).success).toBe(false);
+    expect(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 10 }).success).toBe(false);
+  });
+  test('rejects out-of-range seed', () => {
+    expect(TreePolypInputSchema.safeParse({ ...valid, seed: -1 }).success).toBe(false);
+    expect(TreePolypInputSchema.safeParse({ ...valid, seed: 2 ** 33 }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail**
+
+Run: `pnpm --filter @reef/shared test src/tree/schema.test.ts` — expect module-not-found FAIL.
+
+- [ ] **Step 3: Implement types**
+
+```ts
+// packages/shared/src/tree/types.ts
+export type TreeVariant = 'forked' | 'trident' | 'starburst' | 'claw' | 'wishbone';
+
+export interface TreePolyp {
+  id: number;
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+  parentId: number | null;     // null for root
+  attachIndex: number;          // which of parent's attach points this piece claims
+  createdAt: number;
+  deviceHash?: string;          // hashed at insert, stripped on public read
+  deleted: boolean;
+}
+
+export type PublicTreePolyp = Omit<TreePolyp, 'deviceHash' | 'deleted'>;
+
+export interface AttachPoint {
+  /** Local-space position on the parent mesh */
+  position: { x: number; y: number; z: number };
+  /** Unit normal pointing outward from the parent surface at this attach point */
+  normal: { x: number; y: number; z: number };
+}
+```
+
+- [ ] **Step 4: Implement schemas**
+
+```ts
+// packages/shared/src/tree/schema.ts
+import { z } from 'zod';
+
+export const TreeVariantSchema = z.enum([
+  'forked', 'trident', 'starburst', 'claw', 'wishbone',
+]);
+
+export const TreePolypInputSchema = z.object({
+  variant: TreeVariantSchema,
+  seed: z.number().int().nonnegative().max(0xffffffff),
+  colorKey: z.string().min(1).max(32),
+  parentId: z.number().int().positive().nullable(),
+  attachIndex: z.number().int().min(0).max(3),  // max 4 tips (starburst) = indices 0-3
+});
+
+export type TreePolypInput = z.infer<typeof TreePolypInputSchema>;
+```
+
+- [ ] **Step 5: Implement WS message types**
+
+```ts
+// packages/shared/src/tree/ws.ts
+import type { PublicTreePolyp } from './types.js';
+
+export type TreeServerMessage =
+  | { type: 'tree_hello'; polypCount: number; serverTime: number }
+  | { type: 'tree_polyp_added'; polyp: PublicTreePolyp }
+  | { type: 'tree_polyp_removed'; id: number };
+```
+
+- [ ] **Step 6: Re-export from package index**
+
+Modify `packages/shared/src/index.ts` — add re-exports:
+
+```ts
+export * from './tree/types.js';
+export * from './tree/schema.js';
+export * from './tree/ws.js';
+```
+
+- [ ] **Step 7: Verify pass + full suite**
+
+```
+pnpm --filter @reef/shared test src/tree/schema.test.ts
+# PASS — 5 tests
+pnpm --filter @reef/shared test
+# all shared tests pass (was 12, now 17)
+```
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/shared/src/tree/ packages/shared/src/index.ts
+git commit -m "Tree: shared types + Zod schemas + WS message types"
+```
+
+---
+
+## Task 2: Server schema migration
+
+**Files:**
+- Create: `packages/server/migrations/003_tree_polyps.sql`
+- Test: existing server test that runs migrations at boot (any of `packages/server/src/db.test.ts`) should exercise the new migration automatically after the file exists
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- packages/server/migrations/003_tree_polyps.sql
+
+CREATE TABLE IF NOT EXISTS tree_polyps (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  variant       TEXT NOT NULL,            -- forked / trident / starburst / claw / wishbone
+  seed          INTEGER NOT NULL,
+  color_key     TEXT NOT NULL,
+  parent_id     INTEGER,                  -- NULL for root
+  attach_index  INTEGER NOT NULL,         -- which tip of parent this piece claims (0..3)
+  created_at    INTEGER NOT NULL,
+  device_hash   TEXT,
+  deleted       INTEGER NOT NULL DEFAULT 0,
+
+  FOREIGN KEY (parent_id) REFERENCES tree_polyps(id),
+
+  -- A given parent's attach slot is consumed by at most one live child.
+  -- Partial unique index so soft-deleted rows don't block re-use.
+  CHECK (attach_index BETWEEN 0 AND 3)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_polyps_parent_attach_live
+  ON tree_polyps (parent_id, attach_index) WHERE deleted = 0;
+
+CREATE INDEX IF NOT EXISTS idx_tree_polyps_live
+  ON tree_polyps (deleted, created_at) WHERE deleted = 0;
+
+CREATE INDEX IF NOT EXISTS idx_tree_polyps_parent
+  ON tree_polyps (parent_id) WHERE deleted = 0;
+```
+
+- [ ] **Step 2: Verify migration runs + server tests pass**
+
+```
+pnpm --filter @reef/server test
+# all 70 existing server tests pass — migrations ran automatically at test boot
+```
+
+If a migration fails, the failure shows up in the DB constructor during test setup. The test harness is the verification.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/server/migrations/003_tree_polyps.sql
+git commit -m "Tree: migration 003 for tree_polyps table with parent/attach constraints"
+```
+
+---
+
+## Task 3: TreeDb class
+
+**Files:**
+- Create: `packages/server/src/tree/db.ts`
+- Create: `packages/server/src/tree/db.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/server/src/tree/db.test.ts
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { ReefDb } from '../db.js';
+import { TreeDb } from './db.js';
+
+function makeDb(): { tree: TreeDb; close: () => void } {
+  const reef = new ReefDb(':memory:');
+  const tree = new TreeDb(reef);
+  return { tree, close: (): void => { /* ReefDb doesn't expose close, GC handles it */ } };
+}
+
+describe('TreeDb.insertRoot', () => {
+  test('inserts a root piece (parentId=null, attachIndex=0)', () => {
+    const { tree } = makeDb();
+    const p = tree.insertRoot({ variant: 'starburst', seed: 42, colorKey: 'neon-cyan' });
+    assert.equal(p.parentId, null);
+    assert.equal(p.variant, 'starburst');
+    assert.equal(p.attachIndex, 0);
+  });
+});
+
+describe('TreeDb.insertChild', () => {
+  test('inserts a child referencing a valid parent + unused attach index', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'neon-cyan' });
+    const child = tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'neon-magenta',
+      parentId: root.id, attachIndex: 1,
+    });
+    assert.equal(child.parentId, root.id);
+    assert.equal(child.attachIndex, 1);
+  });
+
+  test('rejects insert when parent does not exist', () => {
+    const { tree } = makeDb();
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 1, colorKey: 'x',
+      parentId: 99999, attachIndex: 0,
+    }), /parent not found/i);
+  });
+
+  test('rejects insert when attach slot is already claimed', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.insertChild({ variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0 });
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 3, colorKey: 'x', parentId: root.id, attachIndex: 0,
+    }), /attach index.*already claimed/i);
+  });
+
+  test('rejects insert when parent is soft-deleted', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.softDelete(root.id);
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0,
+    }), /parent not found/i);
+  });
+});
+
+describe('TreeDb.listLive', () => {
+  test('returns all live pieces with deviceHash stripped', () => {
+    const { tree } = makeDb();
+    tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const list = tree.listLive();
+    assert.equal(list.length, 1);
+    assert.equal((list[0] as { deviceHash?: string }).deviceHash, undefined);
+  });
+});
+
+describe('TreeDb.softDelete (leaf-only)', () => {
+  test('deletes a leaf piece', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const result = tree.softDelete(root.id);
+    assert.equal(result.ok, true);
+    assert.equal(tree.listLive().length, 0);
+  });
+
+  test('refuses to delete a piece that has live children', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.insertChild({ variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0 });
+    const result = tree.softDelete(root.id);
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? '', /has children/i);
+  });
+
+  test('returns ok=false not_found for unknown ids', () => {
+    const { tree } = makeDb();
+    const result = tree.softDelete(99999);
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? '', /not.?found/i);
+  });
+});
+
+describe('TreeDb.hasAnyLive', () => {
+  test('returns false on an empty tree', () => {
+    const { tree } = makeDb();
+    assert.equal(tree.hasAnyLive(), false);
+  });
+  test('returns true once any root is inserted', () => {
+    const { tree } = makeDb();
+    tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    assert.equal(tree.hasAnyLive(), true);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail**
+
+Run: `pnpm --filter @reef/server test` — expect FAIL (module not found for `./tree/db.js`).
+
+- [ ] **Step 3: Implement TreeDb**
+
+```ts
+// packages/server/src/tree/db.ts
+import Database from 'better-sqlite3';
+import type { ReefDb } from '../db.js';
+import type { PublicTreePolyp, TreePolyp, TreeVariant } from '@reef/shared';
+
+export interface InsertRootInput {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+  deviceHash?: string;
+}
+
+export interface InsertChildInput extends InsertRootInput {
+  parentId: number;
+  attachIndex: number;
+}
+
+export interface SoftDeleteResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export class TreeDb {
+  private readonly db: Database.Database;
+  private readonly stmt: {
+    insert: Database.Statement;
+    findParent: Database.Statement;
+    findAttachClaimed: Database.Statement;
+    listLive: Database.Statement;
+    findById: Database.Statement;
+    countLiveChildren: Database.Statement;
+    softDelete: Database.Statement;
+    hasAny: Database.Statement;
+  };
+
+  // ReefDb owns the underlying sqlite handle. Share it so migrations run once
+  // and tree + landscape data live in the same file.
+  constructor(private readonly reef: ReefDb) {
+    // Access the raw db from ReefDb via a property we'll add, OR re-open the
+    // same file. Simplest: ReefDb already exposes its `db` (or we open by path).
+    // For this plan: add a getter `raw()` to ReefDb returning `this.db` if not
+    // already present.
+    this.db = (reef as unknown as { db: Database.Database }).db;
+
+    this.stmt = {
+      insert: this.db.prepare(
+        `INSERT INTO tree_polyps (variant, seed, color_key, parent_id, attach_index, created_at, device_hash)
+         VALUES (@variant, @seed, @colorKey, @parentId, @attachIndex, @createdAt, @deviceHash)`,
+      ),
+      findParent: this.db.prepare(
+        'SELECT id FROM tree_polyps WHERE id = ? AND deleted = 0',
+      ),
+      findAttachClaimed: this.db.prepare(
+        'SELECT id FROM tree_polyps WHERE parent_id = ? AND attach_index = ? AND deleted = 0',
+      ),
+      listLive: this.db.prepare(
+        'SELECT * FROM tree_polyps WHERE deleted = 0 ORDER BY created_at ASC',
+      ),
+      findById: this.db.prepare(
+        'SELECT * FROM tree_polyps WHERE id = ? AND deleted = 0',
+      ),
+      countLiveChildren: this.db.prepare(
+        'SELECT COUNT(*) AS n FROM tree_polyps WHERE parent_id = ? AND deleted = 0',
+      ),
+      softDelete: this.db.prepare(
+        'UPDATE tree_polyps SET deleted = 1 WHERE id = ? AND deleted = 0',
+      ),
+      hasAny: this.db.prepare(
+        'SELECT 1 FROM tree_polyps WHERE deleted = 0 LIMIT 1',
+      ),
+    };
+  }
+
+  insertRoot(input: InsertRootInput): PublicTreePolyp {
+    const createdAt = Date.now();
+    const row = this.stmt.insert.run({
+      variant: input.variant,
+      seed: input.seed,
+      colorKey: input.colorKey,
+      parentId: null,
+      attachIndex: 0,
+      createdAt,
+      deviceHash: input.deviceHash ?? null,
+    });
+    return this.toPublic(this.stmt.findById.get(Number(row.lastInsertRowid)) as DbRow);
+  }
+
+  insertChild(input: InsertChildInput): PublicTreePolyp {
+    const parent = this.stmt.findParent.get(input.parentId);
+    if (!parent) throw new Error(`parent not found (id=${input.parentId})`);
+    const claimed = this.stmt.findAttachClaimed.get(input.parentId, input.attachIndex);
+    if (claimed) {
+      throw new Error(`attach index ${input.attachIndex} already claimed on parent ${input.parentId}`);
+    }
+    const createdAt = Date.now();
+    const row = this.stmt.insert.run({
+      variant: input.variant,
+      seed: input.seed,
+      colorKey: input.colorKey,
+      parentId: input.parentId,
+      attachIndex: input.attachIndex,
+      createdAt,
+      deviceHash: input.deviceHash ?? null,
+    });
+    return this.toPublic(this.stmt.findById.get(Number(row.lastInsertRowid)) as DbRow);
+  }
+
+  listLive(): PublicTreePolyp[] {
+    const rows = this.stmt.listLive.all() as DbRow[];
+    return rows.map((r) => this.toPublic(r));
+  }
+
+  getById(id: number): PublicTreePolyp | null {
+    const row = this.stmt.findById.get(id) as DbRow | undefined;
+    return row ? this.toPublic(row) : null;
+  }
+
+  softDelete(id: number): SoftDeleteResult {
+    const row = this.stmt.findById.get(id);
+    if (!row) return { ok: false, reason: 'not_found' };
+    const children = this.stmt.countLiveChildren.get(id) as { n: number };
+    if (children.n > 0) return { ok: false, reason: 'has_children' };
+    this.stmt.softDelete.run(id);
+    return { ok: true };
+  }
+
+  hasAnyLive(): boolean {
+    return !!this.stmt.hasAny.get();
+  }
+
+  private toPublic(row: DbRow): PublicTreePolyp {
+    return {
+      id: row.id,
+      variant: row.variant as TreeVariant,
+      seed: row.seed,
+      colorKey: row.color_key,
+      parentId: row.parent_id,
+      attachIndex: row.attach_index,
+      createdAt: row.created_at,
+    };
+  }
+}
+
+interface DbRow {
+  id: number;
+  variant: string;
+  seed: number;
+  color_key: string;
+  parent_id: number | null;
+  attach_index: number;
+  created_at: number;
+  device_hash: string | null;
+  deleted: number;
+}
+```
+
+> **Dependency note:** `TreeDb` reaches into `ReefDb`'s private `db` field via a cast. If `ReefDb` doesn't expose the raw Database, add a `raw(): Database.Database` method to `ReefDb` and call that instead. Either works; the cast is the smaller diff.
+
+- [ ] **Step 4: Verify pass**
+
+```
+pnpm --filter @reef/server test src/tree/db.test.ts
+# PASS — 9 tests
+pnpm --filter @reef/server test
+# all existing tests + 9 new = 79
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/server/src/tree/db.ts packages/server/src/tree/db.test.ts
+git commit -m "Tree: TreeDb with parent/attach validation + leaf-only delete"
+```
+
+---
+
+## Task 4: Tree API routes
+
+**Files:**
+- Create: `packages/server/src/tree/routes.ts`
+- Create: `packages/server/src/tree/routes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/server/src/tree/routes.test.ts
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import Fastify from 'fastify';
+import { ReefDb } from '../db.js';
+import { Hub } from '../hub.js';
+import { TreeDb } from './db.js';
+import { registerTreeRoutes } from './routes.js';
+
+async function makeServer(): Promise<{ app: Awaited<ReturnType<typeof Fastify>>; close: () => Promise<void> }> {
+  const reef = new ReefDb(':memory:');
+  const tree = new TreeDb(reef);
+  const hub = new Hub();
+  const app = Fastify({ logger: false });
+  registerTreeRoutes(app, tree, hub);
+  await app.ready();
+  return { app, close: async (): Promise<void> => { await app.close(); } };
+}
+
+describe('GET /api/tree', () => {
+  test('returns an empty tree on a fresh db', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({ method: 'GET', url: '/api/tree' });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as { polyps: unknown[] };
+    assert.deepEqual(body.polyps, []);
+    await close();
+  });
+});
+
+describe('POST /api/tree/polyp', () => {
+  test('inserts a root piece when parentId is null', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as { id: number; parentId: number | null };
+    assert.ok(body.id > 0);
+    assert.equal(body.parentId, null);
+    await close();
+  });
+
+  test('inserts a child when parentId points to a live polyp', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+
+    const child = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 1 },
+    });
+    assert.equal(child.statusCode, 200);
+    assert.equal((JSON.parse(child.body) as { parentId: number }).parentId, rootId);
+    await close();
+  });
+
+  test('returns 409 when the attach slot is already claimed', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+
+    await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+    });
+    const dup = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'claw', seed: 3, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+    });
+    assert.equal(dup.statusCode, 409);
+    assert.match(JSON.parse(dup.body).error as string, /claim/i);
+    await close();
+  });
+
+  test('returns 404 when parent does not exist', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 1, colorKey: 'x', parentId: 99999, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 404);
+    await close();
+  });
+
+  test('returns 400 on malformed input (unknown variant)', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'branching', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 400);
+    await close();
+  });
+
+  test('broadcasts tree_polyp_added via the hub on success', async () => {
+    const { app, close } = await makeServer();
+    let received: unknown = null;
+    const fakeWs = {
+      readyState: 1,
+      send(data: string) { received = JSON.parse(data); },
+      on() { /* noop */ },
+    };
+    const hub = new Hub();
+    hub.add(fakeWs);
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const app2 = Fastify({ logger: false });
+    registerTreeRoutes(app2, tree, hub);
+    await app2.ready();
+    await app2.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    assert.equal((received as { type: string } | null)?.type, 'tree_polyp_added');
+    await app2.close();
+    await close();
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail**
+
+`pnpm --filter @reef/server test src/tree/routes.test.ts` — expect module-not-found.
+
+- [ ] **Step 3: Implement routes**
+
+```ts
+// packages/server/src/tree/routes.ts
+import type { FastifyInstance } from 'fastify';
+import { TreePolypInputSchema } from '@reef/shared';
+import type { Hub } from '../hub.js';
+import type { TreeDb } from './db.js';
+
+export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub): void {
+  app.get('/api/tree', async () => ({
+    polyps: tree.listLive(),
+    serverTime: Date.now(),
+  }));
+
+  app.post('/api/tree/polyp', async (req, reply) => {
+    const parsed = TreePolypInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'invalid payload', issues: parsed.error.issues };
+    }
+    const input = parsed.data;
+    try {
+      const polyp = input.parentId === null
+        ? tree.insertRoot({ variant: input.variant, seed: input.seed, colorKey: input.colorKey })
+        : tree.insertChild({
+            variant: input.variant,
+            seed: input.seed,
+            colorKey: input.colorKey,
+            parentId: input.parentId,
+            attachIndex: input.attachIndex,
+          });
+      hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
+      return polyp;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/parent not found/i.test(msg)) { reply.code(404); return { error: msg }; }
+      if (/already claim/i.test(msg))    { reply.code(409); return { error: msg }; }
+      reply.code(500);
+      return { error: msg };
+    }
+  });
+}
+```
+
+> **Hub typing note:** `hub.broadcast(msg as never)` skips the `ServerMessage` type-guard because tree uses its own message type (`TreeServerMessage`). Acceptable here since the Hub is structurally a broadcast primitive — it doesn't read the payload. If you want strict typing, parameterize `Hub<Msg>`; that's a separate refactor.
+
+- [ ] **Step 4: Verify pass**
+
+```
+pnpm --filter @reef/server test src/tree/routes.test.ts
+# PASS — 6 tests
+pnpm --filter @reef/server test
+# 79 + 6 = 85 server tests
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/server/src/tree/routes.ts packages/server/src/tree/routes.test.ts
+git commit -m "Tree: /api/tree GET + POST routes with parent/attach validation"
+```
+
+---
+
+## Task 5: Seed-on-startup
+
+**Files:**
+- Create: `packages/server/src/tree/seed.ts`
+- Create: `packages/server/src/tree/seed.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/server/src/tree/seed.test.ts
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { ReefDb } from '../db.js';
+import { TreeDb } from './db.js';
+import { seedRootIfEmpty } from './seed.js';
+
+describe('seedRootIfEmpty', () => {
+  test('inserts exactly one Starburst root when the tree is empty', () => {
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const result = seedRootIfEmpty(tree);
+    assert.equal(result.seeded, true);
+    const all = tree.listLive();
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.variant, 'starburst');
+    assert.equal(all[0]!.parentId, null);
+  });
+
+  test('is a no-op when the tree already has pieces', () => {
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    tree.insertRoot({ variant: 'forked', seed: 1, colorKey: 'x' });
+    const result = seedRootIfEmpty(tree);
+    assert.equal(result.seeded, false);
+    assert.equal(tree.listLive().length, 1);
+    // Existing piece untouched.
+    assert.equal(tree.listLive()[0]!.variant, 'forked');
+  });
+
+  test('the seed uses a random seed + colorKey (not hard-coded)', () => {
+    const results = new Set<number>();
+    for (let i = 0; i < 5; i++) {
+      const reef = new ReefDb(':memory:');
+      const tree = new TreeDb(reef);
+      seedRootIfEmpty(tree);
+      results.add(tree.listLive()[0]!.seed);
+    }
+    // Not all five identical — random.
+    assert.ok(results.size > 1, `expected randomness, got ${[...results].join(',')}`);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail**
+
+`pnpm --filter @reef/server test src/tree/seed.test.ts` — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/server/src/tree/seed.ts
+import type { TreeDb } from './db.js';
+
+// Avatar-aesthetic palette — matches the client-side tree material palette.
+const ROOT_COLORS = ['neon-magenta', 'neon-cyan', 'neon-violet', 'neon-lime', 'neon-orange'];
+
+export interface SeedResult {
+  seeded: boolean;
+}
+
+/**
+ * Ensures the tree is never empty. First boot (or first boot with a fresh
+ * volume) drops in one Starburst at the pedestal origin so visitors always
+ * have something to branch from.
+ *
+ * Idempotent — calling repeatedly is safe because of the hasAnyLive check.
+ */
+export function seedRootIfEmpty(tree: TreeDb): SeedResult {
+  if (tree.hasAnyLive()) return { seeded: false };
+  const seed = Math.floor(Math.random() * 0xffffffff);
+  const colorKey = ROOT_COLORS[Math.floor(Math.random() * ROOT_COLORS.length)]!;
+  tree.insertRoot({ variant: 'starburst', seed, colorKey });
+  return { seeded: true };
+}
+```
+
+- [ ] **Step 4: Verify pass**
+
+```
+pnpm --filter @reef/server test src/tree/seed.test.ts
+# PASS — 3 tests
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/server/src/tree/seed.ts packages/server/src/tree/seed.test.ts
+git commit -m "Tree: seed a random Starburst root when the tree is empty"
+```
+
+---
+
+## Task 6: Wire tree into server boot
+
+**Files:**
+- Modify: `packages/server/src/index.ts`
+
+- [ ] **Step 1: Modify `makeServer` factory to instantiate tree layer**
+
+In `packages/server/src/index.ts`, after the `new ReefDb(...)` line, add:
+
+```ts
+import { TreeDb } from './tree/db.js';
+import { registerTreeRoutes } from './tree/routes.js';
+import { seedRootIfEmpty } from './tree/seed.js';
+
+// inside makeServer(), after `const db = new ReefDb(...)`:
+const treeDb = new TreeDb(db);
+const treeHub = new Hub();
+seedRootIfEmpty(treeDb);
+```
+
+After `registerMetricsRoutes(app, db, hub);` (the existing routes block), add:
+
+```ts
+registerTreeRoutes(app, treeDb, treeHub);
+```
+
+After the existing `app.get('/ws', ...)` block, add a tree WebSocket route:
+
+```ts
+app.get('/ws/tree', { websocket: true }, (sock) => {
+  const ws = sock as unknown as {
+    readyState: number;
+    send: (data: string) => void;
+    on: (event: 'close' | 'pong', cb: () => void) => void;
+    ping?(): void;
+    terminate?(): void;
+  };
+  treeHub.add(ws);
+  ws.send(JSON.stringify({
+    type: 'tree_hello',
+    polypCount: treeDb.listLive().length,
+    serverTime: Date.now(),
+  }));
+});
+```
+
+In `main()` (the one that starts workers), add:
+
+```ts
+treeHub.startHeartbeat();
+// and in shutdown():
+treeHub.stopHeartbeat();
+```
+
+- [ ] **Step 2: Update `MakeServerResult` to expose treeDb for tests**
+
+```ts
+// packages/server/src/index.ts
+export interface MakeServerResult {
+  app: FastifyInstance;
+  db: ReefDb;
+  hub: Hub;
+  treeDb: TreeDb;     // new
+  treeHub: Hub;       // new
+}
+```
+
+Return `{ app, db, hub, treeDb, treeHub }` from `makeServer`.
+
+- [ ] **Step 3: Extend the boot smoke test**
+
+Add a new test to `packages/server/src/boot.smoke.test.ts`:
+
+```ts
+test('smoke: /api/tree returns a seeded state (not empty) on fresh boot', async () => {
+  const { app } = await makeServer({
+    dbPath: ':memory:', adminToken: '', corsOrigins: ['*'],
+    clientDistDir: undefined, logger: false,
+  });
+  after(async () => { await app.close(); });
+
+  const res = await app.inject({ method: 'GET', url: '/api/tree' });
+  assert.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body) as { polyps: unknown[] };
+  // seedRootIfEmpty ran at boot — expect exactly one root.
+  assert.equal(body.polyps.length, 1);
+});
+```
+
+- [ ] **Step 4: Verify**
+
+```
+pnpm --filter @reef/server test
+# all previous tests + the new smoke test pass
+pnpm --filter @reef/server typecheck
+# clean
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/server/src/index.ts packages/server/src/boot.smoke.test.ts
+git commit -m "Tree: wire TreeDb + routes + /ws/tree + seed-on-boot into makeServer"
+```
+
+---
+
+## Task 7: Variant shared module (attach-point type + generator helpers)
+
+**Files:**
+- Create: `packages/generator/src/tree/variant.ts`
+- Create: `packages/generator/src/tree/variant.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/generator/src/tree/variant.test.ts
+import { describe, expect, test } from 'vitest';
+import { tipAttachPoint } from './variant.js';
+
+describe('tipAttachPoint', () => {
+  test('constructs an attach point from a local-space tip position + outward direction', () => {
+    const ap = tipAttachPoint({ x: 0, y: 0.1, z: 0 }, { x: 0, y: 1, z: 0 });
+    expect(ap.position).toEqual({ x: 0, y: 0.1, z: 0 });
+    expect(ap.normal).toEqual({ x: 0, y: 1, z: 0 });
+  });
+
+  test('normalizes the outward direction', () => {
+    const ap = tipAttachPoint({ x: 0, y: 0, z: 0 }, { x: 3, y: 4, z: 0 });
+    expect(ap.normal.x).toBeCloseTo(0.6);
+    expect(ap.normal.y).toBeCloseTo(0.8);
+    expect(ap.normal.z).toBeCloseTo(0);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+// packages/generator/src/tree/variant.ts
+import type { MeshData } from '../meshdata.js';
+import type { AttachPoint } from '@reef/shared';
+import type { TreeVariant } from '@reef/shared';
+
+export interface VariantGenerateInput {
+  seed: number;
+  colorKey: string;
+}
+
+export interface VariantOutput {
+  mesh: MeshData;
+  attachPoints: AttachPoint[];
+  /** Axis-aligned bounding box in local space, used for client-side collision. */
+  boundingBox: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+}
+
+export type VariantModule = (input: VariantGenerateInput) => VariantOutput;
+
+export function tipAttachPoint(
+  position: { x: number; y: number; z: number },
+  outwardDir: { x: number; y: number; z: number },
+): AttachPoint {
+  const len = Math.hypot(outwardDir.x, outwardDir.y, outwardDir.z) || 1;
+  return {
+    position,
+    normal: { x: outwardDir.x / len, y: outwardDir.y / len, z: outwardDir.z / len },
+  };
+}
+
+export interface TreeVariantRegistry {
+  forked: VariantModule;
+  trident: VariantModule;
+  starburst: VariantModule;
+  claw: VariantModule;
+  wishbone: VariantModule;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/generator/src/tree/variant.ts packages/generator/src/tree/variant.test.ts
+git commit -m "Tree: shared variant module type + tipAttachPoint helper"
+```
+
+---
+
+## Task 8: Forked variant
+
+**Files:**
+- Create: `packages/generator/src/tree/variants/forked.ts`
+- Create: `packages/generator/src/tree/variants/forked.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/generator/src/tree/variants/forked.test.ts
+import { describe, expect, test } from 'vitest';
+import { generateForked } from './forked.js';
+
+describe('generateForked', () => {
+  test('produces a mesh with positions/normals/indices', () => {
+    const out = generateForked({ seed: 1, colorKey: 'neon-magenta' });
+    expect(out.mesh.positions.length).toBeGreaterThan(0);
+    expect(out.mesh.positions.length % 3).toBe(0);
+    expect(out.mesh.normals.length).toBe(out.mesh.positions.length);
+    expect(out.mesh.colors.length).toBe(out.mesh.positions.length);
+    expect(out.mesh.indices.length % 3).toBe(0);
+  });
+
+  test('exposes exactly 2 attach points (two tips of the Y)', () => {
+    const out = generateForked({ seed: 1, colorKey: 'neon-magenta' });
+    expect(out.attachPoints).toHaveLength(2);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateForked({ seed: 1, colorKey: 'neon-cyan' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      expect(n).toBeCloseTo(1, 5);
+    }
+  });
+
+  test('attach-point tips are diverging (not identical positions)', () => {
+    const [a, b] = generateForked({ seed: 1, colorKey: 'x' }).attachPoints;
+    const dx = a!.position.x - b!.position.x;
+    const dz = a!.position.z - b!.position.z;
+    expect(Math.hypot(dx, dz)).toBeGreaterThan(0.01);
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateForked({ seed: 1, colorKey: 'x' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      expect(out.mesh.positions[i]).toBeGreaterThanOrEqual(min.x);
+      expect(out.mesh.positions[i]).toBeLessThanOrEqual(max.x);
+      expect(out.mesh.positions[i + 1]).toBeGreaterThanOrEqual(min.y);
+      expect(out.mesh.positions[i + 1]).toBeLessThanOrEqual(max.y);
+      expect(out.mesh.positions[i + 2]).toBeGreaterThanOrEqual(min.z);
+      expect(out.mesh.positions[i + 2]).toBeLessThanOrEqual(max.z);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Implement `generateForked`**
+
+The implementation generates a tapered trunk (~0.6 height), then two diverging tapered branches at ~30° from vertical, each ~0.4 long. Uses existing primitives from `packages/generator/src/species/_common.ts` if they fit (e.g. cylinder/frustum generators); otherwise inline a minimal frustum-generator here.
+
+```ts
+// packages/generator/src/tree/variants/forked.ts
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';  // reuse existing color lookup
+
+const TRUNK_BASE_RADIUS = 0.008;
+const TRUNK_TIP_RADIUS = 0.006;
+const TRUNK_HEIGHT = 0.06;
+const BRANCH_LENGTH = 0.045;
+const BRANCH_BASE_RADIUS = 0.006;
+const BRANCH_TIP_RADIUS = 0.003;
+const BRANCH_ANGLE = Math.PI / 6;  // 30°
+
+export function generateForked(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  // Trunk: frustum from (0,0,0) up to (0, TRUNK_HEIGHT, 0).
+  // ... implementation builds a tapered cylinder with 6 radial segments ...
+  // For brevity the implementer can copy the pattern from
+  // packages/generator/src/species/tube.ts's cylinder helper.
+
+  // Two branches: diverging in ±X, each tilted BRANCH_ANGLE from vertical.
+  const tipA = {
+    x: Math.sin(BRANCH_ANGLE) * BRANCH_LENGTH,
+    y: TRUNK_HEIGHT + Math.cos(BRANCH_ANGLE) * BRANCH_LENGTH,
+    z: 0,
+  };
+  const tipB = { x: -tipA.x, y: tipA.y, z: 0 };
+  const dirA = { x: Math.sin(BRANCH_ANGLE), y: Math.cos(BRANCH_ANGLE), z: 0 };
+  const dirB = { x: -dirA.x, y: dirA.y, z: 0 };
+
+  // ... emit branch frustum geometry from (0, TRUNK_HEIGHT, 0) along each dir ...
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints: [tipAttachPoint(tipA, dirA), tipAttachPoint(tipB, dirB)],
+    boundingBox: computeAABB(positions),
+  };
+}
+
+function computeAABB(positions: number[]) {
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i]!, y = positions[i + 1]!, z = positions[i + 2]!;
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+  }
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}
+```
+
+> **Implementation detail:** the frustum geometry is the bulk of the code. The implementer should extract a shared `emitFrustum(positions, normals, colors, indices, from, to, r0, r1, color, segments)` helper before implementing Forked — use it for all five variants. If `packages/generator/src/species/_common.ts` already has a usable version, import it.
+
+- [ ] **Step 3: Verify pass**
+
+```
+pnpm --filter @reef/generator test src/tree/variants/forked.test.ts
+# PASS — 5 tests
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/generator/src/tree/variants/forked.ts packages/generator/src/tree/variants/forked.test.ts
+# Plus any shared frustum helper extracted to packages/generator/src/tree/variant.ts
+git commit -m "Tree: Forked variant (Y-split, 2 attach points)"
+```
+
+---
+
+## Tasks 9-12: Remaining variants (Trident, Starburst, Claw, Wishbone)
+
+Same structure as Task 8. Each variant gets its own `.ts` + `.test.ts` file and a commit. Test shape:
+
+- Mesh has valid positions/normals/colors/indices (counts match, triangulated)
+- Attach point count matches the variant spec (Trident: 3, Starburst: 4, Claw: 2, Wishbone: 2)
+- Attach-point normals are unit length
+- Attach-point positions are spatially distinct (no duplicates)
+- Bounding box contains all vertex positions
+- **Per-variant shape check** — e.g. Starburst has attach points in 4 different horizontal octants (verify by bucketing by `Math.atan2(z, x)`)
+
+### Task 9: Trident
+3 spikes fanning from a single node. Attach points at 0°, +120°, −120° around the Y-axis, each tilted ~30° from vertical toward its azimuth.
+
+### Task 10: Starburst (critical — this is the root-seed variant)
+4 short tips radiating in +X / −X / +Z / −Z, each at ~45° above horizontal. Dense spherical central mass. This is what the server seeds at install.
+
+### Task 11: Claw
+Single trunk that bends ~60° off vertical before splitting. Two tips at the bent end. Drives horizontal growth.
+
+### Task 12: Wishbone
+Two long tips diverging horizontally with a gentle curve. Base is minimal — mostly just the two curves from a central point.
+
+Each task commits with `git commit -m "Tree: {Variant} variant (...)"`.
+
+---
+
+## Task 13: Variant registry + index
+
+**Files:**
+- Create: `packages/generator/src/tree/index.ts`
+- Create: `packages/generator/src/tree/index.test.ts`
+- Modify: `packages/generator/src/index.ts` — re-export tree entry
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/generator/src/tree/index.test.ts
+import { describe, expect, test } from 'vitest';
+import { generateTreeVariant } from './index.js';
+
+describe('generateTreeVariant', () => {
+  test('dispatches to each of the 5 variants', () => {
+    const variants = ['forked', 'trident', 'starburst', 'claw', 'wishbone'] as const;
+    for (const v of variants) {
+      const out = generateTreeVariant({ variant: v, seed: 1, colorKey: 'neon-cyan' });
+      expect(out.mesh.positions.length).toBeGreaterThan(0);
+      expect(out.attachPoints.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('is deterministic per (variant, seed, colorKey)', () => {
+    const a = generateTreeVariant({ variant: 'starburst', seed: 42, colorKey: 'neon-magenta' });
+    const b = generateTreeVariant({ variant: 'starburst', seed: 42, colorKey: 'neon-magenta' });
+    expect(Array.from(a.mesh.positions)).toEqual(Array.from(b.mesh.positions));
+  });
+
+  test('throws on unknown variant', () => {
+    expect(() => generateTreeVariant({
+      variant: 'rubbish' as never, seed: 1, colorKey: 'x',
+    })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+// packages/generator/src/tree/index.ts
+import type { TreeVariant } from '@reef/shared';
+import type { VariantOutput } from './variant.js';
+import { generateForked } from './variants/forked.js';
+import { generateTrident } from './variants/trident.js';
+import { generateStarburst } from './variants/starburst.js';
+import { generateClaw } from './variants/claw.js';
+import { generateWishbone } from './variants/wishbone.js';
+
+export interface GenerateInput {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+}
+
+export function generateTreeVariant(input: GenerateInput): VariantOutput {
+  switch (input.variant) {
+    case 'forked':    return generateForked(input);
+    case 'trident':   return generateTrident(input);
+    case 'starburst': return generateStarburst(input);
+    case 'claw':      return generateClaw(input);
+    case 'wishbone':  return generateWishbone(input);
+    default: {
+      const _exhaustive: never = input.variant;
+      throw new Error(`unknown tree variant: ${_exhaustive as string}`);
+    }
+  }
+}
+
+export { tipAttachPoint } from './variant.js';
+export type { VariantOutput, VariantGenerateInput } from './variant.js';
+```
+
+Re-export from `packages/generator/src/index.ts`:
+
+```ts
+export * from './tree/index.js';
+```
+
+- [ ] **Step 3: Verify pass + commit**
+
+```
+pnpm --filter @reef/generator test
+# all 22 existing + 5 variants × ~5 tests + 3 dispatcher tests ≈ 50 tests
+git add packages/generator/src/tree/index.ts packages/generator/src/tree/index.test.ts packages/generator/src/index.ts
+git commit -m "Tree: variant registry + dispatcher"
+```
+
+---
+
+## Task 14: Client tree/config parser
+
+**Files:**
+- Create: `packages/client/src/tree/config.ts`
+- Create: `packages/client/src/tree/config.test.ts`
+
+Mirror the playground's config parser (`packages/client/src/playground/config.ts`) — same URL params (`mode`, `readonly`, `api`), same types, same 6 test cases. Only the imports and the type name change.
+
+```ts
+// packages/client/src/tree/config.ts
+export type TreeMode = 'interactive' | 'screen';
+
+export interface TreeConfig {
+  mode: TreeMode;
+  readonly: boolean;
+  apiBase: string;
+}
+
+export function readTreeConfig(): TreeConfig {
+  const params = new URLSearchParams(globalThis.location?.search ?? '');
+  const rawMode = params.get('mode');
+  const mode: TreeMode = rawMode === 'screen' ? 'screen' : 'interactive';
+  return {
+    mode,
+    readonly: params.get('readonly') === '1',
+    apiBase: params.get('api') ?? '',
+  };
+}
+```
+
+Commit: `Tree: URL config parser`.
+
+---
+
+## Task 15: Client tree material preset + bloom scene setup
+
+**Files:**
+- Create: `packages/client/src/tree/material.ts`
+- Create: `packages/client/src/tree/scene.ts`
+- Create: `packages/client/src/tree/material.test.ts`
+- Create: `packages/client/src/tree/scene.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// packages/client/src/tree/material.test.ts
+import { describe, expect, test } from 'vitest';
+import { Color, MeshStandardMaterial } from 'three';
+import { applyTreeMaterial } from './material.js';
+
+describe('applyTreeMaterial', () => {
+  test('sets opacity to 1 (fully opaque — Avatar aesthetic)', () => {
+    const m = new MeshStandardMaterial({ color: 0xff00ff });
+    applyTreeMaterial(m);
+    expect(m.opacity).toBe(1);
+    expect(m.transparent).toBe(false);
+  });
+
+  test('emissive matches the material color', () => {
+    const m = new MeshStandardMaterial({ color: 0x2dffe4 });
+    applyTreeMaterial(m);
+    const expected = new Color(0x2dffe4);
+    expect(m.emissive.r).toBeCloseTo(expected.r, 5);
+    expect(m.emissive.g).toBeCloseTo(expected.g, 5);
+    expect(m.emissive.b).toBeCloseTo(expected.b, 5);
+  });
+
+  test('emissive intensity is high enough to read as fluorescent', () => {
+    const m = new MeshStandardMaterial();
+    applyTreeMaterial(m);
+    expect(m.emissiveIntensity).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test('vertexColors remain enabled (piece color is per-vertex)', () => {
+    const m = new MeshStandardMaterial({ vertexColors: true });
+    applyTreeMaterial(m);
+    expect(m.vertexColors).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Implement material preset**
+
+```ts
+// packages/client/src/tree/material.ts
+import type { MeshStandardMaterial } from 'three';
+
+export const TREE_EMISSIVE_INTENSITY = 1.0;
+
+/**
+ * Avatar-bioluminescent aesthetic: fully opaque, emissive matches the
+ * surface color, vertex colors still drive per-piece hue. Downstream a
+ * bloom post-processing pass turns the emissive into halos.
+ */
+export function applyTreeMaterial(mat: MeshStandardMaterial): void {
+  mat.transparent = false;
+  mat.opacity = 1;
+  mat.emissive.copy(mat.color);
+  mat.emissiveIntensity = TREE_EMISSIVE_INTENSITY;
+  mat.needsUpdate = true;
+}
+```
+
+- [ ] **Step 3: Implement scene + bloom composer**
+
+```ts
+// packages/client/src/tree/scene.ts
+import { CylinderGeometry, Mesh, MeshStandardMaterial, Scene, type WebGLRenderer, type PerspectiveCamera, Vector2 } from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+
+const PEDESTAL_RADIUS = 0.15;
+const PEDESTAL_HEIGHT = 0.04;
+
+export function createTreePedestal(): Mesh {
+  const geom = new CylinderGeometry(PEDESTAL_RADIUS, PEDESTAL_RADIUS, PEDESTAL_HEIGHT, 64);
+  const mat = new MeshStandardMaterial({ color: 0x0a0f18, roughness: 0.95, metalness: 0.0 });
+  const mesh = new Mesh(geom, mat);
+  mesh.position.y = -PEDESTAL_HEIGHT / 2;
+  return mesh;
+}
+
+export interface BloomSetup {
+  composer: EffectComposer;
+  bloomPass: UnrealBloomPass;
+  render: () => void;
+}
+
+export function createBloomComposer(
+  renderer: WebGLRenderer,
+  scene: Scene,
+  camera: PerspectiveCamera,
+): BloomSetup {
+  const composer = new EffectComposer(renderer);
+  composer.addPass(new RenderPass(scene, camera));
+  const bloomPass = new UnrealBloomPass(
+    new Vector2(renderer.domElement.width, renderer.domElement.height),
+    1.2,   // strength — tune higher for brighter halos, lower for more subtle
+    0.6,   // radius — blur size
+    0.4,   // threshold — pixels brighter than this bloom
+  );
+  composer.addPass(bloomPass);
+  return {
+    composer,
+    bloomPass,
+    render: (): void => { composer.render(); },
+  };
+}
+```
+
+Scene test exercises `createTreePedestal` and `createBloomComposer` construction (the latter can be minimal — just assert it returns the expected shape without running WebGL in happy-dom).
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/client/src/tree/material.ts packages/client/src/tree/material.test.ts packages/client/src/tree/scene.ts packages/client/src/tree/scene.test.ts
+git commit -m "Tree: Avatar material preset + bloom composer + dark pedestal"
+```
+
+---
+
+## Task 16: Client tree/variants adapter
+
+**Files:**
+- Create: `packages/client/src/tree/variants.ts` — thin wrapper: calls `generateTreeVariant` from `@reef/generator` then `polypMesh` from `./scene/meshAdapter.js`, applies the tree material, returns `{ mesh: Three.Mesh, attachPointsWorldLocal: AttachPoint[], boundingBox: Box3 }`.
+- Create: `packages/client/src/tree/variants.test.ts`
+
+Test shape: for each variant, the returned Three.Mesh has a geometry + applies the Avatar material, and the attach-point count matches.
+
+Commit: `Tree: client variant→Three.Mesh adapter with Avatar material`.
+
+---
+
+## Task 17: TreeReef class
+
+**Files:**
+- Create: `packages/client/src/tree/reef.ts`
+- Create: `packages/client/src/tree/reef.test.ts`
+
+A tree-aware registry of rendered pieces. Different from landscape's `Reef` because placement depends on parent:
+
+```ts
+export class TreeReef {
+  readonly anchor: Group;
+  private byId = new Map<number, { mesh: Mesh; polyp: PublicTreePolyp; worldAttachPoints: AttachPoint[]; worldBox: Box3 }>();
+
+  addPiece(polyp: PublicTreePolyp): void;   // computes world transform from parent chain
+  removePiece(id: number): void;
+  getPiece(id: number): Mesh | undefined;
+  allPieces(): Iterable<{ polyp: PublicTreePolyp; mesh: Mesh }>;
+  getAvailableAttachPoints(): Array<{ parentId: number; index: number; worldPos: Vector3; worldNormal: Vector3 }>;
+}
+```
+
+The placement chain is built by walking parents at `addPiece` time: each piece's world transform = parent's world transform × local-attach transform. Cached per piece.
+
+Tests: adding a root, adding a child, computing world position of the child based on parent's attach-point, `getAvailableAttachPoints` returns only unclaimed slots.
+
+Commit: `Tree: TreeReef registry with parent-chain world transforms`.
+
+---
+
+## Task 18: Attach-point indicators (glowing orbs)
+
+**Files:**
+- Create: `packages/client/src/tree/indicators.ts`
+- Create: `packages/client/src/tree/indicators.test.ts`
+
+`AttachIndicators` class owns a single `Group` containing one small emissive sphere per unused attach point. On every `refresh()` it rebuilds from `treeReef.getAvailableAttachPoints()`. Picker/click code raycasts against these spheres (not the pieces themselves) — cleaner hit-test.
+
+```ts
+export class AttachIndicators {
+  readonly group: Group;
+  private bySlot = new Map<string, Mesh>();  // key: `${parentId}/${index}`
+
+  refresh(available: Array<{ parentId: number; index: number; worldPos: Vector3; worldNormal: Vector3 }>): void;
+  meshAt(parentId: number, index: number): Mesh | undefined;
+  all(): Iterable<{ parentId: number; index: number; mesh: Mesh }>;
+}
+```
+
+Tests: constructing refresh with 3 attach points creates 3 meshes; refreshing with 2 (one was claimed) removes the claimed mesh; all attach-point orbs are children of the group.
+
+Commit: `Tree: attach-point indicator orbs`.
+
+---
+
+## Task 19: Collision check
+
+**Files:**
+- Create: `packages/client/src/tree/collision.ts`
+- Create: `packages/client/src/tree/collision.test.ts`
+
+Pure AABB-vs-AABB check: given a proposed new piece's world bounding box and the list of all existing pieces' world bounding boxes, return whether it collides.
+
+```ts
+export function wouldCollide(
+  proposedBox: Box3,
+  existingBoxes: Iterable<Box3>,
+): boolean {
+  for (const other of existingBoxes) {
+    if (proposedBox.intersectsBox(other)) return true;
+  }
+  return false;
+}
+```
+
+Tests: three different geometry arrangements — non-overlapping (no collision), overlapping (collision), touching at a shared face (edge case — `intersectsBox` counts touching as intersection; test documents this).
+
+Commit: `Tree: AABB collision helper`.
+
+---
+
+## Task 20: Tree placement controller
+
+**Files:**
+- Create: `packages/client/src/tree/placement.ts`
+- Create: `packages/client/src/tree/placement.test.ts`
+
+Orchestrates the click → ghost → commit flow for tree mode. Separate from landscape `Placement`:
+
+```ts
+export class TreePlacement {
+  showGhost(variant: TreeVariant, seed: number, colorKey: string, parentId: number, attachIndex: number): Mesh | null;
+  // Returns null if the proposed placement collides.
+
+  reset(): void;
+  getPending(): { variant: TreeVariant; seed: number; colorKey: string; parentId: number; attachIndex: number } | null;
+}
+```
+
+Internally: compute the world transform for a piece at (parent, attachIndex), compute its world AABB, check against existing pieces via `wouldCollide`. If clear, spawn a ghost mesh (semi-opaque version of the piece) at the computed transform.
+
+Tests with a minimal TreeReef + mocked attach points. Assert collision rejects; assert a valid placement returns the ghost.
+
+Commit: `Tree: placement controller with collision rejection`.
+
+---
+
+## Task 21: Tree HTML shell + minimal entry
+
+**Files:**
+- Create: `packages/client/tree.html`
+- Create: `packages/client/src/tree.ts` (minimal — pedestal, bloom, orbit camera, no reef yet)
+- Modify: `packages/client/vite.config.ts` — add `tree` to `rollupOptions.input`
+
+Same shape as `playground.html` + minimal `playground.ts` from Task 5 of the playground plan. Differences:
+- `<title>Coral Reef — Tree</title>`
+- Uses `createBloomComposer` in the render loop instead of `renderer.render`
+- Scene background is slightly darker (`0x01060d`) to make the bloom pop
+
+Commit: `Tree: HTML shell + minimal entry with bloom composer`.
+
+---
+
+## Task 22: Tree fetch + WebSocket
+
+**Files:**
+- Create: `packages/client/src/tree/api.ts`
+- Create: `packages/client/src/tree/api.test.ts`
+
+```ts
+export async function fetchTree(apiBase = ''): Promise<{ polyps: PublicTreePolyp[] }>;
+export async function submitTreePolyp(input: TreePolypInput, apiBase = ''): Promise<PublicTreePolyp>;
+export class TreeSocket {
+  constructor(url: string);
+  connect(): void;
+  on(cb: (msg: TreeServerMessage) => void): void;
+  close(): void;
+}
+```
+
+Mirror the landscape `api.ts` + `ws.ts` pattern exactly, typed against `TreeServerMessage`.
+
+Tests: fake `fetch`/`WebSocket`, assert the right URLs are called, JSON errors surface, messages dispatch.
+
+Commit: `Tree: fetch + WebSocket client with TreeSocket`.
+
+---
+
+## Task 23: Tree entry wiring (pieces + sockets + click)
+
+**Files:**
+- Modify: `packages/client/src/tree.ts`
+
+Flesh out the entry from Task 21:
+
+- Instantiate `TreeReef`, `AttachIndicators`, `TreePlacement`
+- `fetchTree` → populate TreeReef → `attachIndicators.refresh()`
+- `TreeSocket.on(msg => ...)` → handle `tree_polyp_added` / `tree_polyp_removed` / `tree_hello`
+- `canvas.addEventListener('click', ...)` → raycast against attachIndicators group → if hit, call `placement.showGhost` → update picker
+- Picker integration (using same `Picker` class but with tree variant list)
+- `picker.onCommit` → `submitTreePolyp` → server validates + broadcasts → socket handler adds the piece → indicators refresh
+
+Include `installSway` + `installPulse` on each new piece (matching playground). Pulse amplitude bumped to match the higher emissive baseline (see Task 15).
+
+Commit: `Tree: wire reef + indicators + placement + picker + commit flow`.
+
+---
+
+## Task 24: Screen mode for tree
+
+**Files:**
+- Modify: `packages/client/src/tree.ts`
+
+Add `if (config.mode === 'screen')` branch mirroring playground Task 8: disable OrbitControls, hide picker, drive camera via `computeOrbitPose(t/1000)` (reuse `packages/client/src/playground/autoOrbit.js` — zero change there). Tree growth still animates; visitors of the screen see the tree change over time.
+
+Commit: `Tree: screen mode (auto-orbit, no UI) reusing playground autoOrbit math`.
+
+---
+
+## Task 25: Pages landing + boot smoke test
+
+**Files:**
+- Modify: `scripts/build-pages-index.sh` — add tree.html + tree.html?mode=screen links
+- Create: `packages/client/src/tree.test.ts` — mirror the playground boot smoke test
+
+Commit: `Tree: Pages landing links + boot smoke test`.
+
+---
+
+## Task 26: Documentation
+
+**Files:**
+- Modify: `README.md`, `NEXT_STEPS.md`, `CONTRIBUTING.md`, `PLAN.md`, `CHANGELOG.md`
+
+- **README**: Client stack bullet gains a third surface — "Tree (`tree.html`) — fractal branching-coral web, visitors build on each other's pieces, Avatar-bioluminescent styling with bloom post-processing. Planned in `docs/superpowers/plans/2026-04-22-tree-mode.md`."
+- **NEXT_STEPS**: Step 0 grows a sub-step "Step 0.5 — Non-AR tree mode testing" with URLs + what it exercises. Phase-2 handoff to AR noted.
+- **CONTRIBUTING**: dev URL for tree mode.
+- **PLAN**: Adds "Branching web (tree mode)" concept as a third surface under the dual-surface bullet. Note that tree mode uses its own data table (`tree_polyps`) and separate WebSocket namespace.
+- **CHANGELOG**: `[Unreleased]` section gets an `### Added` block describing the tree mode at a high level + link to the plan doc.
+
+Commit: `Docs: announce tree mode + link to plan`.
+
+---
+
+## Task 27: Final verify + PR
+
+- [ ] `pnpm -r test` — expect a large new test count (estimated: 180 → ~240+; 5 variants × 6 tests = 30, plus server (~15), shared (~5), client (~30))
+- [ ] `pnpm -r typecheck` — clean
+- [ ] `pnpm lint` — clean
+- [ ] Manual browser test against local dev:
+  - `pnpm --filter @reef/server dev`
+  - `pnpm --filter @reef/client dev`
+  - Open `http://localhost:5173/tree.html?api=http://localhost:8787`
+  - Observe: Starburst at origin, 4 glowing attach-point orbs, bloom halo visible
+  - Click a slot → ghost variant spawns + picker appears
+  - Pick variant + color → ghost updates
+  - Grow → piece persists, new attach-points glow on the new piece, old slot disappears
+  - Open `?mode=screen` in a second tab — camera auto-orbits, no UI, live updates from the first tab's actions
+- [ ] Open PR against main. Body mirrors the playground PR style: summary, what's new, architecture notes, test plan.
+- [ ] Post-merge: **DO NOT tag or redeploy autonomously** — this is a big release. Surface to the user for explicit approval of `v0.5.0` + LXC redeploy.
+
+---
+
+## Risks + open questions
+
+1. **Frustum geometry emission is the bulk of variant code.** Extract a shared `emitFrustum` helper early (Task 7-8 area) — without it each variant duplicates ~40 lines of vertex/normal/index bookkeeping.
+2. **Attach-point orientation math is fiddly.** When a piece is at (parent's attach position, oriented so its local +Y aligns with parent's attach normal), the piece's world transform composes parent's world × local-tilt. Off-by-one in the rotation frame and the whole tree goes sideways. Tests should exercise at least one 2-deep tree (grandchild world position) to catch this.
+3. **Bloom perf on the pedestal screen-view monitor.** `UnrealBloomPass` on a 4K display without good GPU → framerate hit. If the eventual screen is low-end, fall back to `threshold: 0.8, strength: 0.6` — less vivid but cheaper. Defer tuning until a real monitor is connected.
+4. **Collision check is AABB-only.** For thin branches that spatially avoid bounding-box intersection but still visually cross, AABB will allow it. Escalate to capsule-capsule if visual pass looks messy. Filing as follow-up if needed.
+5. **Two-level undo** — what if an admin deletes a leaf, then another admin planned to delete its parent next? The leaf's parent's attach-slot is now re-available. Visitors can plant on it again. Accepted behavior, worth noting.
+6. **Root-seed determinism.** Currently the seed uses `Math.random()` for the initial variant's seed + color. This means two fresh installs produce different root shapes. Acceptable — each installation is a little different by design.
+
+## Known out-of-scope
+
+- Server-side collision check (client-only for MVP; defers to issue after playtesting)
+- Generation counter or depth-limit (growth tapers naturally via piece sizes)
+- Admin UI for tree (`/tree-admin`) — filed as separate task after plan lands
+- Multi-root support (single root is MVP; deferred per design conversation)
+- Migrating AR client to tree data (Phase 2, per design conversation)


### PR DESCRIPTION
## Summary
Plan-and-docs PR. No code changes. Ships:

1. **Implementation plan** at \`docs/superpowers/plans/2026-04-22-tree-mode.md\` — 27 TDD-style tasks covering data layer (server + shared types + schema), generator (5 branch variants), client surface (tree.html + bloom + attach-point indicators + collision + placement + WebSocket + picker), and docs.
2. **Research/doc updates** across README, NEXT_STEPS, CONTRIBUTING, PLAN, CHANGELOG reflecting tree mode as a real planned feature.

## What tree mode is (vs playground)
The playground is a different *view* of the same landscape reef. Tree mode is a different *reef entirely* with its own data table, its own placement rules, and its own visual aesthetic.

- **Fractal branching-coral web**, not a tree-with-trunk. Every piece has a base + N exposed tips. Pieces attach to tips, not to the pedestal plane (except the seeded root).
- **Five variants**: forked, trident, starburst (the root-seed shape, 4 tips), claw, wishbone. Each can attach to any other's tips — uniform shape grammar.
- **Avatar-bioluminescent**: opacity 1.0, emissive = vertex color at intensity ~1.0, UnrealBloomPass post-processing, vivid palette (magenta, cyan, violet, lime, orange). No translucency. Pulse + sway retained but with higher amplitude to match the brighter baseline.
- **Separate database table** \`tree_polyps\` with \`parent_id\` + \`attach_index\`. Separate \`/api/tree/*\` routes, separate \`/ws/tree\` hub. Landscape reef and tree reef never mix.
- **Auto-seeded root**: a random Starburst at install time so the tree is never empty when visitors walk up.
- **Leaf-only delete**: admin can only remove pieces with no children. Keeps the tree structurally honest.
- **Collision (MVP)**: AABB-vs-AABB. Rejects placements where the new piece's bounding box would overlap an existing piece.

## Architecture decisions documented in the plan
- **Variant names**: descriptive (forked / trident / starburst / claw / wishbone), can be renamed later without breaking anything
- **Admin**: separate \`/tree-admin\` route (not a tab on the existing admin UI) so tree and landscape moderation are distinct
- **Codename**: "tree" in code paths even though the vision is "fractal web" — renaming later is trivial
- **Staging**: Phase 1 ships tree mode as a browser surface (playground-style). Phase 2 later migrates the AR client to read tree data so the pedestal AR view shows the same growing structure as the wall-mounted screen

## Scope and risks flagged
- Frustum geometry emission is duplicated across 5 variants — plan extracts a shared \`emitFrustum\` helper early (Task 7-8)
- Attach-point orientation math is fiddly; plan includes a 2-deep tree test to catch frame-composition bugs
- Bloom perf on the eventual screen monitor may need tuning
- AABB collision is approximate; capsule-capsule deferred as a follow-up if visual pass looks messy
- Server-side collision check deferred (client-only for MVP)

## Test plan
- [x] Markdown renders cleanly in GitHub preview
- [x] Plan file paths referenced from other docs are correct
- [x] No broken internal links
- [x] CHANGELOG structure consistent with prior plan PRs (#70 playground plan)

## Estimated output when implementation lands
- Server tests: 70 → ~90 (+schema + TreeDb + routes + seed + boot smoke)
- Shared tests: 12 → ~22 (+schema + types + variant helpers)
- Generator tests: 22 → ~50 (+5 variants × ~5 tests + dispatcher)
- Client tests: 76 → ~100 (+config + material + scene + reef + indicators + placement + collision + boot)
- **Total estimate: ~262 (was 180 after v0.4.0)**

## What comes after this PR
- Merge this plan PR
- Dispatch subagent-driven implementation (same pattern as playground)
- Once code is complete, tag v0.5.0 + release + redeploy LXC + browser-test tree.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)