### PR TITLE
Tree mode: third client surface with fractal branching web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,20 @@ versions are SemVer.
 
 ## [Unreleased]
 
-### Planned
+### Added
 
 - **Tree mode (`tree.html`)** — a third client surface for a
   fractal branching-coral web. Visitors attach small composable
   pieces to each other's exposed tips, growing a structure over
-  days. Avatar-bioluminescent styling: bloom post-processing,
+  time. Avatar-bioluminescent styling: bloom post-processing,
   vivid palette (magenta / cyan / violet / lime / orange), no
   translucency. Five variants (forked / trident / starburst / claw
   / wishbone) with 1-4 attach slots each. Separate reef in the DB
   (`tree_polyps` table, `/api/tree/*`, `/ws/tree`), seeded with a
   random Starburst at install so visitors always have something to
-  branch off. Implementation plan in
+  branch off. Implements
   [`docs/superpowers/plans/2026-04-22-tree-mode.md`](docs/superpowers/plans/2026-04-22-tree-mode.md).
+  Phase 2 will migrate the AR client to read tree data.
 
 ## [0.4.0] — 2026-04-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,17 @@ For desktop dev without a camera / pedestal, open
 `http://localhost:5173/?tracker=noop` — the reef anchors a fixed
 distance in front of the virtual camera.
 
-Or skip AR entirely and use the playground:
+Or use the playground:
 `http://localhost:5173/playground.html?api=http://localhost:8787`.
 Orbit-camera view, click-to-place, full picker UI — no AR
 code-paths involved. Add `?mode=screen` for the auto-orbit
 museum-display variant.
 
-Once the tree-mode surface ships (planned in
-[`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md)):
+Or use tree mode:
 `http://localhost:5173/tree.html?api=http://localhost:8787`. A
 different reef — fractal branching-coral web with Avatar-bioluminescent
-styling. Click attach-point orbs on existing pieces to build outward.
+styling. Click attach-point orbs on existing pieces to build outward. See
+[`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md) for the spec.
 
 ## Testing
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,14 +15,14 @@ Related docs:
 
 ## Current state
 
-- **Main branch CI**: green. 180 tests pass across 4 packages (shared 12 /
-  generator 22 / server 70 / client 76).
+- **Main branch CI**: green. 313 tests pass across 4 packages (shared 19 /
+  generator 54 / server 92 / client 148).
 - **Deployed version**: v0.4.0 live on the Beelink LXC at
   `https://reef.home.local/`. Three surfaces available:
   `index.html` (AR, phone), `playground.html` (orbit camera, desktop),
   `playground.html?mode=screen` (auto-orbit, museum display).
-- **Planned next**: tree mode (third surface) — implementation plan
-  merged (#72), execution pending.
+- **Latest**: tree mode (third surface) — fully implemented. Phase 2
+  (AR client migration) ahead.
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
   @fastify/cors 9 (pinned — issue #54 tracks Fastify 5 migration) ·
   node:25-alpine · happy-dom 19 · Oxlint.
@@ -194,32 +194,6 @@ Tracking issue: [#28].
 
 ## Operator runbook — exactly what you need to do
 
-### Step 0.5 — Tree mode testing (coming soon)
-
-A new third surface, `tree.html`, is planned — see
-[`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md).
-Different from the landscape playground: visitors attach small
-composable branch pieces to each other's exposed tips, growing a
-fractal coral web. Avatar-bioluminescent styling (bloom, vivid
-palette, no translucency). Separate reef in the DB — doesn't share
-polyps with the landscape view.
-
-Usage (once shipped):
-
-```
-https://reef.home.local/tree.html              # interactive
-https://reef.home.local/tree.html?mode=screen  # auto-orbit demo view
-https://reef.home.local/tree.html?readonly=1   # browse-only
-```
-
-The tree's pedestal is auto-seeded with one Starburst piece at
-install time, so visitors always have something to branch off
-(the first visitor's experience isn't an empty stage).
-
-Phase 2 of the plan: once the tree's visuals feel right, migrate the
-AR client to read from the tree data so visitors at the pedestal see
-the same fractal reef growing in AR that the wall screen shows.
-
 ### Step 0 — Non-AR testing via the playground
 
 Before investing in the marker print + NFC tag + real-device cycle,
@@ -246,6 +220,31 @@ Local dev: `pnpm --filter @reef/client dev` → `http://localhost:5173/playgroun
 What it **doesn't** test: the 8th Wall engine, camera permissions,
 SLAM tracking, anchor stability, real lighting, the marker print.
 Steps 1-5 below remain necessary for AR verification.
+
+### Step 0.5 — Non-AR tree mode testing
+
+A third client surface, `tree.html`, is now live. Different from the
+landscape playground: visitors attach small composable branch pieces to
+each other's exposed tips, growing a fractal coral web. Avatar-bioluminescent
+styling (bloom post-processing, vivid palette, no translucency). Separate
+reef in the DB (`tree_polyps` table), seeded with one Starburst root at
+install so visitors always have something to branch off. Phase 2 will migrate
+the AR client to read the tree data so the pedestal AR view shows the same
+growing fractal structure.
+
+URLs:
+
+```
+https://reef.home.local/tree.html              # interactive
+https://reef.home.local/tree.html?mode=screen  # auto-orbit demo view
+https://reef.home.local/tree.html?readonly=1   # browse-only
+```
+
+Local dev: `pnpm --filter @reef/client dev` → `http://localhost:5173/tree.html?api=http://localhost:8787`.
+
+What it exercises: fetching initial tree state, clicking attach-point orbs,
+picker UI + color selection, bloom aesthetic, screen mode (auto-orbit for a
+museum wall pedestal next to the AR display).
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,8 +9,10 @@ A collaborative AR installation where visitors tap an NFC tag, open a web-based 
 - **Liveness:** Simulated currents, background growth, and ambient life. The reef changes visibly even with zero tappers.
 - **Tracking abstraction:** Swappable tracking provider interface so a future provider (WebXR image-tracking, another engine) can slot in without touching app code.
 - **Still $0 ongoing cost.** Everything self-hosted on existing Beelink + Cloudflare Tunnel.
-- **Dual surface:** the installation has both an AR layer (phone tapped to a pedestal) and a non-AR screen layer (`playground.html`) that shows the reef growing from a fixed orbit viewpoint on a wall-mounted display. Same backend, same sim loop, same geometry — two ways to experience the same living reef.
-- **Third surface (planned — tree mode):** a third entry (`tree.html`) for a different reef — a fractal branching-coral web where visitors attach small composable pieces to each other's exposed tips. Avatar-bioluminescent styling (bloom post-processing, vivid palette). Separate reef in the DB. Concept fully specified in [`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md). Phase 2 migrates the AR client to read the tree data so the pedestal AR view shows the same growing fractal structure the wall screen shows.
+- **Multiple surfaces:** the installation has three entry points sharing one backend:
+  - **AR** (phone tapped to pedestal) — SLAM-tracked reef anchor.
+  - **Playground** (`playground.html`) — orbit-camera non-AR view for a wall-mounted display next to the AR pedestal.
+  - **Branching web (tree mode)** (`tree.html`) — a different reef where visitors attach small composable pieces to each other's exposed tips, growing a fractal coral structure. Avatar-bioluminescent styling (bloom, vivid palette). Separate DB table (`tree_polyps`), separate WebSocket namespace (`/ws/tree`). Phase 2 will migrate the AR client to read tree data so the pedestal AR shows the same growing fractal the wall screen shows. See [`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md).
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ box behind Cloudflare Tunnel, or a $5/mo Fly.io VM, or anything in between.
   - **Tree** (`tree.html`) — a different reef. Fractal branching-coral
     web built by attaching small composable pieces to each other's
     tips. Avatar-bioluminescent styling (bloom post-processing, vivid
-    palette). Planned — implementation in
+    palette). Implemented per
     [`docs/superpowers/plans/2026-04-22-tree-mode.md`](docs/superpowers/plans/2026-04-22-tree-mode.md).
-- **CI**: lint (Oxlint) · typecheck · build · 180 tests across four
+- **CI**: lint (Oxlint) · typecheck · build · 313 tests across four
   packages · multi-arch Docker image on tag · Pages deploy on push.
 
 ## Layout

--- a/packages/client/src/tree.test.ts
+++ b/packages/client/src/tree.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// We don't run the full tree entry in test — it calls WebGL and fetch.
+// Instead, verify the module imports without throwing and the config parser
+// + scene factory work together as expected.
+describe('tree module', () => {
+  test('config + scene + api all importable together', async () => {
+    const [config, scene, api] = await Promise.all([
+      import('./tree/config.js'),
+      import('./tree/scene.js'),
+      import('./tree/api.js'),
+    ]);
+    expect(typeof config.readTreeConfig).toBe('function');
+    expect(typeof scene.createTreePedestal).toBe('function');
+    expect(typeof api.fetchTree).toBe('function');
+  });
+
+  test('readTreeConfig + createTreePedestal produce a valid pair', async () => {
+    const { readTreeConfig } = await import('./tree/config.js');
+    const { createTreePedestal } = await import('./tree/scene.js');
+    vi.stubGlobal('location', { search: '?mode=screen' });
+    expect(readTreeConfig().mode).toBe('screen');
+    expect(createTreePedestal()).toBeTruthy();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -18,6 +18,7 @@ import { AttachIndicators } from './tree/indicators.js';
 import { TreePlacement } from './tree/placement.js';
 import { fetchTree, submitTreePolyp, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
 import { TreePicker } from './ui/treePicker.js';
+import { computeOrbitPose } from './playground/autoOrbit.js';
 
 // ------------------------------------------------------------------
 // Sentinel symbols so sway/pulse are installed at most once per mesh.
@@ -255,6 +256,7 @@ if (config.mode === 'interactive') {
 
 if (config.mode === 'screen') {
   picker.hide();
+  (document.getElementById('picker') as HTMLElement).classList.add('hidden');
   controls.enabled = false;
 }
 
@@ -331,7 +333,14 @@ async function loadInitial(): Promise<void> {
 function loop(t: number): void {
   swayClock.value = t / 1000;
 
-  controls.update();
+  if (config.mode === 'screen') {
+    const pose = computeOrbitPose(t / 1000);
+    camera.position.copy(pose.position);
+    camera.lookAt(pose.target);
+  } else {
+    controls.update();
+  }
+
   bloomSetup.render();
   requestAnimationFrame(loop);
 }

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -1,0 +1,51 @@
+import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { readTreeConfig } from './tree/config.js';
+import { createTreePedestal, createBloomComposer } from './tree/scene.js';
+import { installLighting } from './scene/lighting.js';
+
+const config = readTreeConfig();
+const canvas = document.getElementById('gl') as HTMLCanvasElement;
+const modeBadge = document.getElementById('mode-badge')!;
+modeBadge.textContent = `${config.mode}${config.readonly ? ' · readonly' : ''}`;
+
+const renderer = new WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+
+const scene = new Scene();
+scene.background = null;
+renderer.setClearColor(0x01060d, 1);
+
+installLighting(scene);
+scene.add(createTreePedestal());
+
+const camera = new PerspectiveCamera(50, 1, 0.01, 20);
+camera.position.set(0.45, 0.2, 0);
+camera.lookAt(0, 0, 0);
+
+const controls = new OrbitControls(camera, canvas);
+controls.target.set(0, 0, 0);
+controls.minDistance = 0.2;
+controls.maxDistance = 1.2;
+controls.maxPolarAngle = Math.PI / 2 - 0.05;
+controls.enableDamping = true;
+
+const bloomSetup = createBloomComposer(renderer, scene, camera);
+
+function resize(): void {
+  const w = window.innerWidth, h = window.innerHeight;
+  renderer.setSize(w, h, false);
+  bloomSetup.composer.setSize(w, h);
+  bloomSetup.bloomPass.resolution.set(w, h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function loop(): void {
+  controls.update();
+  bloomSetup.render();
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -1,14 +1,41 @@
-import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import {
+  PerspectiveCamera,
+  Raycaster,
+  Scene,
+  Vector2,
+  WebGLRenderer,
+  type Mesh,
+} from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { PublicTreePolyp } from '@reef/shared';
+import { installLighting } from './scene/lighting.js';
+import { installSway } from './scene/currentSway.js';
+import { installPulse } from './scene/pulse.js';
 import { readTreeConfig } from './tree/config.js';
 import { createTreePedestal, createBloomComposer } from './tree/scene.js';
-import { installLighting } from './scene/lighting.js';
+import { TreeReef } from './tree/reef.js';
+import { AttachIndicators } from './tree/indicators.js';
+import { TreePlacement } from './tree/placement.js';
+import { fetchTree, submitTreePolyp, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
+import { TreePicker } from './ui/treePicker.js';
 
+// ------------------------------------------------------------------
+// Sentinel symbols so sway/pulse are installed at most once per mesh.
+// ------------------------------------------------------------------
+const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
+
+// ------------------------------------------------------------------
+// Config + canvas
+// ------------------------------------------------------------------
 const config = readTreeConfig();
 const canvas = document.getElementById('gl') as HTMLCanvasElement;
 const modeBadge = document.getElementById('mode-badge')!;
 modeBadge.textContent = `${config.mode}${config.readonly ? ' · readonly' : ''}`;
 
+// ------------------------------------------------------------------
+// Renderer + scene
+// ------------------------------------------------------------------
 const renderer = new WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
 
@@ -19,6 +46,9 @@ renderer.setClearColor(0x01060d, 1);
 installLighting(scene);
 scene.add(createTreePedestal());
 
+// ------------------------------------------------------------------
+// Camera + controls
+// ------------------------------------------------------------------
 const camera = new PerspectiveCamera(50, 1, 0.01, 20);
 camera.position.set(0.45, 0.2, 0);
 camera.lookAt(0, 0, 0);
@@ -30,8 +60,70 @@ controls.maxDistance = 1.2;
 controls.maxPolarAngle = Math.PI / 2 - 0.05;
 controls.enableDamping = true;
 
+// ------------------------------------------------------------------
+// Bloom composer
+// ------------------------------------------------------------------
 const bloomSetup = createBloomComposer(renderer, scene, camera);
 
+// ------------------------------------------------------------------
+// Tree objects
+// ------------------------------------------------------------------
+const treeReef = new TreeReef();
+scene.add(treeReef.anchor);
+
+const attachIndicators = new AttachIndicators();
+scene.add(attachIndicators.group);
+
+const placement = new TreePlacement(treeReef);
+scene.add(placement.ghostAnchor);
+
+// ------------------------------------------------------------------
+// Shared clock for sway/pulse animations
+// ------------------------------------------------------------------
+const swayClock = { value: 0 };
+
+// ------------------------------------------------------------------
+// Sway/pulse helpers
+// ------------------------------------------------------------------
+
+/**
+ * Walk all pieces in treeReef and install sway/pulse on any new meshes.
+ * Tree emissive baseline is higher (see Task 15), so pulse amplitude
+ * is applied at the same rate — the higher baseline is set in the
+ * material itself; installPulse drives around it.
+ */
+function installEffectsOnNewPieces(): void {
+  for (const { polyp, mesh } of treeReef.allPieces()) {
+    const flags = mesh.userData as Record<PropertyKey, unknown>;
+    if (!flags[SWAY_INSTALLED]) {
+      installSway(mesh as Mesh, swayClock);
+      flags[SWAY_INSTALLED] = true;
+    }
+    if (!flags[PULSE_INSTALLED]) {
+      installPulse(mesh as Mesh, swayClock, polyp.seed);
+      flags[PULSE_INSTALLED] = true;
+    }
+  }
+}
+
+// ------------------------------------------------------------------
+// Picker (tree variant)
+// ------------------------------------------------------------------
+const pickerRoot = document.getElementById('picker')!;
+const picker = new TreePicker(pickerRoot);
+const hintEl = document.getElementById('hint')!;
+
+let currentSeed = Math.floor(Math.random() * 0xffffffff);
+
+// ------------------------------------------------------------------
+// Pending attach slot — set on click, cleared on commit/cancel
+// ------------------------------------------------------------------
+let pendingParentId: number | null = null;
+let pendingAttachIndex = 0;
+
+// ------------------------------------------------------------------
+// Resize
+// ------------------------------------------------------------------
 function resize(): void {
   const w = window.innerWidth, h = window.innerHeight;
   renderer.setSize(w, h, false);
@@ -43,9 +135,207 @@ function resize(): void {
 window.addEventListener('resize', resize);
 resize();
 
-function loop(): void {
+// ------------------------------------------------------------------
+// Interactive mode: click handler + picker wiring
+// ------------------------------------------------------------------
+if (config.mode === 'interactive') {
+  picker.show();
+
+  const raycaster = new Raycaster();
+  // Make raycaster threshold generous enough to pick small indicator spheres.
+  raycaster.params.Points = { threshold: 0.01 };
+
+  canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const ndc = new Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -(((e.clientY - rect.top) / rect.height) * 2 - 1),
+    );
+
+    raycaster.setFromCamera(ndc, camera);
+    const intersects = raycaster.intersectObjects(attachIndicators.group.children, false);
+    if (intersects.length === 0) {
+      hintEl.textContent = 'Click a glowing dot to attach your piece.';
+      return;
+    }
+
+    const hit = intersects[0]!;
+    const ud = hit.object.userData as { parentId?: number; attachIndex?: number };
+    if (ud.parentId === undefined || ud.attachIndex === undefined) return;
+
+    pendingParentId = ud.parentId;
+    pendingAttachIndex = ud.attachIndex;
+    currentSeed = Math.floor(Math.random() * 0xffffffff);
+
+    const s = picker.get();
+    const ghost = placement.showGhost(
+      s.variant,
+      currentSeed,
+      s.colorKey,
+      pendingParentId,
+      pendingAttachIndex,
+    );
+
+    if (ghost) {
+      picker.setCommittable(true);
+      hintEl.textContent = 'Happy with it? Click Grow.';
+    } else {
+      hintEl.textContent = 'That spot is blocked. Try another dot.';
+    }
+  });
+
+  picker.onChange(({ variant, colorKey }) => {
+    if (pendingParentId === null) return;
+    const ghost = placement.showGhost(
+      variant,
+      currentSeed,
+      colorKey,
+      pendingParentId,
+      pendingAttachIndex,
+    );
+    picker.setCommittable(!!ghost);
+    if (!ghost) hintEl.textContent = 'That spot is blocked. Try another dot.';
+  });
+
+  picker.onReroll(() => {
+    if (pendingParentId === null) return;
+    currentSeed = Math.floor(Math.random() * 0xffffffff);
+    const s = picker.get();
+    const ghost = placement.showGhost(
+      s.variant,
+      currentSeed,
+      s.colorKey,
+      pendingParentId,
+      pendingAttachIndex,
+    );
+    picker.setCommittable(!!ghost);
+  });
+
+  picker.onCancel(() => {
+    placement.reset();
+    pendingParentId = null;
+    picker.setCommittable(false);
+    hintEl.textContent = 'Cancelled. Click a dot to try again.';
+  });
+
+  picker.onCommit(async () => {
+    if (config.readonly) {
+      hintEl.textContent = 'Readonly mode — Grow is disabled.';
+      return;
+    }
+    const pending = placement.getPending();
+    if (!pending) return;
+
+    picker.setSubmitting(true);
+    try {
+      await submitTreePolyp(
+        {
+          variant: pending.variant,
+          seed: pending.seed,
+          colorKey: pending.colorKey,
+          parentId: pending.parentId,
+          attachIndex: pending.attachIndex,
+        },
+        config.apiBase,
+      );
+      // The socket echo (tree_polyp_added) will call treeReef.addPiece and
+      // placement.reset(). No need to add the piece locally here — let the
+      // server broadcast drive it (consistent with the playground pattern).
+      picker.setSubmitting(false);
+      picker.setCommittable(false);
+      hintEl.textContent = 'Grown! Click another dot to plant again.';
+      pendingParentId = null;
+    } catch (e) {
+      picker.setSubmitting(false);
+      hintEl.textContent = 'Server rejected the piece. Check the console.';
+      console.error(e);
+    }
+  });
+}
+
+if (config.mode === 'screen') {
+  picker.hide();
+  controls.enabled = false;
+}
+
+// ------------------------------------------------------------------
+// WebSocket
+// ------------------------------------------------------------------
+function buildTreeWsUrl(): string {
+  if (!config.apiBase) return defaultTreeWsUrl();
+  const u = new URL(config.apiBase);
+  const proto = u.protocol === 'https:' ? 'wss' : 'ws';
+  return `${proto}://${u.host}/ws/tree`;
+}
+
+const socket = new TreeSocket(buildTreeWsUrl());
+socket.on((msg) => {
+  if (msg.type === 'tree_hello') {
+    console.log(`[tree] connected — server has ${msg.polypCount} piece(s)`);
+  } else if (msg.type === 'tree_polyp_added') {
+    // Avoid double-adding if the addPiece call throws on duplicate.
+    try {
+      addAndRefresh(msg.polyp);
+    } catch (err) {
+      // Parent might not be registered yet in a race — log and ignore.
+      console.warn('[tree] tree_polyp_added could not add piece', err);
+      return;
+    }
+    // If this matches the current pending ghost, resolve it.
+    const pending = placement.getPending();
+    if (
+      pending &&
+      pending.parentId === msg.polyp.parentId &&
+      pending.attachIndex === msg.polyp.attachIndex &&
+      pending.variant === msg.polyp.variant &&
+      pending.seed === msg.polyp.seed
+    ) {
+      placement.reset();
+    }
+  } else if (msg.type === 'tree_polyp_removed') {
+    treeReef.removePiece(msg.id);
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  }
+});
+
+function addAndRefresh(polyp: PublicTreePolyp): void {
+  treeReef.addPiece(polyp);
+  installEffectsOnNewPieces();
+  attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+}
+
+// ------------------------------------------------------------------
+// Initial fetch
+// ------------------------------------------------------------------
+async function loadInitial(): Promise<void> {
+  try {
+    const state = await fetchTree(config.apiBase);
+    // Sort ascending so parents are always inserted before children.
+    const sorted = [...state.polyps].sort((a, b) => a.createdAt - b.createdAt);
+    for (const polyp of sorted) {
+      treeReef.addPiece(polyp);
+    }
+    installEffectsOnNewPieces();
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+    if (hintEl && config.mode === 'interactive') {
+      hintEl.textContent = 'Click a glowing dot to attach your piece.';
+    }
+  } catch (e) {
+    console.error('[tree] Failed to load tree', e);
+  }
+}
+
+// ------------------------------------------------------------------
+// Render loop
+// ------------------------------------------------------------------
+function loop(t: number): void {
+  swayClock.value = t / 1000;
+
   controls.update();
   bloomSetup.render();
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);
+
+void loadInitial();
+socket.connect();

--- a/packages/client/src/tree/api.test.ts
+++ b/packages/client/src/tree/api.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { fetchTree, submitTreePolyp, TreeSocket, defaultTreeWsUrl } from './api.js';
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status: number, body: unknown): void {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(
+    typeof body === 'string' ? body : JSON.stringify(body),
+    { status, headers: { 'content-type': 'application/json' } },
+  )));
+}
+
+const validInput = {
+  variant: 'forked' as const,
+  seed: 42,
+  colorKey: 'reef-blue',
+  parentId: null,
+  attachIndex: 0,
+};
+
+describe('fetchTree', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('calls GET /api/tree and returns parsed JSON', async () => {
+    const payload = { polyps: [], serverTime: 1000 };
+    mockFetch(200, payload);
+
+    const result = await fetchTree();
+
+    expect(result).toEqual(payload);
+    const fetchMock = vi.mocked(globalThis.fetch as typeof fetch);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/tree');
+  });
+
+  test('respects the apiBase parameter', async () => {
+    mockFetch(200, { polyps: [], serverTime: 0 });
+    await fetchTree('https://api.example.com');
+    const fetchMock = vi.mocked(globalThis.fetch as typeof fetch);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.example.com/api/tree');
+  });
+
+  test('throws on non-OK response with status in message', async () => {
+    mockFetch(500, {});
+    await expect(fetchTree()).rejects.toThrowError(/fetchTree 500/);
+  });
+
+  test('throws on 404 with status in message', async () => {
+    mockFetch(404, {});
+    await expect(fetchTree()).rejects.toThrowError(/fetchTree 404/);
+  });
+});
+
+describe('submitTreePolyp', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('calls POST /api/tree/polyp with JSON body', async () => {
+    const saved = { id: 1, ...validInput, createdAt: 999 };
+    mockFetch(201, saved);
+
+    const result = await submitTreePolyp(validInput);
+
+    const fetchMock = vi.mocked(globalThis.fetch as typeof fetch);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/tree/polyp');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual(validInput);
+    expect(result.id).toBe(1);
+  });
+
+  test('respects the apiBase parameter', async () => {
+    mockFetch(201, { id: 2, ...validInput, createdAt: 1 });
+    await submitTreePolyp(validInput, 'https://api.example.com');
+    const fetchMock = vi.mocked(globalThis.fetch as typeof fetch);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.example.com/api/tree/polyp');
+  });
+
+  test('throws on non-OK response with status in message', async () => {
+    mockFetch(400, 'bad request');
+    const err = await submitTreePolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/submitTreePolyp 400/);
+  });
+
+  test('throws on 500 with status in message', async () => {
+    mockFetch(500, 'server error');
+    const err = await submitTreePolyp(validInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain('500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TreeSocket
+// ---------------------------------------------------------------------------
+
+class FakeWs {
+  readonly listeners = new Map<string, Set<(ev: unknown) => void>>();
+  readonly url: string;
+  readonly closeSpy = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWs.created.push(this);
+  }
+
+  addEventListener(type: string, cb: (ev: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(cb);
+  }
+
+  close(): void {
+    this.closeSpy();
+    // Fire 'close' synchronously so reconnect logic is testable.
+    this.fire('close', {});
+  }
+
+  fire(type: string, ev: unknown): void {
+    this.listeners.get(type)?.forEach((cb) => cb(ev));
+  }
+
+  static created: FakeWs[] = [];
+  static reset(): void { FakeWs.created = []; }
+}
+
+describe('TreeSocket', () => {
+  beforeEach(() => {
+    FakeWs.reset();
+    vi.stubGlobal('WebSocket', FakeWs);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test('connect() opens a WebSocket to the given URL', () => {
+    const s = new TreeSocket('ws://example.test/ws/tree');
+    s.connect();
+
+    expect(FakeWs.created).toHaveLength(1);
+    expect(FakeWs.created[0]!.url).toBe('ws://example.test/ws/tree');
+  });
+
+  test('on() registers a listener that receives parsed messages', () => {
+    const cb = vi.fn();
+    const s = new TreeSocket('ws://t');
+    s.on(cb);
+    s.connect();
+
+    const msg = { type: 'tree_hello', polypCount: 5, serverTime: 100 };
+    FakeWs.created[0]!.fire('message', { data: JSON.stringify(msg) });
+
+    expect(cb).toHaveBeenCalledOnce();
+    expect(cb).toHaveBeenCalledWith(msg);
+  });
+
+  test('messages dispatch to every registered listener', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const s = new TreeSocket('ws://t');
+    s.on(cb1);
+    s.on(cb2);
+    s.connect();
+
+    const msg = { type: 'tree_polyp_added', polyp: { id: 1, variant: 'forked', seed: 0, colorKey: 'x', parentId: null, attachIndex: 0, createdAt: 0 } };
+    FakeWs.created[0]!.fire('message', { data: JSON.stringify(msg) });
+
+    expect(cb1).toHaveBeenCalledWith(msg);
+    expect(cb2).toHaveBeenCalledWith(msg);
+  });
+
+  test('close() closes the underlying WebSocket', () => {
+    const s = new TreeSocket('ws://t');
+    s.connect();
+    s.close();
+
+    expect(FakeWs.created[0]!.closeSpy).toHaveBeenCalledOnce();
+  });
+
+  test('close() stops reconnects', () => {
+    const s = new TreeSocket('ws://t');
+    s.connect();
+    s.close();
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWs.created).toHaveLength(1);
+  });
+
+  test('tolerates malformed JSON messages silently', () => {
+    const cb = vi.fn();
+    const s = new TreeSocket('ws://t');
+    s.on(cb);
+    s.connect();
+
+    // Fire garbage — should not throw and should not call the listener.
+    expect(() => {
+      FakeWs.created[0]!.fire('message', { data: 'not valid JSON {{{{' });
+    }).not.toThrow();
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test('reconnects with exponential backoff on close', () => {
+    const s = new TreeSocket('ws://t');
+    s.connect();
+
+    // First drop: delay = 1000 * 1.8^0 = 1000ms.
+    FakeWs.created[0]!.fire('close', {});
+
+    vi.advanceTimersByTime(999);
+    expect(FakeWs.created).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(FakeWs.created).toHaveLength(2);
+  });
+
+  test('open event resets retries so the next drop starts from baseline', () => {
+    const s = new TreeSocket('ws://t');
+    s.connect();
+
+    // Fail twice to build up retries.
+    FakeWs.created[0]!.fire('close', {});
+    vi.advanceTimersByTime(1000);
+    FakeWs.created[1]!.fire('close', {});
+    vi.advanceTimersByTime(1800);
+
+    // Socket 2: open it successfully then drop.
+    FakeWs.created[2]!.fire('open', {});
+    FakeWs.created[2]!.fire('close', {});
+
+    // Next delay should be 1000ms (retries reset), not 3240ms.
+    vi.advanceTimersByTime(999);
+    expect(FakeWs.created).toHaveLength(3);
+    vi.advanceTimersByTime(1);
+    expect(FakeWs.created).toHaveLength(4);
+  });
+});
+
+describe('defaultTreeWsUrl', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('picks wss for https and ws for http, path is /ws/tree', () => {
+    vi.stubGlobal('location', { protocol: 'https:', host: 'reef.example.com' });
+    expect(defaultTreeWsUrl()).toBe('wss://reef.example.com/ws/tree');
+
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+    expect(defaultTreeWsUrl()).toBe('ws://localhost:5173/ws/tree');
+  });
+});

--- a/packages/client/src/tree/api.ts
+++ b/packages/client/src/tree/api.ts
@@ -1,0 +1,78 @@
+import type { PublicTreePolyp, TreePolypInput, TreeServerMessage } from '@reef/shared';
+
+export async function fetchTree(apiBase = ''): Promise<{ polyps: PublicTreePolyp[]; serverTime: number }> {
+  const r = await fetch(`${apiBase}/api/tree`);
+  if (!r.ok) throw new Error(`fetchTree ${r.status}`);
+  return r.json() as Promise<{ polyps: PublicTreePolyp[]; serverTime: number }>;
+}
+
+export async function submitTreePolyp(input: TreePolypInput, apiBase = ''): Promise<PublicTreePolyp> {
+  const r = await fetch(`${apiBase}/api/tree/polyp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!r.ok) {
+    const detail = await r.text().catch(() => '');
+    throw new Error(`submitTreePolyp ${r.status}${detail ? ` ${detail}` : ''}`);
+  }
+  return r.json() as Promise<PublicTreePolyp>;
+}
+
+/**
+ * Reconnecting WebSocket with exponential backoff. Capped at 30s between
+ * tries. Fires every server message to each registered handler.
+ */
+export class TreeSocket {
+  private ws?: WebSocket;
+  private listeners: Array<(msg: TreeServerMessage) => void> = [];
+  private retries = 0;
+  private closed = false;
+
+  constructor(readonly url: string) {}
+
+  on(cb: (msg: TreeServerMessage) => void): void {
+    this.listeners.push(cb);
+  }
+
+  connect(): void {
+    if (this.closed) return;
+    this.ws = new WebSocket(this.url);
+    this.ws.addEventListener('open', () => { this.retries = 0; });
+    this.ws.addEventListener('message', (ev) => {
+      let msg: TreeServerMessage;
+      try {
+        msg = JSON.parse(ev.data as string) as TreeServerMessage;
+      } catch (err) {
+        console.warn('ws/tree: malformed frame', err);
+        return;
+      }
+      for (const cb of this.listeners) {
+        try {
+          cb(msg);
+        } catch (err) {
+          console.error('ws/tree: handler threw on', (msg as { type?: string }).type, err);
+        }
+      }
+    });
+    this.ws.addEventListener('close', () => this.scheduleReconnect());
+    this.ws.addEventListener('error', () => this.ws?.close());
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed) return;
+    const delay = Math.min(30_000, 1000 * Math.pow(1.8, this.retries++));
+    setTimeout(() => this.connect(), delay);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.ws?.close();
+  }
+}
+
+export function defaultTreeWsUrl(): string {
+  const l = window.location;
+  const proto = l.protocol === 'https:' ? 'wss' : 'ws';
+  return `${proto}://${l.host}/ws/tree`;
+}

--- a/packages/client/src/tree/collision.test.ts
+++ b/packages/client/src/tree/collision.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { Box3, Vector3 } from 'three';
+import { wouldCollide } from './collision.js';
+
+function box(minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number): Box3 {
+  return new Box3(new Vector3(minX, minY, minZ), new Vector3(maxX, maxY, maxZ));
+}
+
+describe('wouldCollide', () => {
+  test('returns false when no existing boxes overlap the proposal', () => {
+    const proposed = box(0, 0, 0, 1, 1, 1);
+    const others = [box(2, 0, 0, 3, 1, 1), box(-3, 0, 0, -2, 1, 1)];
+    expect(wouldCollide(proposed, others)).toBe(false);
+  });
+
+  test('returns true when the proposal overlaps any existing box', () => {
+    const proposed = box(0, 0, 0, 1, 1, 1);
+    const others = [box(2, 0, 0, 3, 1, 1), box(0.5, 0.5, 0.5, 1.5, 1.5, 1.5)];
+    expect(wouldCollide(proposed, others)).toBe(true);
+  });
+
+  test('touching boxes at a shared face count as intersecting (Three.js behavior)', () => {
+    const proposed = box(0, 0, 0, 1, 1, 1);
+    const others = [box(1, 0, 0, 2, 1, 1)];  // shares the x=1 face
+    expect(wouldCollide(proposed, others)).toBe(true);
+  });
+
+  test('no existing boxes → no collision', () => {
+    const proposed = box(0, 0, 0, 1, 1, 1);
+    expect(wouldCollide(proposed, [])).toBe(false);
+  });
+});

--- a/packages/client/src/tree/collision.ts
+++ b/packages/client/src/tree/collision.ts
@@ -1,0 +1,11 @@
+import type { Box3 } from 'three';
+
+export function wouldCollide(
+  proposedBox: Box3,
+  existingBoxes: Iterable<Box3>,
+): boolean {
+  for (const other of existingBoxes) {
+    if (proposedBox.intersectsBox(other)) return true;
+  }
+  return false;
+}

--- a/packages/client/src/tree/config.test.ts
+++ b/packages/client/src/tree/config.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readTreeConfig } from './config.js';
+
+describe('readTreeConfig', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  test('defaults: interactive mode, not readonly, apiBase empty (same origin)', () => {
+    vi.stubGlobal('location', { search: '' });
+    expect(readTreeConfig()).toEqual({
+      mode: 'interactive',
+      readonly: false,
+      apiBase: '',
+    });
+  });
+
+  test('?mode=screen → screen mode (auto-orbit, no picker)', () => {
+    vi.stubGlobal('location', { search: '?mode=screen' });
+    expect(readTreeConfig().mode).toBe('screen');
+  });
+
+  test('?readonly=1 → readonly flag true', () => {
+    vi.stubGlobal('location', { search: '?readonly=1' });
+    expect(readTreeConfig().readonly).toBe(true);
+  });
+
+  test('?api=http://localhost:8787 → apiBase set', () => {
+    vi.stubGlobal('location', { search: '?api=http://localhost:8787' });
+    expect(readTreeConfig().apiBase).toBe('http://localhost:8787');
+  });
+
+  test('unknown mode falls back to interactive', () => {
+    vi.stubGlobal('location', { search: '?mode=rubbish' });
+    expect(readTreeConfig().mode).toBe('interactive');
+  });
+
+  test('combined: mode=screen + api override', () => {
+    vi.stubGlobal('location', { search: '?mode=screen&api=http://reef.example' });
+    const c = readTreeConfig();
+    expect(c.mode).toBe('screen');
+    expect(c.apiBase).toBe('http://reef.example');
+  });
+});

--- a/packages/client/src/tree/config.ts
+++ b/packages/client/src/tree/config.ts
@@ -1,0 +1,17 @@
+export type TreeMode = 'interactive' | 'screen';
+
+export interface TreeConfig {
+  mode: TreeMode;
+  readonly: boolean;
+  /** Empty string = same origin. Otherwise a URL like `http://localhost:8787`. */
+  apiBase: string;
+}
+
+export function readTreeConfig(): TreeConfig {
+  const params = new URLSearchParams(globalThis.location?.search ?? '');
+  const rawMode = params.get('mode');
+  const mode: TreeMode = rawMode === 'screen' ? 'screen' : 'interactive';
+  const readonly = params.get('readonly') === '1';
+  const apiBase = params.get('api') ?? '';
+  return { mode, readonly, apiBase };
+}

--- a/packages/client/src/tree/indicators.test.ts
+++ b/packages/client/src/tree/indicators.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { Vector3, Mesh } from 'three';
+import { AttachIndicators } from './indicators.js';
+
+describe('AttachIndicators', () => {
+  let indicators: AttachIndicators;
+
+  beforeEach(() => {
+    indicators = new AttachIndicators();
+  });
+
+  test('refresh with 3 slots creates 3 indicators', () => {
+    const slots = [
+      { parentId: 1, index: 0, worldPos: new Vector3(0, 0, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 1, index: 1, worldPos: new Vector3(0.1, 0.1, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 2, index: 0, worldPos: new Vector3(0.2, 0.2, 0), worldNormal: new Vector3(0, 1, 0) },
+    ];
+
+    indicators.refresh(slots);
+
+    expect(indicators.group.children).toHaveLength(3);
+    expect(indicators.meshAt(1, 0)).toBeInstanceOf(Mesh);
+    expect(indicators.meshAt(1, 1)).toBeInstanceOf(Mesh);
+    expect(indicators.meshAt(2, 0)).toBeInstanceOf(Mesh);
+  });
+
+  test('refreshing with fewer slots removes the missing ones', () => {
+    const slots3 = [
+      { parentId: 1, index: 0, worldPos: new Vector3(0, 0, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 1, index: 1, worldPos: new Vector3(0.1, 0.1, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 2, index: 0, worldPos: new Vector3(0.2, 0.2, 0), worldNormal: new Vector3(0, 1, 0) },
+    ];
+
+    indicators.refresh(slots3);
+    expect(indicators.group.children).toHaveLength(3);
+
+    // Refresh with only 2 slots (removing parentId 1, index 1)
+    const slots2 = [
+      { parentId: 1, index: 0, worldPos: new Vector3(0, 0, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 2, index: 0, worldPos: new Vector3(0.2, 0.2, 0), worldNormal: new Vector3(0, 1, 0) },
+    ];
+
+    indicators.refresh(slots2);
+
+    expect(indicators.group.children).toHaveLength(2);
+    expect(indicators.meshAt(1, 0)).toBeInstanceOf(Mesh);
+    expect(indicators.meshAt(1, 1)).toBeUndefined();
+    expect(indicators.meshAt(2, 0)).toBeInstanceOf(Mesh);
+  });
+
+  test('indicators are positioned at the slot world position', () => {
+    const worldPos = new Vector3(0.1, 0.2, 0.3);
+    const slots = [
+      { parentId: 1, index: 0, worldPos, worldNormal: new Vector3(0, 1, 0) },
+    ];
+
+    indicators.refresh(slots);
+
+    const mesh = indicators.meshAt(1, 0)!;
+    expect(mesh.position.x).toBeCloseTo(0.1, 5);
+    expect(mesh.position.y).toBeCloseTo(0.2, 5);
+    expect(mesh.position.z).toBeCloseTo(0.3, 5);
+  });
+
+  test('all() yields every registered indicator', () => {
+    const slots = [
+      { parentId: 1, index: 0, worldPos: new Vector3(0, 0, 0), worldNormal: new Vector3(0, 1, 0) },
+      { parentId: 2, index: 0, worldPos: new Vector3(0.2, 0.2, 0), worldNormal: new Vector3(0, 1, 0) },
+    ];
+
+    indicators.refresh(slots);
+
+    const items = Array.from(indicators.all());
+    expect(items).toHaveLength(2);
+
+    const item1 = items.find((i) => i.parentId === 1 && i.index === 0);
+    const item2 = items.find((i) => i.parentId === 2 && i.index === 0);
+
+    expect(item1).toBeDefined();
+    expect(item1!.mesh).toBeInstanceOf(Mesh);
+    expect(item2).toBeDefined();
+    expect(item2!.mesh).toBeInstanceOf(Mesh);
+  });
+});

--- a/packages/client/src/tree/indicators.ts
+++ b/packages/client/src/tree/indicators.ts
@@ -1,0 +1,64 @@
+import { Group, Mesh, MeshStandardMaterial, SphereGeometry, Vector3 } from 'three';
+
+export interface AttachSlot {
+  parentId: number;
+  index: number;
+  worldPos: Vector3;
+  worldNormal: Vector3;
+}
+
+const INDICATOR_RADIUS = 0.004;
+const INDICATOR_SEGMENTS = 12;
+
+function makeIndicatorMesh(): Mesh {
+  const geom = new SphereGeometry(INDICATOR_RADIUS, INDICATOR_SEGMENTS, INDICATOR_SEGMENTS);
+  const mat = new MeshStandardMaterial({
+    color: 0xffffff,
+    emissive: 0xffffff,
+    emissiveIntensity: 1.2,
+    transparent: false,
+    opacity: 1,
+  });
+  return new Mesh(geom, mat);
+}
+
+export class AttachIndicators {
+  readonly group = new Group();
+  private bySlot = new Map<string, Mesh>();
+
+  refresh(available: AttachSlot[]): void {
+    const wantedKeys = new Set(available.map((s) => `${s.parentId}/${s.index}`));
+
+    // Remove indicators for slots no longer available.
+    for (const [key, mesh] of this.bySlot) {
+      if (!wantedKeys.has(key)) {
+        this.group.remove(mesh);
+        mesh.geometry.dispose();
+        (mesh.material as MeshStandardMaterial).dispose();
+        this.bySlot.delete(key);
+      }
+    }
+
+    // Add indicators for new slots.
+    for (const slot of available) {
+      const key = `${slot.parentId}/${slot.index}`;
+      if (this.bySlot.has(key)) continue;
+      const mesh = makeIndicatorMesh();
+      mesh.position.copy(slot.worldPos);
+      mesh.userData = { parentId: slot.parentId, attachIndex: slot.index };
+      this.group.add(mesh);
+      this.bySlot.set(key, mesh);
+    }
+  }
+
+  meshAt(parentId: number, index: number): Mesh | undefined {
+    return this.bySlot.get(`${parentId}/${index}`);
+  }
+
+  *all(): Iterable<{ parentId: number; index: number; mesh: Mesh }> {
+    for (const [key, mesh] of this.bySlot) {
+      const [pid, idx] = key.split('/');
+      yield { parentId: Number(pid), index: Number(idx), mesh };
+    }
+  }
+}

--- a/packages/client/src/tree/material.test.ts
+++ b/packages/client/src/tree/material.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { Color, MeshStandardMaterial } from 'three';
+import { applyTreeMaterial } from './material.js';
+
+describe('applyTreeMaterial', () => {
+  test('sets opacity to 1 (fully opaque — Avatar aesthetic)', () => {
+    const m = new MeshStandardMaterial({ color: 0xff00ff });
+    applyTreeMaterial(m);
+    expect(m.opacity).toBe(1);
+    expect(m.transparent).toBe(false);
+  });
+
+  test('emissive matches the material color', () => {
+    const m = new MeshStandardMaterial({ color: 0x2dffe4 });
+    applyTreeMaterial(m);
+    const expected = new Color(0x2dffe4);
+    expect(m.emissive.r).toBeCloseTo(expected.r, 5);
+    expect(m.emissive.g).toBeCloseTo(expected.g, 5);
+    expect(m.emissive.b).toBeCloseTo(expected.b, 5);
+  });
+
+  test('emissive intensity is high enough to read as fluorescent', () => {
+    const m = new MeshStandardMaterial();
+    applyTreeMaterial(m);
+    expect(m.emissiveIntensity).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test('vertexColors remain enabled (piece color is per-vertex)', () => {
+    const m = new MeshStandardMaterial({ vertexColors: true });
+    applyTreeMaterial(m);
+    expect(m.vertexColors).toBe(true);
+  });
+});

--- a/packages/client/src/tree/material.ts
+++ b/packages/client/src/tree/material.ts
@@ -1,0 +1,16 @@
+import type { MeshStandardMaterial } from 'three';
+
+export const TREE_EMISSIVE_INTENSITY = 1.0;
+
+/**
+ * Avatar-bioluminescent aesthetic: fully opaque, emissive matches the
+ * surface color, vertex colors still drive per-piece hue. Downstream a
+ * bloom post-processing pass turns the emissive into halos.
+ */
+export function applyTreeMaterial(mat: MeshStandardMaterial): void {
+  mat.transparent = false;
+  mat.opacity = 1;
+  mat.emissive.copy(mat.color);
+  mat.emissiveIntensity = TREE_EMISSIVE_INTENSITY;
+  mat.needsUpdate = true;
+}

--- a/packages/client/src/tree/placement.test.ts
+++ b/packages/client/src/tree/placement.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { Box3, Group, Mesh, MeshStandardMaterial, Vector3 } from 'three';
+import type { PublicTreePolyp } from '@reef/shared';
+import { TreeReef } from './reef.js';
+import { TreePlacement } from './placement.js';
+
+function makeRoot(id = 1): PublicTreePolyp {
+  return {
+    id,
+    variant: 'starburst',
+    seed: 42,
+    colorKey: 'neon-cyan',
+    parentId: null,
+    attachIndex: 0,
+    createdAt: Date.now(),
+  };
+}
+
+function makeChild(
+  id: number,
+  parentId: number,
+  attachIndex = 0,
+  variant: PublicTreePolyp['variant'] = 'forked',
+): PublicTreePolyp {
+  return {
+    id,
+    variant,
+    seed: id * 7,
+    colorKey: 'neon-magenta',
+    parentId,
+    attachIndex,
+    createdAt: Date.now() + id,
+  };
+}
+
+describe('TreePlacement', () => {
+  let reef: TreeReef;
+  let placement: TreePlacement;
+
+  beforeEach(() => {
+    reef = new TreeReef();
+    placement = new TreePlacement(reef);
+  });
+
+  // Test 1: valid parent + index returns a Mesh and adds it to ghostAnchor
+  test('showGhost with valid parent + index returns a Mesh and adds it to ghostAnchor', () => {
+    reef.addPiece(makeRoot(1)); // starburst: 4 attach points
+
+    const ghost = placement.showGhost('forked', 99, 'neon-cyan', 1, 0);
+
+    expect(ghost).toBeInstanceOf(Mesh);
+    expect(placement.ghostAnchor.children).toHaveLength(1);
+    expect(placement.ghostAnchor.children[0]).toBe(ghost);
+  });
+
+  // Test 2: unknown parentId returns null
+  test('showGhost with unknown parentId returns null and leaves ghostAnchor empty', () => {
+    const ghost = placement.showGhost('forked', 1, 'neon-cyan', 9999, 0);
+
+    expect(ghost).toBeNull();
+    expect(placement.ghostAnchor.children).toHaveLength(0);
+  });
+
+  // Test 3: out-of-range attachIndex returns null
+  test('showGhost with out-of-range attachIndex returns null', () => {
+    reef.addPiece(makeRoot(1)); // starburst has 4 attach points (0–3)
+
+    const ghost = placement.showGhost('forked', 1, 'neon-cyan', 1, 99);
+
+    expect(ghost).toBeNull();
+    expect(placement.ghostAnchor.children).toHaveLength(0);
+  });
+
+  // Test 4: collision rejection via mocked allWorldBoxes
+  test('showGhost returns null when the proposed AABB overlaps existing pieces', () => {
+    reef.addPiece(makeRoot(1));
+
+    // Mock allWorldBoxes to return a box that definitely covers world-space origin region,
+    // which is where the ghost for attach index 0 of the root starburst would be placed.
+    // By returning a very large box, we guarantee intersection with any proposed placement.
+    const hugeBox = new Box3(new Vector3(-100, -100, -100), new Vector3(100, 100, 100));
+    vi.spyOn(reef, 'allWorldBoxes').mockImplementation(function* () {
+      yield hugeBox;
+    });
+
+    const ghost = placement.showGhost('forked', 1, 'neon-cyan', 1, 0);
+
+    expect(ghost).toBeNull();
+    expect(placement.ghostAnchor.children).toHaveLength(0);
+  });
+
+  // Test 5: ghost material is semi-transparent
+  test('showGhost sets the ghost material to transparent with reduced opacity', () => {
+    reef.addPiece(makeRoot(1));
+
+    const ghost = placement.showGhost('forked', 1, 'neon-cyan', 1, 0);
+
+    expect(ghost).not.toBeNull();
+    const mat = ghost!.material as MeshStandardMaterial;
+    expect(mat.transparent).toBe(true);
+    expect(mat.opacity).toBeCloseTo(0.45, 5);
+    expect(mat.emissiveIntensity).toBeCloseTo(0.6, 5);
+  });
+
+  // Test 6: reset removes ghost from ghostAnchor and clears pending
+  test('reset removes the ghost from ghostAnchor and clears pending', () => {
+    reef.addPiece(makeRoot(1));
+
+    const ghost = placement.showGhost('forked', 1, 'neon-cyan', 1, 0);
+    expect(ghost).not.toBeNull();
+    expect(placement.ghostAnchor.children).toHaveLength(1);
+    expect(placement.getPending()).not.toBeNull();
+
+    placement.reset();
+
+    expect(placement.ghostAnchor.children).toHaveLength(0);
+    expect(placement.getPending()).toBeNull();
+  });
+
+  // Test 7: getPending returns the correct pending intent
+  test('getPending returns the current pending intent', () => {
+    reef.addPiece(makeRoot(1));
+
+    expect(placement.getPending()).toBeNull();
+
+    placement.showGhost('trident', 77, 'neon-magenta', 1, 2);
+
+    const pending = placement.getPending();
+    expect(pending).not.toBeNull();
+    expect(pending!.variant).toBe('trident');
+    expect(pending!.seed).toBe(77);
+    expect(pending!.colorKey).toBe('neon-magenta');
+    expect(pending!.parentId).toBe(1);
+    expect(pending!.attachIndex).toBe(2);
+  });
+
+  // Bonus: calling showGhost twice replaces the first ghost (reset is called internally)
+  test('calling showGhost twice replaces the first ghost — ghostAnchor never accumulates', () => {
+    reef.addPiece(makeRoot(1)); // starburst: 4 slots (0–3)
+
+    const first = placement.showGhost('forked', 1, 'neon-cyan', 1, 0);
+    expect(placement.ghostAnchor.children).toHaveLength(1);
+
+    const second = placement.showGhost('forked', 2, 'neon-magenta', 1, 1);
+    expect(placement.ghostAnchor.children).toHaveLength(1);
+    expect(placement.ghostAnchor.children[0]).toBe(second);
+    expect(placement.ghostAnchor.children[0]).not.toBe(first);
+  });
+
+  // Extra: ghostAnchor is a Group (verifying the public property type)
+  test('ghostAnchor is a Group', () => {
+    expect(placement.ghostAnchor).toBeInstanceOf(Group);
+  });
+});

--- a/packages/client/src/tree/placement.ts
+++ b/packages/client/src/tree/placement.ts
@@ -1,0 +1,100 @@
+import { Box3, Group, Matrix4, Mesh, Quaternion, Vector3 } from 'three';
+import type { TreeVariant } from '@reef/shared';
+import type { TreeReef } from './reef.js';
+import { generateTreeVariantMesh } from './variants.js';
+import { wouldCollide } from './collision.js';
+
+export interface PendingTreePiece {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+  parentId: number;
+  attachIndex: number;
+}
+
+export class TreePlacement {
+  readonly ghostAnchor = new Group();
+  private ghost: Mesh | null = null;
+  private pending: PendingTreePiece | null = null;
+
+  constructor(private readonly reef: TreeReef) {}
+
+  /**
+   * Compute where a child piece would be placed at (parentId, attachIndex).
+   * If the resulting world AABB collides with any existing piece, return null
+   * (placement blocked). Otherwise: spawn a semi-opaque ghost mesh, wire it
+   * into ghostAnchor, record the pending intent, and return the ghost.
+   */
+  showGhost(
+    variant: TreeVariant,
+    seed: number,
+    colorKey: string,
+    parentId: number,
+    attachIndex: number,
+  ): Mesh | null {
+    this.reset();
+
+    const parent = this.reef.getPieceEntry(parentId);
+    if (!parent) return null;
+    const attach = parent.worldAttachPoints[attachIndex];
+    if (!attach) return null;
+
+    const generated = generateTreeVariantMesh({ variant, seed, colorKey });
+
+    // Same composition logic as TreeReef.addPiece — mirror it.
+    const quat = new Quaternion().setFromUnitVectors(
+      new Vector3(0, 1, 0),
+      new Vector3(attach.normal.x, attach.normal.y, attach.normal.z).normalize(),
+    );
+    const position = new Vector3(attach.position.x, attach.position.y, attach.position.z);
+    const matrix = new Matrix4().compose(position, quat, new Vector3(1, 1, 1));
+
+    generated.mesh.applyMatrix4(matrix);
+    const worldBox = generated.boundingBox.clone().applyMatrix4(matrix);
+
+    // Reject if colliding with any existing piece other than the parent itself.
+    // The new piece attaches to the parent, so their bounding boxes will naturally
+    // overlap — exclude the parent's world box from the collision set.
+    const parentBox = parent.worldBox;
+    const otherBoxes = (function* (all: Iterable<Box3>) {
+      for (const b of all) {
+        if (b !== parentBox) yield b;
+      }
+    })(this.reef.allWorldBoxes());
+
+    if (wouldCollide(worldBox, otherBoxes)) {
+      generated.mesh.geometry.dispose();
+      (generated.mesh.material as { dispose: () => void }).dispose();
+      return null;
+    }
+
+    // Make it visually a ghost: lower opacity, enable transparent.
+    const mat = generated.mesh.material as unknown as {
+      transparent: boolean;
+      opacity: number;
+      emissiveIntensity: number;
+    };
+    mat.transparent = true;
+    mat.opacity = 0.45;
+    mat.emissiveIntensity = 0.6;
+
+    this.ghost = generated.mesh;
+    this.pending = { variant, seed, colorKey, parentId, attachIndex };
+    this.ghostAnchor.add(generated.mesh);
+    return generated.mesh;
+  }
+
+  reset(): void {
+    if (this.ghost) {
+      this.ghostAnchor.remove(this.ghost);
+      this.ghost.geometry.dispose();
+      (this.ghost.material as { dispose: () => void }).dispose();
+      this.ghost = null;
+    }
+    this.pending = null;
+  }
+
+  getPending(): PendingTreePiece | null {
+    return this.pending;
+  }
+}

--- a/packages/client/src/tree/reef.test.ts
+++ b/packages/client/src/tree/reef.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { Mesh, Vector3 } from 'three';
+import type { PublicTreePolyp } from '@reef/shared';
+import { TreeReef } from './reef.js';
+
+// Attach counts per variant (from variants.test.ts)
+// starburst: 4, forked: 2, trident: 3
+
+function makeRoot(id = 1): PublicTreePolyp {
+  return {
+    id,
+    variant: 'starburst',
+    seed: 42,
+    colorKey: 'neon-cyan',
+    parentId: null,
+    attachIndex: 0,
+    createdAt: Date.now(),
+  };
+}
+
+function makeChild(
+  id: number,
+  parentId: number,
+  attachIndex = 0,
+  variant: PublicTreePolyp['variant'] = 'forked',
+): PublicTreePolyp {
+  return {
+    id,
+    variant,
+    seed: id * 7,
+    colorKey: 'neon-magenta',
+    parentId,
+    attachIndex,
+    createdAt: Date.now() + id,
+  };
+}
+
+describe('TreeReef', () => {
+  let reef: TreeReef;
+
+  beforeEach(() => {
+    reef = new TreeReef();
+  });
+
+  // Test 1: addPiece(root)
+  test('addPiece(root) adds mesh under anchor and getPiece returns it', () => {
+    const root = makeRoot(1);
+    reef.addPiece(root);
+    expect(reef.anchor.children).toHaveLength(1);
+    const mesh = reef.getPiece(1);
+    expect(mesh).toBeInstanceOf(Mesh);
+  });
+
+  // Test 2: addPiece(child) — world position close to parent's first attach point
+  test('addPiece(child) places child at parent world attach-point position', () => {
+    const root = makeRoot(1);
+    reef.addPiece(root);
+
+    // Retrieve root's actual first attach point world position via getAvailableAttachPoints
+    const rootPoints = reef.getAvailableAttachPoints().filter((p) => p.parentId === 1);
+    expect(rootPoints.length).toBeGreaterThan(0);
+    const attachPoint0 = rootPoints.find((p) => p.index === 0)!;
+
+    const child = makeChild(2, 1, 0);
+    reef.addPiece(child);
+
+    expect(reef.anchor.children).toHaveLength(2);
+    const childMesh = reef.getPiece(2)!;
+    expect(childMesh).toBeInstanceOf(Mesh);
+
+    // Child's world position (mesh origin after applyMatrix4) should be at attach point
+    // We verify by checking the child appears in the scene and the slot is now claimed
+    const pointsAfterChild = reef.getAvailableAttachPoints().filter((p) => p.parentId === 1 && p.index === 0);
+    expect(pointsAfterChild).toHaveLength(0); // slot 0 is claimed
+  });
+
+  // Test 3: addPiece throws when parent not registered
+  test('addPiece throws when parent is not yet registered', () => {
+    const child = makeChild(2, 999, 0);
+    expect(() => reef.addPiece(child)).toThrow(/parent 999 not registered/i);
+  });
+
+  // Test 4: addPiece throws when attach index is out of range
+  test('addPiece throws when attach index is out of range for parent', () => {
+    const root = makeRoot(1); // starburst has 4 attach points (indices 0-3)
+    reef.addPiece(root);
+    const child = makeChild(2, 1, 99); // index 99 doesn't exist
+    expect(() => reef.addPiece(child)).toThrow(/no attach index 99/i);
+  });
+
+  // Test 5: removePiece
+  test('removePiece removes mesh from anchor and clears registry', () => {
+    const root = makeRoot(1);
+    reef.addPiece(root);
+    reef.removePiece(1);
+    expect(reef.anchor.children).toHaveLength(0);
+    expect(reef.getPiece(1)).toBeUndefined();
+  });
+
+  test('removePiece releases claimed slot when child is removed', () => {
+    const root = makeRoot(1);
+    reef.addPiece(root);
+    const child = makeChild(2, 1, 0);
+    reef.addPiece(child);
+
+    // Slot 0 is claimed
+    const beforeRemoval = reef.getAvailableAttachPoints().filter((p) => p.parentId === 1 && p.index === 0);
+    expect(beforeRemoval).toHaveLength(0);
+
+    reef.removePiece(2);
+
+    // Slot 0 should be available again
+    const afterRemoval = reef.getAvailableAttachPoints().filter((p) => p.parentId === 1 && p.index === 0);
+    expect(afterRemoval).toHaveLength(1);
+  });
+
+  test('removePiece is a no-op for unknown id', () => {
+    expect(() => reef.removePiece(9999)).not.toThrow();
+  });
+
+  // Test 6: getAvailableAttachPoints
+  test('getAvailableAttachPoints: root starburst exposes 4 slots, child claims one', () => {
+    const root = makeRoot(1); // starburst: 4 attach points
+    reef.addPiece(root);
+
+    const beforeChild = reef.getAvailableAttachPoints().filter((p) => p.parentId === 1);
+    expect(beforeChild).toHaveLength(4);
+
+    // Attach a child at index 0 (forked: 2 attach points)
+    const child = makeChild(2, 1, 0, 'forked');
+    reef.addPiece(child);
+
+    const afterChild = reef.getAvailableAttachPoints();
+    const rootSlots = afterChild.filter((p) => p.parentId === 1);
+    const childSlots = afterChild.filter((p) => p.parentId === 2);
+
+    expect(rootSlots).toHaveLength(3); // index 0 claimed
+    expect(childSlots).toHaveLength(2); // forked has 2 slots, none claimed
+    expect(afterChild).toHaveLength(5);
+  });
+
+  test('getAvailableAttachPoints returns Vector3 worldPos and worldNormal', () => {
+    reef.addPiece(makeRoot(1));
+    const points = reef.getAvailableAttachPoints();
+    for (const p of points) {
+      expect(p.worldPos).toBeInstanceOf(Vector3);
+      expect(p.worldNormal).toBeInstanceOf(Vector3);
+      // Normal should be unit-length
+      expect(p.worldNormal.length()).toBeCloseTo(1, 3);
+    }
+  });
+
+  // Test 7: allPieces yields all registered pieces
+  test('allPieces yields all registered pieces', () => {
+    reef.addPiece(makeRoot(1));
+    reef.addPiece(makeChild(2, 1, 0));
+    reef.addPiece(makeChild(3, 1, 1));
+
+    const pieces = [...reef.allPieces()];
+    expect(pieces).toHaveLength(3);
+    const ids = pieces.map((p) => p.polyp.id).sort();
+    expect(ids).toEqual([1, 2, 3]);
+    for (const { mesh } of pieces) {
+      expect(mesh).toBeInstanceOf(Mesh);
+    }
+  });
+
+  // Test 8: 2-deep chain world position — grandchild is transformed twice
+  test('2-deep chain: grandchild world position differs from child attach-point raw values', () => {
+    // Root at origin
+    const root = makeRoot(1); // starburst
+    reef.addPiece(root);
+
+    // Child claims root's slot 0
+    const child = makeChild(2, 1, 0, 'forked'); // forked: 2 attach points
+    reef.addPiece(child);
+
+    // Grandchild claims child's slot 0
+    const grandchild = makeChild(3, 2, 0, 'starburst');
+    reef.addPiece(grandchild);
+
+    expect(reef.anchor.children).toHaveLength(3);
+
+    // Get grandchild's world attach points (none claimed)
+    const allPoints = reef.getAvailableAttachPoints();
+    const childSlots = allPoints.filter((p) => p.parentId === 2);
+    const grandchildSlots = allPoints.filter((p) => p.parentId === 3);
+
+    // Child slot 0 is claimed by grandchild, so only slot 1 remains
+    expect(childSlots).toHaveLength(1);
+    expect(childSlots[0]!.index).toBe(1);
+
+    // Grandchild has starburst: 4 attach points, none claimed
+    expect(grandchildSlots).toHaveLength(4);
+
+    // Core rotation-frame check:
+    // Grandchild's world attach point positions must differ from root's attach point positions
+    // (they've been rotated twice through the parent chain)
+    const rootSlots = allPoints.filter((p) => p.parentId === 1);
+    // grandchild slots' world positions should not coincide with root slots
+    if (grandchildSlots.length > 0 && rootSlots.length > 0) {
+      const gcPos = grandchildSlots[0]!.worldPos;
+      const rootPos = rootSlots[0]!.worldPos;
+      // They are distinct pieces at distinct world positions (unless degenerate geometry)
+      // At minimum, the grandchild's position has been double-transformed
+      const dist = gcPos.distanceTo(new Vector3(0, 0, 0));
+      // Root is at origin so its attach points are close to origin
+      // Grandchild is at least one attach-point distance away from root,
+      // and further from origin than rootPos (which is right at origin radius)
+      // This is a weak sanity check: grandchild is not at the exact same spot as root
+      expect(gcPos.distanceTo(new Vector3(0, 0, 0))).not.toBeCloseTo(0, 3);
+      // Grandchild's position should be further from origin than root attach point positions
+      // (it was placed at a child which was placed away from origin)
+      const rootAttachDist = rootPos.length();
+      // grandchild world attach points start from child's world position, which is away from origin
+      // so at minimum they should be further than the raw root attach dist
+      expect(dist).toBeGreaterThan(rootAttachDist * 0.5);
+    }
+  });
+
+  // addPiece is idempotent
+  test('addPiece is idempotent — calling twice does not duplicate mesh', () => {
+    const root = makeRoot(1);
+    reef.addPiece(root);
+    reef.addPiece(root); // second call is no-op
+    expect(reef.anchor.children).toHaveLength(1);
+  });
+});

--- a/packages/client/src/tree/reef.ts
+++ b/packages/client/src/tree/reef.ts
@@ -1,0 +1,178 @@
+import { Box3, Group, Matrix4, Mesh, Quaternion, Vector3 } from 'three';
+import type { AttachPoint, PublicTreePolyp } from '@reef/shared';
+import { generateTreeVariantMesh } from './variants.js';
+
+interface RegisteredPiece {
+  polyp: PublicTreePolyp;
+  mesh: Mesh;
+  localAttachPoints: AttachPoint[];
+  worldAttachPoints: AttachPoint[];
+  worldBox: Box3;
+}
+
+/**
+ * Tree-aware registry of rendered pieces.
+ *
+ * Placement depends on parent pieces: root pieces are placed at the origin;
+ * child pieces are placed at the parent's world attach-point, oriented so
+ * the child's local +Y aligns with the parent attach-point normal.
+ *
+ * Insertion order requirement: parents must be added before children.
+ * The caller (Task 23) is responsible for ordering (e.g., sort by createdAt ASC).
+ */
+export class TreeReef {
+  readonly anchor: Group = new Group();
+  private byId = new Map<number, RegisteredPiece>();
+  /** Tracks which (parentId/attachIndex) slots have been claimed by a child piece. */
+  private claimedSlots = new Set<string>();
+
+  addPiece(polyp: PublicTreePolyp): void {
+    if (this.byId.has(polyp.id)) return;
+
+    const generated = generateTreeVariantMesh({
+      variant: polyp.variant,
+      seed: polyp.seed,
+      colorKey: polyp.colorKey,
+    });
+
+    // Compute world transform matrix for this piece.
+    const matrix = new Matrix4();
+
+    if (polyp.parentId === null) {
+      // Root: identity transform — local +Y is world +Y.
+      matrix.identity();
+    } else {
+      const parent = this.byId.get(polyp.parentId);
+      if (!parent) {
+        throw new Error(
+          `TreeReef.addPiece: parent ${polyp.parentId} not registered yet — insert parents before children`,
+        );
+      }
+      const attach = parent.worldAttachPoints[polyp.attachIndex];
+      if (!attach) {
+        throw new Error(
+          `TreeReef.addPiece: parent ${polyp.parentId} has no attach index ${polyp.attachIndex}`,
+        );
+      }
+
+      // Rotate so this piece's local +Y aligns with the parent's world attach-point normal.
+      const localUp = new Vector3(0, 1, 0);
+      const targetNormal = new Vector3(
+        attach.normal.x,
+        attach.normal.y,
+        attach.normal.z,
+      ).normalize();
+      const quat = new Quaternion().setFromUnitVectors(localUp, targetNormal);
+
+      const position = new Vector3(attach.position.x, attach.position.y, attach.position.z);
+      matrix.compose(position, quat, new Vector3(1, 1, 1));
+    }
+
+    // Apply world transform directly to the mesh's vertex data.
+    // After this call, the mesh is already in world space (under anchor).
+    generated.mesh.applyMatrix4(matrix);
+    this.anchor.add(generated.mesh);
+
+    // Transform local attach points into world space using the same matrix.
+    const rotationMatrix = new Matrix4().extractRotation(matrix);
+    const worldAttachPoints: AttachPoint[] = generated.attachPointsLocal.map((ap) => {
+      const wPos = new Vector3(ap.position.x, ap.position.y, ap.position.z).applyMatrix4(matrix);
+      const wNorm = new Vector3(ap.normal.x, ap.normal.y, ap.normal.z)
+        .applyMatrix4(rotationMatrix)
+        .normalize();
+      return {
+        position: { x: wPos.x, y: wPos.y, z: wPos.z },
+        normal: { x: wNorm.x, y: wNorm.y, z: wNorm.z },
+      };
+    });
+
+    // Transform local bounding box into world space.
+    const worldBox = generated.boundingBox.clone().applyMatrix4(matrix);
+
+    this.byId.set(polyp.id, {
+      polyp,
+      mesh: generated.mesh,
+      localAttachPoints: generated.attachPointsLocal,
+      worldAttachPoints,
+      worldBox,
+    });
+
+    // Mark the parent's slot as claimed.
+    if (polyp.parentId !== null) {
+      this.claimedSlots.add(`${polyp.parentId}/${polyp.attachIndex}`);
+    }
+  }
+
+  removePiece(id: number): void {
+    const entry = this.byId.get(id);
+    if (!entry) return;
+
+    this.anchor.remove(entry.mesh);
+    entry.mesh.geometry.dispose();
+    if (Array.isArray(entry.mesh.material)) {
+      for (const m of entry.mesh.material) m.dispose();
+    } else {
+      entry.mesh.material.dispose();
+    }
+
+    this.byId.delete(id);
+
+    if (entry.polyp.parentId !== null) {
+      this.claimedSlots.delete(`${entry.polyp.parentId}/${entry.polyp.attachIndex}`);
+    }
+  }
+
+  getPiece(id: number): Mesh | undefined {
+    return this.byId.get(id)?.mesh;
+  }
+
+  *allPieces(): Iterable<{ polyp: PublicTreePolyp; mesh: Mesh }> {
+    for (const entry of this.byId.values()) {
+      yield { polyp: entry.polyp, mesh: entry.mesh };
+    }
+  }
+
+  /** Used by collision checks and placement logic. */
+  *allWorldBoxes(): Iterable<Box3> {
+    for (const entry of this.byId.values()) {
+      yield entry.worldBox;
+    }
+  }
+
+  /**
+   * Returns all unclaimed attach points across all registered pieces, in world space.
+   *
+   * An attach point is claimed when a child piece references (parentId, attachIndex).
+   * Walk all pieces; for each, skip any slot already in claimedSlots.
+   */
+  getAvailableAttachPoints(): Array<{
+    parentId: number;
+    index: number;
+    worldPos: Vector3;
+    worldNormal: Vector3;
+  }> {
+    const out: Array<{
+      parentId: number;
+      index: number;
+      worldPos: Vector3;
+      worldNormal: Vector3;
+    }> = [];
+
+    for (const entry of this.byId.values()) {
+      for (let i = 0; i < entry.worldAttachPoints.length; i++) {
+        const slotKey = `${entry.polyp.id}/${i}`;
+        if (this.claimedSlots.has(slotKey)) continue;
+
+        const ap = entry.worldAttachPoints[i]!;
+        out.push({
+          parentId: entry.polyp.id,
+          index: i,
+          worldPos: new Vector3(ap.position.x, ap.position.y, ap.position.z),
+          worldNormal: new Vector3(ap.normal.x, ap.normal.y, ap.normal.z),
+        });
+      }
+    }
+
+    return out;
+  }
+}

--- a/packages/client/src/tree/reef.ts
+++ b/packages/client/src/tree/reef.ts
@@ -126,6 +126,13 @@ export class TreeReef {
     return this.byId.get(id)?.mesh;
   }
 
+  /** Returns the world attach points and world bounding box for a registered piece, or undefined if not found. */
+  getPieceEntry(id: number): { worldAttachPoints: AttachPoint[]; worldBox: Box3 } | undefined {
+    const entry = this.byId.get(id);
+    if (!entry) return undefined;
+    return { worldAttachPoints: entry.worldAttachPoints, worldBox: entry.worldBox };
+  }
+
   *allPieces(): Iterable<{ polyp: PublicTreePolyp; mesh: Mesh }> {
     for (const entry of this.byId.values()) {
       yield { polyp: entry.polyp, mesh: entry.mesh };

--- a/packages/client/src/tree/scene.test.ts
+++ b/packages/client/src/tree/scene.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { Mesh } from 'three';
+import { createTreePedestal } from './scene.js';
+
+// createBloomComposer requires a live WebGLRenderer which happy-dom cannot
+// provide (no WebGL context). Only createTreePedestal is exercised here.
+
+describe('createTreePedestal', () => {
+  test('returns a Mesh with non-null geometry and material', () => {
+    const mesh = createTreePedestal();
+    expect(mesh).toBeInstanceOf(Mesh);
+    expect(mesh.geometry).not.toBeNull();
+    expect(mesh.material).not.toBeNull();
+  });
+
+  test('pedestal sits below world origin (position.y is negative)', () => {
+    const mesh = createTreePedestal();
+    expect(mesh.position.y).toBeLessThan(0);
+  });
+});

--- a/packages/client/src/tree/scene.ts
+++ b/packages/client/src/tree/scene.ts
@@ -1,0 +1,50 @@
+import {
+  CylinderGeometry,
+  Mesh,
+  MeshStandardMaterial,
+  Scene,
+  Vector2,
+  type PerspectiveCamera,
+  type WebGLRenderer,
+} from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+
+const PEDESTAL_RADIUS = 0.15;
+const PEDESTAL_HEIGHT = 0.04;
+
+export function createTreePedestal(): Mesh {
+  const geom = new CylinderGeometry(PEDESTAL_RADIUS, PEDESTAL_RADIUS, PEDESTAL_HEIGHT, 64);
+  const mat = new MeshStandardMaterial({ color: 0x0a0f18, roughness: 0.95, metalness: 0.0 });
+  const mesh = new Mesh(geom, mat);
+  mesh.position.y = -PEDESTAL_HEIGHT / 2;
+  return mesh;
+}
+
+export interface BloomSetup {
+  composer: EffectComposer;
+  bloomPass: UnrealBloomPass;
+  render: () => void;
+}
+
+export function createBloomComposer(
+  renderer: WebGLRenderer,
+  scene: Scene,
+  camera: PerspectiveCamera,
+): BloomSetup {
+  const composer = new EffectComposer(renderer);
+  composer.addPass(new RenderPass(scene, camera));
+  const bloomPass = new UnrealBloomPass(
+    new Vector2(renderer.domElement.width, renderer.domElement.height),
+    1.2,  // strength
+    0.6,  // radius
+    0.4,  // threshold
+  );
+  composer.addPass(bloomPass);
+  return {
+    composer,
+    bloomPass,
+    render: (): void => { composer.render(); },
+  };
+}

--- a/packages/client/src/tree/variants.test.ts
+++ b/packages/client/src/tree/variants.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import { Mesh, Box3, MeshStandardMaterial } from 'three';
+import { generateTreeVariantMesh } from './variants.js';
+
+const VARIANTS = ['forked', 'trident', 'starburst', 'claw', 'wishbone'] as const;
+const ATTACH_COUNTS = { forked: 2, trident: 3, starburst: 4, claw: 2, wishbone: 2 };
+
+describe('generateTreeVariantMesh', () => {
+  test.each(VARIANTS)('returns a Three.Mesh for variant %s', (variant) => {
+    const result = generateTreeVariantMesh({ variant, seed: 1, colorKey: 'neon-magenta' });
+    expect(result.mesh).toBeInstanceOf(Mesh);
+    expect(result.mesh.geometry).toBeDefined();
+    expect(result.mesh.material).toBeDefined();
+  });
+
+  test.each(VARIANTS)('attach-point count matches variant %s', (variant) => {
+    const result = generateTreeVariantMesh({ variant, seed: 1, colorKey: 'neon-magenta' });
+    expect(result.attachPointsLocal).toHaveLength(ATTACH_COUNTS[variant]);
+  });
+
+  test('applies Avatar material preset (opacity 1 + high emissive)', () => {
+    const result = generateTreeVariantMesh({ variant: 'starburst', seed: 1, colorKey: 'neon-cyan' });
+    const mat = result.mesh.material as MeshStandardMaterial;
+    expect(mat.opacity).toBe(1);
+    expect(mat.transparent).toBe(false);
+    expect(mat.emissiveIntensity).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test('returns a Box3 bounding box', () => {
+    const result = generateTreeVariantMesh({ variant: 'forked', seed: 1, colorKey: 'neon-magenta' });
+    expect(result.boundingBox).toBeInstanceOf(Box3);
+    expect(result.boundingBox.isEmpty()).toBe(false);
+  });
+});

--- a/packages/client/src/tree/variants.ts
+++ b/packages/client/src/tree/variants.ts
@@ -1,0 +1,30 @@
+import { Box3, MeshStandardMaterial, Vector3 } from 'three';
+import type { Mesh } from 'three';
+import type { AttachPoint, TreeVariant } from '@reef/shared';
+import { generateTreeVariant } from '@reef/generator';
+import { polypMesh } from '../scene/meshAdapter.js';
+import { applyTreeMaterial } from './material.js';
+
+export interface TreeMeshResult {
+  mesh: Mesh;
+  attachPointsLocal: AttachPoint[];
+  boundingBox: Box3;
+}
+
+export function generateTreeVariantMesh(input: {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+}): TreeMeshResult {
+  const { mesh: meshData, attachPoints, boundingBox: bb } = generateTreeVariant(input);
+
+  const mesh = polypMesh(meshData);
+  applyTreeMaterial(mesh.material as MeshStandardMaterial);
+
+  const boundingBox = new Box3(
+    new Vector3(bb.min.x, bb.min.y, bb.min.z),
+    new Vector3(bb.max.x, bb.max.y, bb.max.z),
+  );
+
+  return { mesh, attachPointsLocal: attachPoints, boundingBox };
+}

--- a/packages/client/src/ui/treePicker.ts
+++ b/packages/client/src/ui/treePicker.ts
@@ -1,0 +1,113 @@
+import { REEF_PALETTE, type TreeVariant } from '@reef/shared';
+
+export const TREE_VARIANTS: TreeVariant[] = [
+  'forked',
+  'trident',
+  'starburst',
+  'claw',
+  'wishbone',
+];
+
+export interface TreePickerState {
+  variant: TreeVariant;
+  colorKey: string;
+}
+
+export type TreePickerListener = (s: TreePickerState) => void;
+
+/**
+ * Picker adapted for the tree mode. Works identically to the landscape Picker
+ * but selects TreeVariant ('forked' | 'trident' | 'starburst' | 'claw' |
+ * 'wishbone') via [data-variant] buttons instead of [data-species] buttons.
+ */
+export class TreePicker {
+  private state: TreePickerState;
+  private listeners: TreePickerListener[] = [];
+  private readonly root: HTMLElement;
+  private readonly growBtn: HTMLButtonElement;
+  private readonly rerollBtn: HTMLButtonElement;
+  private readonly cancelBtn: HTMLButtonElement;
+
+  constructor(root: HTMLElement) {
+    this.root = root;
+    this.growBtn = root.querySelector<HTMLButtonElement>('#growBtn')!;
+    this.rerollBtn = root.querySelector<HTMLButtonElement>('#rerollBtn')!;
+    this.cancelBtn = root.querySelector<HTMLButtonElement>('#cancelBtn')!;
+    this.state = { variant: 'forked', colorKey: REEF_PALETTE[0]!.key };
+    this.wireVariants();
+    this.renderColors();
+    this.highlight();
+  }
+
+  onChange(l: TreePickerListener): void { this.listeners.push(l); }
+  get(): TreePickerState { return this.state; }
+
+  setCommittable(ok: boolean): void {
+    this.growBtn.disabled = !ok;
+    this.rerollBtn.disabled = !ok;
+    this.cancelBtn.disabled = !ok;
+  }
+
+  setSubmitting(inFlight: boolean): void {
+    this.growBtn.disabled = inFlight || this.growBtn.disabled;
+    this.growBtn.textContent = inFlight ? 'Growing…' : 'Grow it';
+    this.rerollBtn.disabled = inFlight;
+    this.cancelBtn.disabled = inFlight;
+  }
+
+  onCommit(cb: () => void): void { this.growBtn.addEventListener('click', cb); }
+  onReroll(cb: () => void): void { this.rerollBtn.addEventListener('click', cb); }
+  onCancel(cb: () => void): void { this.cancelBtn.addEventListener('click', cb); }
+
+  show(): void { this.root.classList.remove('hidden'); }
+  hide(): void { this.root.classList.add('hidden'); }
+
+  private wireVariants(): void {
+    for (const btn of this.root.querySelectorAll<HTMLButtonElement>('[data-variant]')) {
+      btn.addEventListener('click', () => {
+        const v = btn.dataset.variant as TreeVariant;
+        if (!TREE_VARIANTS.includes(v)) return;
+        this.state = { ...this.state, variant: v };
+        this.highlight();
+        this.emit();
+      });
+    }
+  }
+
+  private renderColors(): void {
+    const colors = this.root.querySelector('#colors');
+    if (!colors) return;
+    for (const entry of REEF_PALETTE) {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'swatch';
+      b.dataset.color = entry.key;
+      b.style.backgroundColor = entry.hex;
+      b.title = entry.name;
+      b.setAttribute('aria-label', entry.name);
+      b.addEventListener('click', () => {
+        this.state = { ...this.state, colorKey: entry.key };
+        this.highlight();
+        this.emit();
+      });
+      colors.appendChild(b);
+    }
+  }
+
+  private highlight(): void {
+    for (const btn of this.root.querySelectorAll<HTMLButtonElement>('[data-variant]')) {
+      const active = btn.dataset.variant === this.state.variant;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-pressed', String(active));
+    }
+    for (const btn of this.root.querySelectorAll<HTMLButtonElement>('.swatch')) {
+      const active = btn.dataset.color === this.state.colorKey;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-pressed', String(active));
+    }
+  }
+
+  private emit(): void {
+    for (const l of this.listeners) l(this.state);
+  }
+}

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -21,12 +21,12 @@
   <canvas id="gl"></canvas>
   <div id="mode-badge"></div>
   <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
-    <div class="picker-row" role="group" aria-label="Species">
-      <button type="button" data-species="branching">Branching</button>
-      <button type="button" data-species="bulbous">Bulbous</button>
-      <button type="button" data-species="fan">Fan</button>
-      <button type="button" data-species="tube">Tube</button>
-      <button type="button" data-species="encrusting">Encrusting</button>
+    <div class="picker-row" role="group" aria-label="Variant">
+      <button type="button" data-variant="forked">Forked</button>
+      <button type="button" data-variant="trident">Trident</button>
+      <button type="button" data-variant="starburst">Starburst</button>
+      <button type="button" data-variant="claw">Claw</button>
+      <button type="button" data-variant="wishbone">Wishbone</button>
     </div>
     <div id="colors" class="picker-row" role="group" aria-label="Color"></div>
     <div class="picker-actions">

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#01060d" />
+  <title>Coral Reef — Tree</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+  <style>
+    body { margin: 0; background: #01060d; overflow: hidden; }
+    #gl { display: block; width: 100vw; height: 100vh; }
+    #mode-badge {
+      position: fixed; top: 12px; left: 12px; padding: 4px 8px;
+      font: 500 11px/1 system-ui, sans-serif; color: #9ab;
+      background: rgba(0,0,0,0.35); border-radius: 3px;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="gl"></canvas>
+  <div id="mode-badge"></div>
+  <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
+    <div class="picker-row" role="group" aria-label="Species">
+      <button type="button" data-species="branching">Branching</button>
+      <button type="button" data-species="bulbous">Bulbous</button>
+      <button type="button" data-species="fan">Fan</button>
+      <button type="button" data-species="tube">Tube</button>
+      <button type="button" data-species="encrusting">Encrusting</button>
+    </div>
+    <div id="colors" class="picker-row" role="group" aria-label="Color"></div>
+    <div class="picker-actions">
+      <button id="rerollBtn" type="button" disabled aria-label="Regenerate shape">Reroll shape</button>
+      <button id="cancelBtn" type="button" disabled aria-label="Cancel placement">Cancel</button>
+    </div>
+    <button id="growBtn" type="button" disabled>Grow it</button>
+    <p id="hint" aria-live="polite">Click the pedestal to place your polyp.</p>
+  </div>
+  <a id="admin-link" style="display:none"></a>
+  <script type="module" src="/src/tree.ts"></script>
+</body>
+</html>

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         preview: resolve(import.meta.dirname, 'preview.html'),
         timelapse: resolve(import.meta.dirname, 'timelapse.html'),
         playground: resolve(import.meta.dirname, 'playground.html'),
+        tree: resolve(import.meta.dirname, 'tree.html'),
       },
       output: {
         // Pull Three.js into its own vendor chunk so all three HTML entries

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -2,3 +2,4 @@ export * from './rng.js';
 export * from './meshdata.js';
 export { generatePolyp } from './generate.js';
 export type { GenerateOptions, GeneratedPolyp } from './generate.js';
+export * from './tree/index.js';

--- a/packages/generator/src/species/_common.ts
+++ b/packages/generator/src/species/_common.ts
@@ -1,6 +1,15 @@
+import { hexToRgb, paletteByKey } from '@reef/shared';
 import type { RNG } from '../rng.js';
 
 export type Rgb = [number, number, number];
+
+/**
+ * Resolve a palette key to a normalised [r, g, b] triple in [0, 1]^3.
+ * Used by tree-mode variant generators that receive a colorKey string.
+ */
+export function colorVec3(colorKey: string): Rgb {
+  return hexToRgb(paletteByKey(colorKey).hex);
+}
 
 export function tintColor(rng: RNG, base: Rgb, jitter = 0.12): Rgb {
   return [

--- a/packages/generator/src/tree/index.test.ts
+++ b/packages/generator/src/tree/index.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateTreeVariant } from './index.js';
+
+describe('generateTreeVariant', () => {
+  test('dispatches to each of the 5 variants', () => {
+    const variants = ['forked', 'trident', 'starburst', 'claw', 'wishbone'] as const;
+    for (const v of variants) {
+      const out = generateTreeVariant({ variant: v, seed: 1, colorKey: 'neon-cyan' });
+      assert.ok(out.mesh.positions.length > 0, `${v} should produce non-empty mesh`);
+      assert.ok(out.attachPoints.length > 0, `${v} should expose attach points`);
+    }
+  });
+
+  test('is deterministic per (variant, seed, colorKey)', () => {
+    const a = generateTreeVariant({ variant: 'starburst', seed: 42, colorKey: 'neon-magenta' });
+    const b = generateTreeVariant({ variant: 'starburst', seed: 42, colorKey: 'neon-magenta' });
+    assert.deepEqual(Array.from(a.mesh.positions), Array.from(b.mesh.positions));
+  });
+
+  test('throws on unknown variant', () => {
+    assert.throws(() => generateTreeVariant({
+      variant: 'rubbish' as never, seed: 1, colorKey: 'neon-magenta',
+    }));
+  });
+});

--- a/packages/generator/src/tree/index.ts
+++ b/packages/generator/src/tree/index.ts
@@ -1,0 +1,30 @@
+import type { TreeVariant } from '@reef/shared';
+import type { VariantOutput } from './variant.js';
+import { generateForked } from './variants/forked.js';
+import { generateTrident } from './variants/trident.js';
+import { generateStarburst } from './variants/starburst.js';
+import { generateClaw } from './variants/claw.js';
+import { generateWishbone } from './variants/wishbone.js';
+
+export interface GenerateInput {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+}
+
+export function generateTreeVariant(input: GenerateInput): VariantOutput {
+  switch (input.variant) {
+    case 'forked':    return generateForked(input);
+    case 'trident':   return generateTrident(input);
+    case 'starburst': return generateStarburst(input);
+    case 'claw':      return generateClaw(input);
+    case 'wishbone':  return generateWishbone(input);
+    default: {
+      const _exhaustive: never = input.variant;
+      throw new Error(`unknown tree variant: ${_exhaustive as string}`);
+    }
+  }
+}
+
+export { tipAttachPoint } from './variant.js';
+export type { VariantOutput, VariantGenerateInput } from './variant.js';

--- a/packages/generator/src/tree/variant.test.ts
+++ b/packages/generator/src/tree/variant.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { tipAttachPoint } from './variant.js';
+
+describe('tipAttachPoint', () => {
+  test('constructs an attach point from a local-space tip position + outward direction', () => {
+    const ap = tipAttachPoint({ x: 0, y: 0.1, z: 0 }, { x: 0, y: 1, z: 0 });
+    assert.deepEqual(ap.position, { x: 0, y: 0.1, z: 0 });
+    assert.deepEqual(ap.normal, { x: 0, y: 1, z: 0 });
+  });
+
+  test('normalizes the outward direction', () => {
+    const ap = tipAttachPoint({ x: 0, y: 0, z: 0 }, { x: 3, y: 4, z: 0 });
+    assert.ok(Math.abs(ap.normal.x - 0.6) < 0.0001, `expected x ≈ 0.6, got ${ap.normal.x}`);
+    assert.ok(Math.abs(ap.normal.y - 0.8) < 0.0001, `expected y ≈ 0.8, got ${ap.normal.y}`);
+    assert.ok(Math.abs(ap.normal.z - 0) < 0.0001, `expected z ≈ 0, got ${ap.normal.z}`);
+  });
+});

--- a/packages/generator/src/tree/variant.ts
+++ b/packages/generator/src/tree/variant.ts
@@ -1,0 +1,38 @@
+import type { MeshData } from '../meshdata.js';
+import type { AttachPoint } from '@reef/shared';
+
+export interface VariantGenerateInput {
+  seed: number;
+  colorKey: string;
+}
+
+export interface VariantOutput {
+  mesh: MeshData;
+  attachPoints: AttachPoint[];
+  /** Axis-aligned bounding box in local space, used for client-side collision. */
+  boundingBox: {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+  };
+}
+
+export type VariantModule = (input: VariantGenerateInput) => VariantOutput;
+
+export function tipAttachPoint(
+  position: { x: number; y: number; z: number },
+  outwardDir: { x: number; y: number; z: number },
+): AttachPoint {
+  const len = Math.hypot(outwardDir.x, outwardDir.y, outwardDir.z) || 1;
+  return {
+    position,
+    normal: { x: outwardDir.x / len, y: outwardDir.y / len, z: outwardDir.z / len },
+  };
+}
+
+export interface TreeVariantRegistry {
+  forked: VariantModule;
+  trident: VariantModule;
+  starburst: VariantModule;
+  claw: VariantModule;
+  wishbone: VariantModule;
+}

--- a/packages/generator/src/tree/variant.ts
+++ b/packages/generator/src/tree/variant.ts
@@ -36,3 +36,118 @@ export interface TreeVariantRegistry {
   claw: VariantModule;
   wishbone: VariantModule;
 }
+
+// ---------------------------------------------------------------------------
+// Shared geometry helpers
+// ---------------------------------------------------------------------------
+
+type Vec3Obj = { x: number; y: number; z: number };
+type ColorInput = Vec3Obj | readonly [number, number, number];
+
+function colorR(c: ColorInput): number { return Array.isArray(c) ? (c as readonly number[])[0]! : (c as Vec3Obj).x; }
+function colorG(c: ColorInput): number { return Array.isArray(c) ? (c as readonly number[])[1]! : (c as Vec3Obj).y; }
+function colorB(c: ColorInput): number { return Array.isArray(c) ? (c as readonly number[])[2]! : (c as Vec3Obj).z; }
+
+/**
+ * Append an open-ended frustum (truncated cone) to the given geometry arrays.
+ *
+ * Orientation is arbitrary — `from`/`to` can point in any direction. The ring
+ * planes are always perpendicular to the (to − from) axis. Side-face normals
+ * use the ring-radial direction (flat-shading approximation; acceptable since
+ * the bloom pass washes out fine normal detail at phone distance).
+ *
+ * No end caps are emitted; branches terminate in tips covered by the next
+ * attached piece.
+ */
+export function emitFrustum(
+  positions: number[],
+  normals: number[],
+  colors: number[],
+  indices: number[],
+  from: Vec3Obj,
+  to: Vec3Obj,
+  r0: number,
+  r1: number,
+  color: ColorInput,
+  segments: number,
+): void {
+  const ax = to.x - from.x;
+  const ay = to.y - from.y;
+  const az = to.z - from.z;
+  const len = Math.hypot(ax, ay, az) || 1e-6;
+  const axn = ax / len, ayn = ay / len, azn = az / len;
+
+  // Build an orthonormal basis (u, v) perpendicular to the axis.
+  // Choose the seed vector away from the axis to avoid near-parallel case.
+  let ux: number, uy: number, uz: number;
+  if (Math.abs(ayn) < 0.9) {
+    ux = -azn; uy = 0; uz = axn;
+  } else {
+    ux = 1; uy = 0; uz = 0;
+  }
+  // Gram-Schmidt: ensure u is exactly perpendicular to axis.
+  const dot = axn * ux + ayn * uy + azn * uz;
+  ux -= axn * dot;
+  uy -= ayn * dot;
+  uz -= azn * dot;
+  const un = Math.hypot(ux, uy, uz) || 1e-6;
+  ux /= un; uy /= un; uz /= un;
+  // v = axis × u  (already unit length since both inputs are unit)
+  const vx = ayn * uz - azn * uy;
+  const vy = azn * ux - axn * uz;
+  const vz = axn * uy - ayn * ux;
+
+  const cr = colorR(color), cg = colorG(color), cb = colorB(color);
+  const baseIdx = positions.length / 3;
+
+  for (let i = 0; i < segments; i++) {
+    const theta = (i / segments) * Math.PI * 2;
+    const ct = Math.cos(theta), st = Math.sin(theta);
+    const nx = ux * ct + vx * st;
+    const ny = uy * ct + vy * st;
+    const nz = uz * ct + vz * st;
+
+    // Bottom vertex (at "from", radius r0)
+    positions.push(from.x + nx * r0, from.y + ny * r0, from.z + nz * r0);
+    normals.push(nx, ny, nz);
+    colors.push(cr, cg, cb);
+
+    // Top vertex (at "to", radius r1)
+    positions.push(to.x + nx * r1, to.y + ny * r1, to.z + nz * r1);
+    normals.push(nx, ny, nz);
+    colors.push(cr, cg, cb);
+  }
+
+  for (let i = 0; i < segments; i++) {
+    const a = baseIdx + i * 2;
+    const b = baseIdx + i * 2 + 1;
+    const c = baseIdx + ((i + 1) % segments) * 2;
+    const d = baseIdx + ((i + 1) % segments) * 2 + 1;
+    indices.push(a, b, d, a, d, c);
+  }
+}
+
+/**
+ * Compute an axis-aligned bounding box from a flat positions array
+ * (layout: x0, y0, z0, x1, y1, z1, …).
+ */
+export function computeAABB(positions: number[]): {
+  min: Vec3Obj;
+  max: Vec3Obj;
+} {
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i]!, y = positions[i + 1]!, z = positions[i + 2]!;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  return {
+    min: { x: minX, y: minY, z: minZ },
+    max: { x: maxX, y: maxY, z: maxZ },
+  };
+}

--- a/packages/generator/src/tree/variants/claw.test.ts
+++ b/packages/generator/src/tree/variants/claw.test.ts
@@ -1,0 +1,60 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateClaw } from './claw.js';
+
+describe('generateClaw', () => {
+  test('produces a mesh with positions/normals/colors/indices', () => {
+    const out = generateClaw({ seed: 1, colorKey: 'neon-magenta' });
+    assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
+    assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
+    assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
+    assert.strictEqual(out.mesh.colors.length, out.mesh.positions.length, 'colors length must match positions');
+    assert.strictEqual(out.mesh.indices.length % 3, 0, 'indices length must be divisible by 3');
+  });
+
+  test('exposes exactly 2 attach points (two tips of the claw)', () => {
+    const out = generateClaw({ seed: 1, colorKey: 'neon-magenta' });
+    assert.strictEqual(out.attachPoints.length, 2);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateClaw({ seed: 1, colorKey: 'neon-cyan' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
+    }
+  });
+
+  test('attach-point positions are spatially distinct', () => {
+    const [a, b] = generateClaw({ seed: 1, colorKey: 'neon-magenta' }).attachPoints;
+    const dx = a!.position.x - b!.position.x;
+    const dy = a!.position.y - b!.position.y;
+    const dz = a!.position.z - b!.position.z;
+    assert.ok(Math.hypot(dx, dy, dz) > 0.01, 'tips must be separated by more than 0.01');
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateClaw({ seed: 1, colorKey: 'neon-magenta' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      const x = out.mesh.positions[i]!;
+      const y = out.mesh.positions[i + 1]!;
+      const z = out.mesh.positions[i + 2]!;
+      assert.ok(x >= min.x - 1e-6, `position x=${x} below min.x=${min.x}`);
+      assert.ok(x <= max.x + 1e-6, `position x=${x} above max.x=${max.x}`);
+      assert.ok(y >= min.y - 1e-6, `position y=${y} below min.y=${min.y}`);
+      assert.ok(y <= max.y + 1e-6, `position y=${y} above max.y=${max.y}`);
+      assert.ok(z >= min.z - 1e-6, `position z=${z} below min.z=${min.z}`);
+      assert.ok(z <= max.z + 1e-6, `position z=${z} above max.z=${max.z}`);
+    }
+  });
+
+  test('attach-point tips are significantly offset horizontally from the trunk base', () => {
+    const out = generateClaw({ seed: 1, colorKey: 'neon-magenta' });
+    const [a, b] = out.attachPoints;
+    const aHoriz = Math.hypot(a!.position.x, a!.position.z);
+    const bHoriz = Math.hypot(b!.position.x, b!.position.z);
+    const maxHoriz = Math.max(aHoriz, bHoriz);
+    assert.ok(maxHoriz > 0.03, `at least one tip should be displaced > 0.03 horizontally, got ${maxHoriz}`);
+  });
+});

--- a/packages/generator/src/tree/variants/claw.ts
+++ b/packages/generator/src/tree/variants/claw.ts
@@ -1,0 +1,74 @@
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';
+
+const STRAIGHT_SEG_LENGTH = 0.03;
+const BENT_SEG_LENGTH = 0.035;
+const TRUNK_BASE_RADIUS = 0.008;
+const TRUNK_MID_RADIUS = 0.006;
+const TRUNK_TIP_RADIUS = 0.005;
+const CLAW_LENGTH = 0.025;
+const CLAW_BASE_RADIUS = 0.005;
+const CLAW_TIP_RADIUS = 0.002;
+const BEND_ANGLE = Math.PI / 3;              // 60° off vertical at the midpoint
+const CLAW_SPLIT_ANGLE = Math.PI / 8;        // ~22° fork angle between the two tips
+const SEGMENTS = 6;
+
+export function generateClaw(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  // Segment 1: straight up from origin to midpoint.
+  const midBase = { x: 0, y: 0, z: 0 };
+  const midApex = { x: 0, y: STRAIGHT_SEG_LENGTH, z: 0 };
+  emitFrustum(positions, normals, colors, indices,
+    midBase, midApex, TRUNK_BASE_RADIUS, TRUNK_MID_RADIUS, color, SEGMENTS);
+
+  // Segment 2: bent — from midApex in a direction tilted BEND_ANGLE off vertical toward +X.
+  const bentDir = { x: Math.sin(BEND_ANGLE), y: Math.cos(BEND_ANGLE), z: 0 };
+  const bentEnd = {
+    x: midApex.x + bentDir.x * BENT_SEG_LENGTH,
+    y: midApex.y + bentDir.y * BENT_SEG_LENGTH,
+    z: 0,
+  };
+  emitFrustum(positions, normals, colors, indices,
+    midApex, bentEnd, TRUNK_MID_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS);
+
+  // Two claw tips splitting from bentEnd — symmetric around the bentDir axis in XY plane.
+  // Rotate bentDir by ±CLAW_SPLIT_ANGLE around the Z axis.
+  const rot = (angle: number) => ({
+    x: Math.cos(angle) * bentDir.x - Math.sin(angle) * bentDir.y,
+    y: Math.sin(angle) * bentDir.x + Math.cos(angle) * bentDir.y,
+    z: 0,
+  });
+  const dirA = rot(+CLAW_SPLIT_ANGLE);
+  const dirB = rot(-CLAW_SPLIT_ANGLE);
+  const tipA = {
+    x: bentEnd.x + dirA.x * CLAW_LENGTH,
+    y: bentEnd.y + dirA.y * CLAW_LENGTH,
+    z: 0,
+  };
+  const tipB = {
+    x: bentEnd.x + dirB.x * CLAW_LENGTH,
+    y: bentEnd.y + dirB.y * CLAW_LENGTH,
+    z: 0,
+  };
+  emitFrustum(positions, normals, colors, indices,
+    bentEnd, tipA, CLAW_BASE_RADIUS, CLAW_TIP_RADIUS, color, SEGMENTS);
+  emitFrustum(positions, normals, colors, indices,
+    bentEnd, tipB, CLAW_BASE_RADIUS, CLAW_TIP_RADIUS, color, SEGMENTS);
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints: [tipAttachPoint(tipA, dirA), tipAttachPoint(tipB, dirB)],
+    boundingBox: computeAABB(positions),
+  };
+}

--- a/packages/generator/src/tree/variants/forked.test.ts
+++ b/packages/generator/src/tree/variants/forked.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateForked } from './forked.js';
+
+describe('generateForked', () => {
+  test('produces a mesh with positions/normals/indices', () => {
+    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
+    assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
+    assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
+    assert.strictEqual(out.mesh.colors.length, out.mesh.positions.length, 'colors length must match positions');
+    assert.strictEqual(out.mesh.indices.length % 3, 0, 'indices length must be divisible by 3');
+  });
+
+  test('exposes exactly 2 attach points (two tips of the Y)', () => {
+    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    assert.strictEqual(out.attachPoints.length, 2);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateForked({ seed: 1, colorKey: 'teal' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
+    }
+  });
+
+  test('attach-point tips are diverging (not identical positions)', () => {
+    const [a, b] = generateForked({ seed: 1, colorKey: 'coral-pink' }).attachPoints;
+    const dx = a!.position.x - b!.position.x;
+    const dz = a!.position.z - b!.position.z;
+    assert.ok(Math.hypot(dx, dz) > 0.01, 'tips must be laterally separated by more than 0.01');
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      const x = out.mesh.positions[i]!;
+      const y = out.mesh.positions[i + 1]!;
+      const z = out.mesh.positions[i + 2]!;
+      assert.ok(x >= min.x - 1e-6, `position x=${x} below min.x=${min.x}`);
+      assert.ok(x <= max.x + 1e-6, `position x=${x} above max.x=${max.x}`);
+      assert.ok(y >= min.y - 1e-6, `position y=${y} below min.y=${min.y}`);
+      assert.ok(y <= max.y + 1e-6, `position y=${y} above max.y=${max.y}`);
+      assert.ok(z >= min.z - 1e-6, `position z=${z} below min.z=${min.z}`);
+      assert.ok(z <= max.z + 1e-6, `position z=${z} above max.z=${max.z}`);
+    }
+  });
+});

--- a/packages/generator/src/tree/variants/forked.test.ts
+++ b/packages/generator/src/tree/variants/forked.test.ts
@@ -4,7 +4,7 @@ import { generateForked } from './forked.js';
 
 describe('generateForked', () => {
   test('produces a mesh with positions/normals/indices', () => {
-    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    const out = generateForked({ seed: 1, colorKey: 'neon-magenta' });
     assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
     assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
     assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
@@ -13,12 +13,12 @@ describe('generateForked', () => {
   });
 
   test('exposes exactly 2 attach points (two tips of the Y)', () => {
-    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    const out = generateForked({ seed: 1, colorKey: 'neon-magenta' });
     assert.strictEqual(out.attachPoints.length, 2);
   });
 
   test('attach-point normals are unit length', () => {
-    const out = generateForked({ seed: 1, colorKey: 'teal' });
+    const out = generateForked({ seed: 1, colorKey: 'neon-cyan' });
     for (const ap of out.attachPoints) {
       const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
       assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
@@ -26,14 +26,14 @@ describe('generateForked', () => {
   });
 
   test('attach-point tips are diverging (not identical positions)', () => {
-    const [a, b] = generateForked({ seed: 1, colorKey: 'coral-pink' }).attachPoints;
+    const [a, b] = generateForked({ seed: 1, colorKey: 'neon-magenta' }).attachPoints;
     const dx = a!.position.x - b!.position.x;
     const dz = a!.position.z - b!.position.z;
     assert.ok(Math.hypot(dx, dz) > 0.01, 'tips must be laterally separated by more than 0.01');
   });
 
   test('bounding box contains all vertex positions', () => {
-    const out = generateForked({ seed: 1, colorKey: 'coral-pink' });
+    const out = generateForked({ seed: 1, colorKey: 'neon-magenta' });
     const { min, max } = out.boundingBox;
     for (let i = 0; i < out.mesh.positions.length; i += 3) {
       const x = out.mesh.positions[i]!;

--- a/packages/generator/src/tree/variants/forked.ts
+++ b/packages/generator/src/tree/variants/forked.ts
@@ -1,0 +1,60 @@
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';
+
+const TRUNK_BASE_RADIUS = 0.008;
+const TRUNK_TIP_RADIUS = 0.006;
+const TRUNK_HEIGHT = 0.06;
+const BRANCH_LENGTH = 0.045;
+const BRANCH_BASE_RADIUS = 0.006;
+const BRANCH_TIP_RADIUS = 0.003;
+const BRANCH_ANGLE = Math.PI / 6; // 30°
+const SEGMENTS = 6;
+
+export function generateForked(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  // Trunk: frustum from (0,0,0) up to (0, TRUNK_HEIGHT, 0).
+  emitFrustum(
+    positions, normals, colors, indices,
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: TRUNK_HEIGHT, z: 0 },
+    TRUNK_BASE_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS,
+  );
+
+  // Two branches: diverging in ±X, each tilted BRANCH_ANGLE from vertical.
+  const tipA = {
+    x: Math.sin(BRANCH_ANGLE) * BRANCH_LENGTH,
+    y: TRUNK_HEIGHT + Math.cos(BRANCH_ANGLE) * BRANCH_LENGTH,
+    z: 0,
+  };
+  const tipB = { x: -tipA.x, y: tipA.y, z: 0 };
+  const dirA = { x: Math.sin(BRANCH_ANGLE), y: Math.cos(BRANCH_ANGLE), z: 0 };
+  const dirB = { x: -dirA.x, y: dirA.y, z: 0 };
+
+  emitFrustum(
+    positions, normals, colors, indices,
+    { x: 0, y: TRUNK_HEIGHT, z: 0 }, tipA,
+    BRANCH_BASE_RADIUS, BRANCH_TIP_RADIUS, color, SEGMENTS,
+  );
+  emitFrustum(
+    positions, normals, colors, indices,
+    { x: 0, y: TRUNK_HEIGHT, z: 0 }, tipB,
+    BRANCH_BASE_RADIUS, BRANCH_TIP_RADIUS, color, SEGMENTS,
+  );
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints: [tipAttachPoint(tipA, dirA), tipAttachPoint(tipB, dirB)],
+    boundingBox: computeAABB(positions),
+  };
+}

--- a/packages/generator/src/tree/variants/starburst.test.ts
+++ b/packages/generator/src/tree/variants/starburst.test.ts
@@ -1,0 +1,73 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateStarburst } from './starburst.js';
+
+describe('generateStarburst', () => {
+  test('produces a mesh with positions/normals/colors/indices', () => {
+    const out = generateStarburst({ seed: 1, colorKey: 'neon-magenta' });
+    assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
+    assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
+    assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
+    assert.strictEqual(out.mesh.colors.length, out.mesh.positions.length, 'colors length must match positions');
+    assert.strictEqual(out.mesh.indices.length % 3, 0, 'indices length must be divisible by 3');
+  });
+
+  test('exposes exactly 4 attach points (four cardinal tips)', () => {
+    const out = generateStarburst({ seed: 1, colorKey: 'neon-magenta' });
+    assert.strictEqual(out.attachPoints.length, 4);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateStarburst({ seed: 1, colorKey: 'neon-cyan' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
+    }
+  });
+
+  test('attach-point positions are in 4 different horizontal quadrants', () => {
+    const out = generateStarburst({ seed: 1, colorKey: 'neon-magenta' }).attachPoints;
+    // For cardinal directions (+X, +Z, -X, -Z), verify azimuth distribution
+    // Compute azimuth for each attach point
+    const azimuths = out.map(ap => Math.atan2(ap.position.z, ap.position.x));
+
+    // Rough check: the 4 azimuths should be roughly at 0, π/2, π, 3π/2
+    // Group into quadrants (±π/4 from cardinal)
+    const quadrants = [0, 0, 0, 0]; // +X, +Z, -X, -Z
+    const threshold = Math.PI / 4 + 0.1; // Allow some tolerance
+
+    for (const az of azimuths) {
+      // Normalize to [0, 2π)
+      const normalized = az < 0 ? az + 2 * Math.PI : az;
+
+      if (normalized < threshold || normalized > 2 * Math.PI - threshold) {
+        quadrants[0]!++; // +X direction (0°)
+      } else if (Math.abs(normalized - Math.PI / 2) < threshold) {
+        quadrants[1]!++; // +Z direction (90°)
+      } else if (Math.abs(normalized - Math.PI) < threshold) {
+        quadrants[2]!++; // -X direction (180°)
+      } else if (Math.abs(normalized - 3 * Math.PI / 2) < threshold) {
+        quadrants[3]!++; // -Z direction (270°)
+      }
+    }
+
+    // Each quadrant should have exactly one tip
+    assert.deepStrictEqual(quadrants, [1, 1, 1, 1], `attach points should be in 4 cardinal directions, got distribution ${quadrants}`);
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateStarburst({ seed: 1, colorKey: 'neon-magenta' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      const x = out.mesh.positions[i]!;
+      const y = out.mesh.positions[i + 1]!;
+      const z = out.mesh.positions[i + 2]!;
+      assert.ok(x >= min.x - 1e-6, `position x=${x} below min.x=${min.x}`);
+      assert.ok(x <= max.x + 1e-6, `position x=${x} above max.x=${max.x}`);
+      assert.ok(y >= min.y - 1e-6, `position y=${y} below min.y=${min.y}`);
+      assert.ok(y <= max.y + 1e-6, `position y=${y} above max.y=${max.y}`);
+      assert.ok(z >= min.z - 1e-6, `position z=${z} below min.z=${min.z}`);
+      assert.ok(z <= max.z + 1e-6, `position z=${z} above max.z=${max.z}`);
+    }
+  });
+});

--- a/packages/generator/src/tree/variants/starburst.ts
+++ b/packages/generator/src/tree/variants/starburst.ts
@@ -1,0 +1,67 @@
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';
+
+const HUB_RADIUS = 0.018;                  // dense central mass (~3× a branch radius)
+const HUB_TALL = 0.006;                    // vertical extent of the hub blob
+const TIP_LENGTH = 0.04;                   // how far each tip extends from center
+const TIP_BASE_RADIUS = 0.006;
+const TIP_TIP_RADIUS = 0.002;
+const TIP_ELEVATION = Math.PI / 4;         // 45° above horizontal
+const TIP_COUNT = 4;
+const SEGMENTS = 8;                         // slightly higher than Trident since hub is prominent
+
+export function generateStarburst(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  // Central spherical mass: approximate with two stacked short frustums for simplicity.
+  // A full UV-sphere would need its own emitter; two fat frustums fused at HUB_TALL/2
+  // read plausibly as a dense blob under the bloom pass.
+  emitFrustum(positions, normals, colors, indices,
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: HUB_TALL / 2, z: 0 },
+    HUB_RADIUS * 0.6, HUB_RADIUS, color, SEGMENTS);
+  emitFrustum(positions, normals, colors, indices,
+    { x: 0, y: HUB_TALL / 2, z: 0 },
+    { x: 0, y: HUB_TALL, z: 0 },
+    HUB_RADIUS, HUB_RADIUS * 0.6, color, SEGMENTS);
+
+  const hub = { x: 0, y: HUB_TALL / 2, z: 0 };
+
+  // 4 tips: +X, +Z, -X, -Z (sweeping counter-clockwise around Y).
+  const cardinalAzimuths = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
+  const horizFactor = Math.cos(TIP_ELEVATION); // lateral component
+  const vertFactor = Math.sin(TIP_ELEVATION);  // upward component
+
+  const attachPoints = [];
+  for (const az of cardinalAzimuths) {
+    const dir = {
+      x: Math.cos(az) * horizFactor,
+      y: vertFactor,
+      z: Math.sin(az) * horizFactor,
+    };
+    const tip = {
+      x: hub.x + dir.x * TIP_LENGTH,
+      y: hub.y + dir.y * TIP_LENGTH,
+      z: hub.z + dir.z * TIP_LENGTH,
+    };
+    emitFrustum(positions, normals, colors, indices,
+      hub, tip, TIP_BASE_RADIUS, TIP_TIP_RADIUS, color, SEGMENTS);
+    attachPoints.push(tipAttachPoint(tip, dir));
+  }
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints,
+    boundingBox: computeAABB(positions),
+  };
+}

--- a/packages/generator/src/tree/variants/trident.test.ts
+++ b/packages/generator/src/tree/variants/trident.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateTrident } from './trident.js';
+
+describe('generateTrident', () => {
+  test('produces a mesh with positions/normals/colors/indices', () => {
+    const out = generateTrident({ seed: 1, colorKey: 'neon-magenta' });
+    assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
+    assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
+    assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
+    assert.strictEqual(out.mesh.colors.length, out.mesh.positions.length, 'colors length must match positions');
+    assert.strictEqual(out.mesh.indices.length % 3, 0, 'indices length must be divisible by 3');
+  });
+
+  test('exposes exactly 3 attach points (three spikes)', () => {
+    const out = generateTrident({ seed: 1, colorKey: 'neon-magenta' });
+    assert.strictEqual(out.attachPoints.length, 3);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateTrident({ seed: 1, colorKey: 'neon-cyan' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
+    }
+  });
+
+  test('attach-point positions are spatially distinct', () => {
+    const out = generateTrident({ seed: 1, colorKey: 'neon-magenta' }).attachPoints;
+    // Check pairwise distances; with 3 spikes at 120° intervals, they should all differ
+    for (let i = 0; i < out.length; i++) {
+      for (let j = i + 1; j < out.length; j++) {
+        const dx = out[i]!.position.x - out[j]!.position.x;
+        const dy = out[i]!.position.y - out[j]!.position.y;
+        const dz = out[i]!.position.z - out[j]!.position.z;
+        const dist = Math.hypot(dx, dy, dz);
+        assert.ok(dist > 0.01, `attach points ${i} and ${j} too close (dist=${dist})`);
+      }
+    }
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateTrident({ seed: 1, colorKey: 'neon-magenta' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      const x = out.mesh.positions[i]!;
+      const y = out.mesh.positions[i + 1]!;
+      const z = out.mesh.positions[i + 2]!;
+      assert.ok(x >= min.x - 1e-6, `position x=${x} below min.x=${min.x}`);
+      assert.ok(x <= max.x + 1e-6, `position x=${x} above max.x=${max.x}`);
+      assert.ok(y >= min.y - 1e-6, `position y=${y} below min.y=${min.y}`);
+      assert.ok(y <= max.y + 1e-6, `position y=${y} above max.y=${max.y}`);
+      assert.ok(z >= min.z - 1e-6, `position z=${z} below min.z=${min.z}`);
+      assert.ok(z <= max.z + 1e-6, `position z=${z} above max.z=${max.z}`);
+    }
+  });
+});

--- a/packages/generator/src/tree/variants/trident.ts
+++ b/packages/generator/src/tree/variants/trident.ts
@@ -1,0 +1,63 @@
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';
+
+const TRUNK_BASE_RADIUS = 0.008;
+const TRUNK_TIP_RADIUS = 0.006;
+const TRUNK_HEIGHT = 0.05;
+const SPIKE_LENGTH = 0.05;
+const SPIKE_BASE_RADIUS = 0.0055;
+const SPIKE_TIP_RADIUS = 0.002;
+const SPIKE_TILT_FROM_VERTICAL = Math.PI / 6; // 30° off vertical, toward each spike's azimuth
+const SPIKE_COUNT = 3;
+const SEGMENTS = 6;
+
+export function generateTrident(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  // Short trunk up to the hub.
+  emitFrustum(
+    positions, normals, colors, indices,
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: TRUNK_HEIGHT, z: 0 },
+    TRUNK_BASE_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS,
+  );
+
+  const hub = { x: 0, y: TRUNK_HEIGHT, z: 0 };
+  const attachPoints = [];
+  for (let i = 0; i < SPIKE_COUNT; i++) {
+    const az = (i * 2 * Math.PI) / SPIKE_COUNT; // 0°, 120°, 240° (= -120°)
+    const horizFactor = Math.sin(SPIKE_TILT_FROM_VERTICAL);
+    const vertFactor = Math.cos(SPIKE_TILT_FROM_VERTICAL);
+    const dir = {
+      x: Math.cos(az) * horizFactor,
+      y: vertFactor,
+      z: Math.sin(az) * horizFactor,
+    };
+    const tip = {
+      x: hub.x + dir.x * SPIKE_LENGTH,
+      y: hub.y + dir.y * SPIKE_LENGTH,
+      z: hub.z + dir.z * SPIKE_LENGTH,
+    };
+    emitFrustum(
+      positions, normals, colors, indices,
+      hub, tip, SPIKE_BASE_RADIUS, SPIKE_TIP_RADIUS, color, SEGMENTS,
+    );
+    attachPoints.push(tipAttachPoint(tip, dir));
+  }
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints,
+    boundingBox: computeAABB(positions),
+  };
+}

--- a/packages/generator/src/tree/variants/wishbone.test.ts
+++ b/packages/generator/src/tree/variants/wishbone.test.ts
@@ -1,0 +1,63 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { generateWishbone } from './wishbone.js';
+
+describe('generateWishbone', () => {
+  test('produces a mesh with positions/normals/colors/indices', () => {
+    const out = generateWishbone({ seed: 1, colorKey: 'neon-cyan' });
+    assert.ok(out.mesh.positions.length > 0, 'positions should be non-empty');
+    assert.strictEqual(out.mesh.positions.length % 3, 0, 'positions length must be divisible by 3');
+    assert.strictEqual(out.mesh.normals.length, out.mesh.positions.length, 'normals length must match positions');
+    assert.strictEqual(out.mesh.colors.length, out.mesh.positions.length, 'colors length must match positions');
+    assert.strictEqual(out.mesh.indices.length % 3, 0, 'indices length must be divisible by 3');
+  });
+
+  test('exposes exactly 2 attach points (two curved tips)', () => {
+    const out = generateWishbone({ seed: 1, colorKey: 'neon-magenta' });
+    assert.strictEqual(out.attachPoints.length, 2);
+  });
+
+  test('attach-point normals are unit length', () => {
+    const out = generateWishbone({ seed: 1, colorKey: 'neon-lime' });
+    for (const ap of out.attachPoints) {
+      const n = Math.hypot(ap.normal.x, ap.normal.y, ap.normal.z);
+      assert.ok(Math.abs(n - 1) < 1e-5, `normal magnitude should be 1, got ${n}`);
+    }
+  });
+
+  test('attach-point positions are spatially distinct', () => {
+    const [a, b] = generateWishbone({ seed: 1, colorKey: 'neon-magenta' }).attachPoints;
+    const dx = a!.position.x - b!.position.x;
+    const dy = a!.position.y - b!.position.y;
+    const dz = a!.position.z - b!.position.z;
+    assert.ok(Math.hypot(dx, dy, dz) > 0.01, 'tips must be separated by more than 0.01');
+    // Verify tips are on opposite sides of X-axis
+    assert.ok(a!.position.x * b!.position.x < 0, 'tips must be on opposite sides of X-axis');
+  });
+
+  test('bounding box contains all vertex positions', () => {
+    const out = generateWishbone({ seed: 1, colorKey: 'neon-magenta' });
+    const { min, max } = out.boundingBox;
+    for (let i = 0; i < out.mesh.positions.length; i += 3) {
+      const x = out.mesh.positions[i]!;
+      const y = out.mesh.positions[i + 1]!;
+      const z = out.mesh.positions[i + 2]!;
+      assert.ok(x >= min.x - 1e-6, `position x=${x} below min.x=${min.x}`);
+      assert.ok(x <= max.x + 1e-6, `position x=${x} above max.x=${max.x}`);
+      assert.ok(y >= min.y - 1e-6, `position y=${y} below min.y=${min.y}`);
+      assert.ok(y <= max.y + 1e-6, `position y=${y} above max.y=${max.y}`);
+      assert.ok(z >= min.z - 1e-6, `position z=${z} below min.z=${min.z}`);
+      assert.ok(z <= max.z + 1e-6, `position z=${z} above max.z=${max.z}`);
+    }
+  });
+
+  test('wishbone is horizontally spread', () => {
+    const out = generateWishbone({ seed: 1, colorKey: 'neon-magenta' });
+    const [a, b] = out.attachPoints;
+    // Each tip should have significant |x| displacement
+    const aAbsX = Math.abs(a!.position.x);
+    const bAbsX = Math.abs(b!.position.x);
+    assert.ok(aAbsX > 0.03, `left tip |x| should be > 0.03, got ${aAbsX}`);
+    assert.ok(bAbsX > 0.03, `right tip |x| should be > 0.03, got ${bAbsX}`);
+  });
+});

--- a/packages/generator/src/tree/variants/wishbone.ts
+++ b/packages/generator/src/tree/variants/wishbone.ts
@@ -1,0 +1,77 @@
+import type { VariantGenerateInput, VariantOutput } from '../variant.js';
+import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import { colorVec3 } from '../../species/_common.js';
+
+const ARM_LENGTH_X = 0.05;      // horizontal distance from center to tip
+const ARM_HEIGHT_Y = 0.035;      // vertical rise of tip above base
+const ARM_CONTROL_Y = 0.05;      // apex of the curve (above the tip)
+const ARM_STEPS = 6;             // segments per arm
+const BASE_RADIUS = 0.0065;
+const TIP_RADIUS = 0.002;
+const SEGMENTS = 6;
+
+interface Vec3 { x: number; y: number; z: number; }
+
+function quadBezier(p0: Vec3, p1: Vec3, p2: Vec3, t: number): Vec3 {
+  const u = 1 - t;
+  return {
+    x: u * u * p0.x + 2 * u * t * p1.x + t * t * p2.x,
+    y: u * u * p0.y + 2 * u * t * p1.y + t * t * p2.y,
+    z: u * u * p0.z + 2 * u * t * p1.z + t * t * p2.z,
+  };
+}
+
+function emitArm(
+  positions: number[],
+  normals: number[],
+  colors: number[],
+  indices: number[],
+  color: ReturnType<typeof colorVec3>,
+  sign: -1 | 1,
+): { tip: Vec3; tipDir: Vec3 } {
+  const p0 = { x: 0, y: 0, z: 0 };
+  const p1 = { x: sign * (ARM_LENGTH_X / 2), y: ARM_CONTROL_Y, z: 0 };
+  const p2 = { x: sign * ARM_LENGTH_X, y: ARM_HEIGHT_Y, z: 0 };
+
+  let prev = p0;
+  for (let i = 1; i <= ARM_STEPS; i++) {
+    const tCurr = i / ARM_STEPS;
+    const tPrev = (i - 1) / ARM_STEPS;
+    const next = quadBezier(p0, p1, p2, tCurr);
+    const r0 = BASE_RADIUS + (TIP_RADIUS - BASE_RADIUS) * tPrev;
+    const r1 = BASE_RADIUS + (TIP_RADIUS - BASE_RADIUS) * tCurr;
+    emitFrustum(positions, normals, colors, indices, prev, next, r0, r1, color, SEGMENTS);
+    prev = next;
+  }
+
+  // Tangent at t=1 is (p2 - p1) * 2; normalize.
+  const tipDirRaw = { x: p2.x - p1.x, y: p2.y - p1.y, z: p2.z - p1.z };
+  const dLen = Math.hypot(tipDirRaw.x, tipDirRaw.y, tipDirRaw.z) || 1;
+  const tipDir = { x: tipDirRaw.x / dLen, y: tipDirRaw.y / dLen, z: tipDirRaw.z / dLen };
+  return { tip: p2, tipDir };
+}
+
+export function generateWishbone(input: VariantGenerateInput): VariantOutput {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const colors: number[] = [];
+  const indices: number[] = [];
+  const color = colorVec3(input.colorKey);
+
+  const left = emitArm(positions, normals, colors, indices, color, -1);
+  const right = emitArm(positions, normals, colors, indices, color, +1);
+
+  return {
+    mesh: {
+      positions: new Float32Array(positions),
+      normals: new Float32Array(normals),
+      colors: new Float32Array(colors),
+      indices: new Uint32Array(indices),
+    },
+    attachPoints: [
+      tipAttachPoint(left.tip, left.tipDir),
+      tipAttachPoint(right.tip, right.tipDir),
+    ],
+    boundingBox: computeAABB(positions),
+  };
+}

--- a/packages/server/migrations/003_tree_polyps.sql
+++ b/packages/server/migrations/003_tree_polyps.sql
@@ -1,0 +1,28 @@
+-- packages/server/migrations/003_tree_polyps.sql
+
+CREATE TABLE IF NOT EXISTS tree_polyps (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  variant       TEXT NOT NULL,            -- forked / trident / starburst / claw / wishbone
+  seed          INTEGER NOT NULL,
+  color_key     TEXT NOT NULL,
+  parent_id     INTEGER,                  -- NULL for root
+  attach_index  INTEGER NOT NULL,         -- which tip of parent this piece claims (0..3)
+  created_at    INTEGER NOT NULL,
+  device_hash   TEXT,
+  deleted       INTEGER NOT NULL DEFAULT 0,
+
+  FOREIGN KEY (parent_id) REFERENCES tree_polyps(id),
+
+  -- A given parent's attach slot is consumed by at most one live child.
+  -- Partial unique index so soft-deleted rows don't block re-use.
+  CHECK (attach_index BETWEEN 0 AND 3)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tree_polyps_parent_attach_live
+  ON tree_polyps (parent_id, attach_index) WHERE deleted = 0;
+
+CREATE INDEX IF NOT EXISTS idx_tree_polyps_live
+  ON tree_polyps (deleted, created_at) WHERE deleted = 0;
+
+CREATE INDEX IF NOT EXISTS idx_tree_polyps_parent
+  ON tree_polyps (parent_id) WHERE deleted = 0;

--- a/packages/server/src/boot.smoke.test.ts
+++ b/packages/server/src/boot.smoke.test.ts
@@ -57,3 +57,17 @@ test('smoke: explicit CORS_ORIGINS list binds without throwing', async () => {
   const res = await app.inject({ method: 'GET', url: '/healthz' });
   assert.equal(res.statusCode, 200);
 });
+
+test('smoke: /api/tree returns a seeded state (not empty) on fresh boot', async () => {
+  const { app } = await makeServer({
+    dbPath: ':memory:', adminToken: '', corsOrigins: ['*'],
+    clientDistDir: undefined, logger: false,
+  });
+  after(async () => { await app.close(); });
+
+  const res = await app.inject({ method: 'GET', url: '/api/tree' });
+  assert.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body) as { polyps: unknown[] };
+  // seedRootIfEmpty ran at boot — expect exactly one root.
+  assert.equal(body.polyps.length, 1);
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,9 @@ import { registerStatsRoutes } from './routes/stats.js';
 import { registerMetricsRoutes } from './routes/metrics.js';
 import { SimWorker, SnapshotWorker } from './sim.js';
 import { installSecurityHeaders } from './security.js';
+import { TreeDb } from './tree/db.js';
+import { registerTreeRoutes } from './tree/routes.js';
+import { seedRootIfEmpty } from './tree/seed.js';
 
 export interface MakeServerOptions {
   dbPath?: string;
@@ -28,6 +31,8 @@ export interface MakeServerResult {
   app: FastifyInstance;
   db: ReefDb;
   hub: Hub;
+  treeDb: TreeDb;
+  treeHub: Hub;
 }
 
 /**
@@ -46,6 +51,9 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
 
   const db = new ReefDb(dbPath);
   const hub = new Hub();
+  const treeDb = new TreeDb(db);
+  const treeHub = new Hub();
+  seedRootIfEmpty(treeDb);
 
   // 8 KB fits the largest valid polyp (schema-bounded). Fastify's 1 MB
   // default lets unauthenticated callers make Zod walk a megabyte before
@@ -68,6 +76,7 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
   registerAdminRoutes(app, db, hub);
   registerStatsRoutes(app, db);
   registerMetricsRoutes(app, db, hub);
+  registerTreeRoutes(app, treeDb, treeHub);
 
   // Optional static hosting: serves the built Vite bundle out of the same
   // container so a single-host deploy doesn't need a separate nginx sidecar.
@@ -100,22 +109,40 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
     }));
   });
 
-  return { app, db, hub };
+  app.get('/ws/tree', { websocket: true }, (sock) => {
+    const ws = sock as unknown as {
+      readyState: number;
+      send: (data: string) => void;
+      on: (event: 'close' | 'pong', cb: () => void) => void;
+      ping?(): void;
+      terminate?(): void;
+    };
+    treeHub.add(ws);
+    ws.send(JSON.stringify({
+      type: 'tree_hello',
+      polypCount: treeDb.listLive().length,
+      serverTime: Date.now(),
+    }));
+  });
+
+  return { app, db, hub, treeDb, treeHub };
 }
 
 async function main(): Promise<void> {
-  const { app, db, hub } = await makeServer();
+  const { app, db, hub, treeHub } = await makeServer();
 
   const sim = new SimWorker(db, hub, config.simIntervalMs);
   sim.start();
   const snapshots = new SnapshotWorker(db, config.snapshotIntervalMs);
   snapshots.start();
   hub.startHeartbeat();
+  treeHub.startHeartbeat();
 
   const shutdown = async (): Promise<void> => {
     sim.stop();
     snapshots.stop();
     hub.stopHeartbeat();
+    treeHub.stopHeartbeat();
     await app.close();
     process.exit(0);
   };

--- a/packages/server/src/tree/db.test.ts
+++ b/packages/server/src/tree/db.test.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { ReefDb } from '../db.js';
+import { TreeDb } from './db.js';
+
+function makeDb(): { tree: TreeDb; close: () => void } {
+  const reef = new ReefDb(':memory:');
+  const tree = new TreeDb(reef);
+  return { tree, close: (): void => { /* ReefDb doesn't expose close, GC handles it */ } };
+}
+
+describe('TreeDb.insertRoot', () => {
+  test('inserts a root piece (parentId=null, attachIndex=0)', () => {
+    const { tree } = makeDb();
+    const p = tree.insertRoot({ variant: 'starburst', seed: 42, colorKey: 'neon-cyan' });
+    assert.equal(p.parentId, null);
+    assert.equal(p.variant, 'starburst');
+    assert.equal(p.attachIndex, 0);
+  });
+});
+
+describe('TreeDb.insertChild', () => {
+  test('inserts a child referencing a valid parent + unused attach index', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'neon-cyan' });
+    const child = tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'neon-magenta',
+      parentId: root.id, attachIndex: 1,
+    });
+    assert.equal(child.parentId, root.id);
+    assert.equal(child.attachIndex, 1);
+  });
+
+  test('rejects insert when parent does not exist', () => {
+    const { tree } = makeDb();
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 1, colorKey: 'x',
+      parentId: 99999, attachIndex: 0,
+    }), /parent not found/i);
+  });
+
+  test('rejects insert when attach slot is already claimed', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.insertChild({ variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0 });
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 3, colorKey: 'x', parentId: root.id, attachIndex: 0,
+    }), /attach index.*already claimed/i);
+  });
+
+  test('rejects insert when parent is soft-deleted', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.softDelete(root.id);
+    assert.throws(() => tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0,
+    }), /parent not found/i);
+  });
+});
+
+describe('TreeDb.listLive', () => {
+  test('returns all live pieces with deviceHash stripped', () => {
+    const { tree } = makeDb();
+    tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const list = tree.listLive();
+    assert.equal(list.length, 1);
+    assert.equal((list[0] as { deviceHash?: string }).deviceHash, undefined);
+  });
+});
+
+describe('TreeDb.softDelete (leaf-only)', () => {
+  test('deletes a leaf piece', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const result = tree.softDelete(root.id);
+    assert.equal(result.ok, true);
+    assert.equal(tree.listLive().length, 0);
+  });
+
+  test('refuses to delete a piece that has live children', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    tree.insertChild({ variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0 });
+    const result = tree.softDelete(root.id);
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? '', /has children/i);
+  });
+
+  test('returns ok=false not_found for unknown ids', () => {
+    const { tree } = makeDb();
+    const result = tree.softDelete(99999);
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? '', /not.?found/i);
+  });
+});
+
+describe('TreeDb.hasAnyLive', () => {
+  test('returns false on an empty tree', () => {
+    const { tree } = makeDb();
+    assert.equal(tree.hasAnyLive(), false);
+  });
+  test('returns true once any root is inserted', () => {
+    const { tree } = makeDb();
+    tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    assert.equal(tree.hasAnyLive(), true);
+  });
+});

--- a/packages/server/src/tree/db.ts
+++ b/packages/server/src/tree/db.ts
@@ -34,12 +34,8 @@ export class TreeDb {
 
   // ReefDb owns the underlying sqlite handle. Share it so migrations run once
   // and tree + landscape data live in the same file.
-  constructor(private readonly reef: ReefDb) {
-    // Access the raw db from ReefDb via a property we'll add, OR re-open the
-    // same file. Simplest: ReefDb already exposes its `db` (or we open by path).
-    // For this plan: add a getter `raw()` to ReefDb returning `this.db` if not
-    // already present.
-    this.db = (reef as unknown as { db: Database.Database }).db;
+  constructor(reef: ReefDb) {
+    this.db = reef.db;
 
     this.stmt = {
       insert: this.db.prepare(

--- a/packages/server/src/tree/db.ts
+++ b/packages/server/src/tree/db.ts
@@ -1,0 +1,153 @@
+import Database from 'better-sqlite3';
+import type { ReefDb } from '../db.js';
+import type { PublicTreePolyp, TreeVariant } from '@reef/shared';
+
+export interface InsertRootInput {
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+  deviceHash?: string;
+}
+
+export interface InsertChildInput extends InsertRootInput {
+  parentId: number;
+  attachIndex: number;
+}
+
+export interface SoftDeleteResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export class TreeDb {
+  private readonly db: Database.Database;
+  private readonly stmt: {
+    insert: Database.Statement;
+    findParent: Database.Statement;
+    findAttachClaimed: Database.Statement;
+    listLive: Database.Statement;
+    findById: Database.Statement;
+    countLiveChildren: Database.Statement;
+    softDelete: Database.Statement;
+    hasAny: Database.Statement;
+  };
+
+  // ReefDb owns the underlying sqlite handle. Share it so migrations run once
+  // and tree + landscape data live in the same file.
+  constructor(private readonly reef: ReefDb) {
+    // Access the raw db from ReefDb via a property we'll add, OR re-open the
+    // same file. Simplest: ReefDb already exposes its `db` (or we open by path).
+    // For this plan: add a getter `raw()` to ReefDb returning `this.db` if not
+    // already present.
+    this.db = (reef as unknown as { db: Database.Database }).db;
+
+    this.stmt = {
+      insert: this.db.prepare(
+        `INSERT INTO tree_polyps (variant, seed, color_key, parent_id, attach_index, created_at, device_hash)
+         VALUES (@variant, @seed, @colorKey, @parentId, @attachIndex, @createdAt, @deviceHash)`,
+      ),
+      findParent: this.db.prepare(
+        'SELECT id FROM tree_polyps WHERE id = ? AND deleted = 0',
+      ),
+      findAttachClaimed: this.db.prepare(
+        'SELECT id FROM tree_polyps WHERE parent_id = ? AND attach_index = ? AND deleted = 0',
+      ),
+      listLive: this.db.prepare(
+        'SELECT * FROM tree_polyps WHERE deleted = 0 ORDER BY created_at ASC',
+      ),
+      findById: this.db.prepare(
+        'SELECT * FROM tree_polyps WHERE id = ? AND deleted = 0',
+      ),
+      countLiveChildren: this.db.prepare(
+        'SELECT COUNT(*) AS n FROM tree_polyps WHERE parent_id = ? AND deleted = 0',
+      ),
+      softDelete: this.db.prepare(
+        'UPDATE tree_polyps SET deleted = 1 WHERE id = ? AND deleted = 0',
+      ),
+      hasAny: this.db.prepare(
+        'SELECT 1 FROM tree_polyps WHERE deleted = 0 LIMIT 1',
+      ),
+    };
+  }
+
+  insertRoot(input: InsertRootInput): PublicTreePolyp {
+    const createdAt = Date.now();
+    const row = this.stmt.insert.run({
+      variant: input.variant,
+      seed: input.seed,
+      colorKey: input.colorKey,
+      parentId: null,
+      attachIndex: 0,
+      createdAt,
+      deviceHash: input.deviceHash ?? null,
+    });
+    return this.toPublic(this.stmt.findById.get(Number(row.lastInsertRowid)) as DbRow);
+  }
+
+  insertChild(input: InsertChildInput): PublicTreePolyp {
+    const parent = this.stmt.findParent.get(input.parentId);
+    if (!parent) throw new Error(`parent not found (id=${input.parentId})`);
+    const claimed = this.stmt.findAttachClaimed.get(input.parentId, input.attachIndex);
+    if (claimed) {
+      throw new Error(`attach index ${input.attachIndex} already claimed on parent ${input.parentId}`);
+    }
+    const createdAt = Date.now();
+    const row = this.stmt.insert.run({
+      variant: input.variant,
+      seed: input.seed,
+      colorKey: input.colorKey,
+      parentId: input.parentId,
+      attachIndex: input.attachIndex,
+      createdAt,
+      deviceHash: input.deviceHash ?? null,
+    });
+    return this.toPublic(this.stmt.findById.get(Number(row.lastInsertRowid)) as DbRow);
+  }
+
+  listLive(): PublicTreePolyp[] {
+    const rows = this.stmt.listLive.all() as DbRow[];
+    return rows.map((r) => this.toPublic(r));
+  }
+
+  getById(id: number): PublicTreePolyp | null {
+    const row = this.stmt.findById.get(id) as DbRow | undefined;
+    return row ? this.toPublic(row) : null;
+  }
+
+  softDelete(id: number): SoftDeleteResult {
+    const row = this.stmt.findById.get(id);
+    if (!row) return { ok: false, reason: 'not_found' };
+    const children = this.stmt.countLiveChildren.get(id) as { n: number };
+    if (children.n > 0) return { ok: false, reason: 'has children' };
+    this.stmt.softDelete.run(id);
+    return { ok: true };
+  }
+
+  hasAnyLive(): boolean {
+    return !!this.stmt.hasAny.get();
+  }
+
+  private toPublic(row: DbRow): PublicTreePolyp {
+    return {
+      id: row.id,
+      variant: row.variant as TreeVariant,
+      seed: row.seed,
+      colorKey: row.color_key,
+      parentId: row.parent_id,
+      attachIndex: row.attach_index,
+      createdAt: row.created_at,
+    };
+  }
+}
+
+interface DbRow {
+  id: number;
+  variant: string;
+  seed: number;
+  color_key: string;
+  parent_id: number | null;
+  attach_index: number;
+  created_at: number;
+  device_hash: string | null;
+  deleted: number;
+}

--- a/packages/server/src/tree/routes.test.ts
+++ b/packages/server/src/tree/routes.test.ts
@@ -1,0 +1,126 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import Fastify from 'fastify';
+import { ReefDb } from '../db.js';
+import { Hub } from '../hub.js';
+import { TreeDb } from './db.js';
+import { registerTreeRoutes } from './routes.js';
+
+async function makeServer(): Promise<{ app: Awaited<ReturnType<typeof Fastify>>; close: () => Promise<void> }> {
+  const reef = new ReefDb(':memory:');
+  const tree = new TreeDb(reef);
+  const hub = new Hub();
+  const app = Fastify({ logger: false });
+  registerTreeRoutes(app, tree, hub);
+  await app.ready();
+  return { app, close: async (): Promise<void> => { await app.close(); } };
+}
+
+describe('GET /api/tree', () => {
+  test('returns an empty tree on a fresh db', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({ method: 'GET', url: '/api/tree' });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as { polyps: unknown[] };
+    assert.deepEqual(body.polyps, []);
+    await close();
+  });
+});
+
+describe('POST /api/tree/polyp', () => {
+  test('inserts a root piece when parentId is null', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as { id: number; parentId: number | null };
+    assert.ok(body.id > 0);
+    assert.equal(body.parentId, null);
+    await close();
+  });
+
+  test('inserts a child when parentId points to a live polyp', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+
+    const child = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 1 },
+    });
+    assert.equal(child.statusCode, 200);
+    assert.equal((JSON.parse(child.body) as { parentId: number }).parentId, rootId);
+    await close();
+  });
+
+  test('returns 409 when the attach slot is already claimed', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+
+    await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+    });
+    const dup = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'claw', seed: 3, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+    });
+    assert.equal(dup.statusCode, 409);
+    assert.match(JSON.parse(dup.body).error as string, /claim/i);
+    await close();
+  });
+
+  test('returns 404 when parent does not exist', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 1, colorKey: 'x', parentId: 99999, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 404);
+    await close();
+  });
+
+  test('returns 400 on malformed input (unknown variant)', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'branching', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 400);
+    await close();
+  });
+
+  test('broadcasts tree_polyp_added via the hub on success', async () => {
+    const { app, close } = await makeServer();
+    let received: unknown = null;
+    const fakeWs = {
+      readyState: 1,
+      send(data: string) { received = JSON.parse(data); },
+      on() { /* noop */ },
+    };
+    const hub = new Hub();
+    hub.add(fakeWs);
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const app2 = Fastify({ logger: false });
+    registerTreeRoutes(app2, tree, hub);
+    await app2.ready();
+    await app2.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    assert.equal((received as { type: string } | null)?.type, 'tree_polyp_added');
+    await app2.close();
+    await close();
+  });
+});

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -1,0 +1,39 @@
+import type { FastifyInstance } from 'fastify';
+import { TreePolypInputSchema } from '@reef/shared';
+import type { Hub } from '../hub.js';
+import type { TreeDb } from './db.js';
+
+export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub): void {
+  app.get('/api/tree', async () => ({
+    polyps: tree.listLive(),
+    serverTime: Date.now(),
+  }));
+
+  app.post('/api/tree/polyp', async (req, reply) => {
+    const parsed = TreePolypInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return { error: 'invalid payload', issues: parsed.error.issues };
+    }
+    const input = parsed.data;
+    try {
+      const polyp = input.parentId === null
+        ? tree.insertRoot({ variant: input.variant, seed: input.seed, colorKey: input.colorKey })
+        : tree.insertChild({
+            variant: input.variant,
+            seed: input.seed,
+            colorKey: input.colorKey,
+            parentId: input.parentId,
+            attachIndex: input.attachIndex,
+          });
+      hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
+      return polyp;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/parent not found/i.test(msg)) { reply.code(404); return { error: msg }; }
+      if (/already claim/i.test(msg))    { reply.code(409); return { error: msg }; }
+      reply.code(500);
+      return { error: msg };
+    }
+  });
+}

--- a/packages/server/src/tree/seed.test.ts
+++ b/packages/server/src/tree/seed.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { ReefDb } from '../db.js';
+import { TreeDb } from './db.js';
+import { seedRootIfEmpty } from './seed.js';
+
+describe('seedRootIfEmpty', () => {
+  test('inserts exactly one Starburst root when the tree is empty', () => {
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const result = seedRootIfEmpty(tree);
+    assert.equal(result.seeded, true);
+    const all = tree.listLive();
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.variant, 'starburst');
+    assert.equal(all[0]!.parentId, null);
+  });
+
+  test('is a no-op when the tree already has pieces', () => {
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    tree.insertRoot({ variant: 'forked', seed: 1, colorKey: 'x' });
+    const result = seedRootIfEmpty(tree);
+    assert.equal(result.seeded, false);
+    assert.equal(tree.listLive().length, 1);
+    // Existing piece untouched.
+    assert.equal(tree.listLive()[0]!.variant, 'forked');
+  });
+
+  test('the seed uses a random seed + colorKey (not hard-coded)', () => {
+    const results = new Set<number>();
+    for (let i = 0; i < 5; i++) {
+      const reef = new ReefDb(':memory:');
+      const tree = new TreeDb(reef);
+      seedRootIfEmpty(tree);
+      results.add(tree.listLive()[0]!.seed);
+    }
+    // Not all five identical — random.
+    assert.ok(results.size > 1, `expected randomness, got ${[...results].join(',')}`);
+  });
+});

--- a/packages/server/src/tree/seed.ts
+++ b/packages/server/src/tree/seed.ts
@@ -1,0 +1,23 @@
+import type { TreeDb } from './db.js';
+
+// Avatar-aesthetic palette — matches the client-side tree material palette.
+const ROOT_COLORS = ['neon-magenta', 'neon-cyan', 'neon-violet', 'neon-lime', 'neon-orange'];
+
+export interface SeedResult {
+  seeded: boolean;
+}
+
+/**
+ * Ensures the tree is never empty. First boot (or first boot with a fresh
+ * volume) drops in one Starburst at the pedestal origin so visitors always
+ * have something to branch from.
+ *
+ * Idempotent — calling repeatedly is safe because of the hasAnyLive check.
+ */
+export function seedRootIfEmpty(tree: TreeDb): SeedResult {
+  if (tree.hasAnyLive()) return { seeded: false };
+  const seed = Math.floor(Math.random() * 0xffffffff);
+  const colorKey = ROOT_COLORS[Math.floor(Math.random() * ROOT_COLORS.length)]!;
+  tree.insertRoot({ variant: 'starburst', seed, colorKey });
+  return { seeded: true };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,6 @@ export * from './palette.js';
 export * from './ws.js';
 export * from './ws-dispatch.js';
 export * from './gestures.js';
+export * from './tree/types.js';
+export * from './tree/schema.js';
+export * from './tree/ws.js';

--- a/packages/shared/src/palette.ts
+++ b/packages/shared/src/palette.ts
@@ -15,6 +15,11 @@ export const REEF_PALETTE: readonly PaletteEntry[] = [
   { key: 'sand', name: 'Sand', hex: '#e6cfa7' },
   { key: 'cerulean', name: 'Cerulean', hex: '#1d6fa5' },
   { key: 'plum', name: 'Plum', hex: '#6d2e46' },
+  { key: 'neon-magenta', name: 'Neon Magenta', hex: '#ff1ad9' },
+  { key: 'neon-cyan', name: 'Neon Cyan', hex: '#2dffe4' },
+  { key: 'neon-violet', name: 'Neon Violet', hex: '#8a4dff' },
+  { key: 'neon-lime', name: 'Neon Lime', hex: '#b0ff3a' },
+  { key: 'neon-orange', name: 'Neon Orange', hex: '#ff6a2a' },
 ] as const;
 
 const byKey = new Map(REEF_PALETTE.map((p) => [p.key, p] as const));

--- a/packages/shared/src/tree/schema.test.ts
+++ b/packages/shared/src/tree/schema.test.ts
@@ -1,0 +1,73 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { TreePolypInputSchema, TreeVariantSchema } from './schema.js';
+
+test('TreeVariantSchema: accepts the five variants', () => {
+  for (const v of ['forked', 'trident', 'starburst', 'claw', 'wishbone']) {
+    assert.equal(TreeVariantSchema.safeParse(v).success, true);
+  }
+});
+
+test('TreeVariantSchema: rejects unknown variants', () => {
+  assert.equal(TreeVariantSchema.safeParse('rubbish').success, false);
+  assert.equal(TreeVariantSchema.safeParse('branching').success, false);
+});
+
+test('TreePolypInputSchema: accepts a well-formed payload', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  assert.equal(TreePolypInputSchema.safeParse(valid).success, true);
+});
+
+test('TreePolypInputSchema: allows parentId=null for root pieces', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  const root = { ...valid, parentId: null };
+  assert.equal(TreePolypInputSchema.safeParse(root).success, true);
+});
+
+test('TreePolypInputSchema: rejects negative or non-integer attachIndex', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachIndex: -1 }).success, false);
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 1.5 }).success, false);
+});
+
+test('TreePolypInputSchema: rejects attachIndex >= 4 (max tips per variant is 4, starburst)', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 4 }).success, false);
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachIndex: 10 }).success, false);
+});
+
+test('TreePolypInputSchema: rejects out-of-range seed', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, seed: -1 }).success, false);
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, seed: 2 ** 33 }).success, false);
+});

--- a/packages/shared/src/tree/schema.ts
+++ b/packages/shared/src/tree/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const TreeVariantSchema = z.enum([
+  'forked', 'trident', 'starburst', 'claw', 'wishbone',
+]);
+
+export const TreePolypInputSchema = z.object({
+  variant: TreeVariantSchema,
+  seed: z.number().int().nonnegative().max(0xffffffff),
+  colorKey: z.string().min(1).max(32),
+  parentId: z.number().int().positive().nullable(),
+  attachIndex: z.number().int().min(0).max(3),  // max 4 tips (starburst) = indices 0-3
+});
+
+export type TreePolypInput = z.infer<typeof TreePolypInputSchema>;

--- a/packages/shared/src/tree/types.ts
+++ b/packages/shared/src/tree/types.ts
@@ -1,0 +1,22 @@
+export type TreeVariant = 'forked' | 'trident' | 'starburst' | 'claw' | 'wishbone';
+
+export interface TreePolyp {
+  id: number;
+  variant: TreeVariant;
+  seed: number;
+  colorKey: string;
+  parentId: number | null;     // null for root
+  attachIndex: number;          // which of parent's attach points this piece claims
+  createdAt: number;
+  deviceHash?: string;          // hashed at insert, stripped on public read
+  deleted: boolean;
+}
+
+export type PublicTreePolyp = Omit<TreePolyp, 'deviceHash' | 'deleted'>;
+
+export interface AttachPoint {
+  /** Local-space position on the parent mesh */
+  position: { x: number; y: number; z: number };
+  /** Unit normal pointing outward from the parent surface at this attach point */
+  normal: { x: number; y: number; z: number };
+}

--- a/packages/shared/src/tree/ws.ts
+++ b/packages/shared/src/tree/ws.ts
@@ -1,0 +1,6 @@
+import type { PublicTreePolyp } from './types.js';
+
+export type TreeServerMessage =
+  | { type: 'tree_hello'; polypCount: number; serverTime: number }
+  | { type: 'tree_polyp_added'; polyp: PublicTreePolyp }
+  | { type: 'tree_polyp_removed'; id: number };

--- a/scripts/build-pages-index.sh
+++ b/scripts/build-pages-index.sh
@@ -41,6 +41,8 @@ cat > "$DIST/index.html" <<'HTML'
     <li><a href="ar.html">AR app</a> — will fail to load the reef (no backend on Pages) but shows the startup screen.</li>
     <li><a href="playground.html">Playground</a> — interactive reef (no AR needed, works against any deployed backend)</li>
     <li><a href="playground.html?mode=screen">Screen view</a> — auto-orbit camera, demo-ready</li>
+    <li><a href="tree.html">Tree (interactive)</a> — procedural tree growth (no AR needed, works against any deployed backend)</li>
+    <li><a href="tree.html?mode=screen">Tree (screen)</a> — auto-orbit camera, demo-ready</li>
     <li><a href="https://github.com/costajohnt/CoralReefAR">Source + runbook</a></li>
     <li><a href="https://github.com/costajohnt/CoralReefAR/pkgs/container/coralreefar">Docker image on GHCR</a></li>
   </ul>


### PR DESCRIPTION
## Summary

- Adds **tree mode** — a third client surface at `tree.html` where visitors attach small composable pieces to each other, growing a fractal branching-coral web over time.
- Five piece variants (Forked / Trident / Starburst / Claw / Wishbone) with 1–4 attach slots each, Avatar-bioluminescent styling with bloom post-processing, AABB collision rejection, leaf-only delete.
- New data path alongside the existing landscape: `tree_polyps` table, `/api/tree/*` routes, `/ws/tree` hub, and a server-side root seed at install.

Full plan: `docs/superpowers/plans/2026-04-22-tree-mode.md`.

## What's new

**Data layer** (server)
- Migration `003_tree_polyps.sql`: table with partial unique index on `(parent_id, attach_index) WHERE deleted=0` so soft-deleted rows free their slot for re-planting.
- `TreeDb` with `insertRoot` / `insertChild` / `listLive` / `softDelete` (leaf-only) / `hasAnyLive`.
- `registerTreeRoutes`: `GET /api/tree`, `POST /api/tree/polyp` with 400/404/409 error shapes, broadcasts on success.
- `seedRootIfEmpty`: drops a random Starburst at the pedestal origin on first boot so visitors always see something to branch from.
- `/ws/tree` WebSocket route + separate `treeHub` with heartbeat; boot smoke test confirms the seeded state.

**Generator** (packages/generator)
- Five variant modules under `src/tree/variants/` (Forked, Trident, Starburst, Claw, Wishbone), each with per-variant shape and invariant tests.
- Shared helpers in `src/tree/variant.ts`: `emitFrustum` (arbitrary-axis tapered cylinder with Gram-Schmidt orientation), `computeAABB`, `tipAttachPoint`.
- Dispatcher `generateTreeVariant` at `src/tree/index.ts` with exhaustive switch and deterministic output per (variant, seed, colorKey).

**Client** (packages/client)
- `tree.html` + `tree.ts` entry with bloom composer (`UnrealBloomPass`), dark pedestal, orbit camera, screen mode (`?mode=screen`).
- `TreeReef` with parent-chain world transforms — each child's world matrix composes from its parent's world attach-point position + orientation (local +Y aligned with parent's attach normal). Grandchild positions verified correct in tests.
- `AttachIndicators` — glowing emissive orbs at every unclaimed attach point; refreshed from `treeReef.getAvailableAttachPoints()` after every mutation.
- `TreePlacement` — click → compute world transform → AABB collision check against `allWorldBoxes()` (excluding parent) → spawn semi-opaque ghost → picker → commit.
- `TreeSocket` — auto-reconnecting WS client typed against `TreeServerMessage`.
- `TreePicker` — tree-only picker class using the 5 variant buttons and the shared `REEF_PALETTE` (now including 5 neon bioluminescent colors: magenta, cyan, violet, lime, orange).

**Shared + docs**
- Shared types + Zod schemas + WS message types under `packages/shared/src/tree/`.
- README, NEXT_STEPS, CONTRIBUTING, PLAN, CHANGELOG updated with tree mode as an "Added" entry.

## Architecture notes

- **Separate reef, shared color palette.** Tree mode has its own DB table and WS namespace, but the 5 new neon colors landed in the shared `REEF_PALETTE` (available to both the landscape picker and the tree picker).
- **Frustum helper in `variant.ts`.** The plan flagged `emitFrustum`'s home as an open choice (`variant.ts` vs a new `primitives.ts`). Opted for `variant.ts` — keeps shared variant types and shared variant helpers co-located, and there's no need for a separate primitives file yet.
- **Collision excludes the parent.** `TreePlacement` filters the parent's own world box out of `allWorldBoxes()` before collision checking, since a child's attach-point-derived bounding box naturally overlaps the parent at the attach surface.
- **`hub.broadcast(... as never)` in tree routes.** The `Hub` class is typed against landscape's `ServerMessage`. Tree broadcasts tunnel through the same Hub primitive via `as never` — runtime-correct, but the cast skips type checking on broadcast payload. Filed as a follow-up: parameterize Hub with a generic type argument so `treeHub` can be typed against `TreeServerMessage`.
- **`tree_polyp_removed` is pre-wired client-side.** The client's socket handler already handles delete messages, but no server route emits them yet. A leaf-only admin delete endpoint is a natural follow-up when the tree-admin UI lands.

## Test plan

Automated:
- [x] `pnpm -r test` — **313 passing, 0 failing** (shared 19 / generator 54 / server 92 / client 148; was 180 on main → +133 new)
- [x] `pnpm -r typecheck` — clean across all 4 packages
- [x] `pnpm --filter @reef/client build` — includes new `tree.html` + `tree-*.js` entry

Manual (local dev, to run before tagging):
- [ ] `pnpm --filter @reef/server dev` + `pnpm --filter @reef/client dev`
- [ ] Open `http://localhost:5173/tree.html?api=http://localhost:8787` — expect seeded Starburst at origin + 4 glowing attach-point orbs + visible bloom halo
- [ ] Click an orb → ghost variant spawns + picker appears → pick a variant + color → commit → piece persists and its attach points now glow
- [ ] Open `?mode=screen` in a second tab — camera auto-orbits, no UI, live updates from the first tab's actions
- [ ] Exercise every variant at least once to confirm the geometry reads correctly under bloom
- [ ] Collision check: try to place two Wishbones on adjacent Starburst tips and confirm the second is rejected if their AABBs overlap

Post-merge (deferred — requires user approval):
- [ ] Tag `v0.5.0` + push tag
- [ ] Wait for multi-arch release workflow
- [ ] Redeploy on LXC 300 and add the tree-mode tile to the homepage dashboard

## Follow-ups filed for later (intentionally not in this PR)

- Admin delete route + `tree-admin` UI (leaf-only soft-delete, broadcasts `tree_polyp_removed`)
- `Hub<T>` generic refactor to remove the `as never` cast
- `/ws/tree` upgrade integration test (parity with the existing landscape WS test)
- `colorKey` palette-membership validation in `TreePolypInputSchema` (returns 400 instead of a 500 from `paletteByKey`)
- Capsule-capsule collision if AABB proves too permissive for thin branches after playtesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
