### PR TITLE
Tree mode: state-machine refactor + visual polish

### DIFF
--- a/docs/superpowers/plans/2026-04-22-tree-state-machine.md
+++ b/docs/superpowers/plans/2026-04-22-tree-state-machine.md
@@ -1,0 +1,1699 @@
+# Tree Placement State Machine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace tree.ts's ad-hoc mutable flag machinery with a deterministic finite state machine — pure reducer + dep-injected effect runner + thin orchestrator.
+
+**Architecture:** Three layers. `state.ts` owns the discriminated union state + pure `reduce` function (no Three.js, no DOM). `effects.ts` owns side effects, receives deps by injection, dispatches follow-up actions on async resolution. `tree.ts` becomes thin wiring — DOM/socket events translate to `dispatch(action)`.
+
+**Tech Stack:** TypeScript 6, Vitest, existing `@reef/shared` types (`TreeVariant`, `PublicTreePolyp`), existing packages (`TreeReef`, `TreePlacement`, `AttachIndicators`, `TreePicker`). No new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-tree-state-machine-design.md`. Read before starting.
+
+---
+
+## File Structure
+
+**New:**
+- `packages/client/src/tree/state.ts` — `TreeState` + `TreeAction` unions, `reduce`, `initialState`. Pure.
+- `packages/client/src/tree/state.test.ts` — reducer tests (Vitest). Pure, no Three.js imports.
+- `packages/client/src/tree/effects.ts` — `createEffects(deps): { apply(prev, next) }` factory.
+
+**Modified:**
+- `packages/client/src/tree.ts` — rewritten as thin orchestrator in a single swap (last task).
+
+**Unchanged (public APIs preserved):**
+- `packages/client/src/tree/{reef,placement,indicators,variants,material,pulse,scene,config,api,shark,clownfish,fishParts}.ts`
+- `packages/client/src/ui/treePicker.ts`
+- `packages/generator/**/*`, `packages/server/**/*`, `packages/shared/**/*`
+
+**Out of scope (separate work):**
+- The in-flight material (`MeshPhysicalMaterial`) + environment (fog, gradient background, underwater lighting) edits stay as-is. They touch `material.ts`, `variants.ts`, `scene.ts`, `tree.ts` — none of the files listed above as unchanged, so there's no conflict with this plan.
+- Multi-branch-per-attach feature.
+- Drag-yaw persistence to server.
+
+---
+
+## Task 1: state.ts scaffold — types + initialState + no-op reducer
+
+**Files:**
+- Create: `packages/client/src/tree/state.ts`
+- Create: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// packages/client/src/tree/state.test.ts
+import { describe, expect, test } from 'vitest';
+import { initialState, reduce, type TreeAction, type TreeState } from './state.js';
+
+describe('initialState', () => {
+  test('returns idle with the provided picker selection', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(s.kind).toBe('idle');
+    if (s.kind === 'idle') {
+      expect(s.picker).toEqual({ variant: 'forked', colorKey: 'neon-cyan' });
+    }
+  });
+});
+
+describe('reduce default behavior', () => {
+  test('any unhandled action returns the same state reference', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    // At this stage no actions are implemented; any action should be a no-op.
+    const a: TreeAction = { type: 'CANCEL_CLICKED' };
+    expect(reduce(s, a)).toBe(s);
+  });
+});
+```
+
+- [ ] **Step 2: Verify the tests fail**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: FAIL with module-not-found (`./state.js`).
+
+- [ ] **Step 3: Implement state.ts**
+
+```ts
+// packages/client/src/tree/state.ts
+import type { TreeVariant } from '@reef/shared';
+
+export interface PickerSelection {
+  variant: TreeVariant;
+  colorKey: string;
+}
+
+export type TreeState =
+  | { kind: 'idle'; picker: PickerSelection }
+  | {
+      kind: 'placing';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+      blocked: boolean;
+    }
+  | {
+      kind: 'submitting';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+    }
+  | { kind: 'resetting'; picker: PickerSelection };
+
+export type TreeAction =
+  | { type: 'VARIANT_CHOSEN'; variant: TreeVariant; seed: number }
+  | { type: 'COLOR_CHOSEN'; colorKey: string }
+  | { type: 'ATTACH_CLICKED'; parentId: number; attachIndex: number; seed: number }
+  | { type: 'REROLL_CLICKED'; variant: TreeVariant; seed: number }
+  | { type: 'PLACEMENT_BLOCKED' }
+  | { type: 'PLACEMENT_OK' }
+  | { type: 'CANCEL_CLICKED' }
+  | { type: 'GROW_CLICKED' }
+  | { type: 'COMMIT_RESOLVED' }
+  | { type: 'COMMIT_REJECTED'; error: string }
+  | { type: 'CLEAR_CLICKED' }
+  | { type: 'RESET_RESOLVED' }
+  | { type: 'RESET_REJECTED'; error: string }
+  | { type: 'TREE_RESET_EXTERNAL' };
+
+export function initialState(picker: PickerSelection): TreeState {
+  return { kind: 'idle', picker };
+}
+
+export function reduce(state: TreeState, _action: TreeAction): TreeState {
+  return state;
+}
+```
+
+- [ ] **Step 4: Verify the tests pass**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: scaffold types, initialState, default-identity reducer"
+```
+
+---
+
+## Task 2: Reducer — picker actions (VARIANT_CHOSEN, COLOR_CHOSEN)
+
+These actions are always legal. `VARIANT_CHOSEN` updates `picker.variant` in every state, and additionally updates `seed` when the current state has one (`placing`/`submitting`). `COLOR_CHOSEN` only updates `picker.colorKey`, never touches `seed`.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.ts`
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `state.test.ts`:
+
+```ts
+describe('VARIANT_CHOSEN', () => {
+  test('in idle: updates picker.variant, seed ignored', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 123 });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'claw', colorKey: 'neon-cyan' } });
+  });
+
+  test('in placing: updates both picker.variant and seed', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'wishbone', seed: 99 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 99, blocked: false,
+    });
+  });
+
+  test('in submitting: updates picker.variant and seed', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'trident', seed: 42 });
+    expect(next).toEqual({
+      kind: 'submitting',
+      picker: { variant: 'trident', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 42,
+    });
+  });
+
+  test('in resetting: updates picker.variant; no seed field exists', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'starburst', seed: 7 });
+    expect(next).toEqual({
+      kind: 'resetting',
+      picker: { variant: 'starburst', colorKey: 'neon-cyan' },
+    });
+  });
+});
+
+describe('COLOR_CHOSEN', () => {
+  test('in idle: updates picker.colorKey', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-magenta' } });
+  });
+
+  test('in placing: preserves seed, updates picker.colorKey only', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-lime' });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-lime' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Verify they fail**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: 6 new failures (reducer still returns state unchanged).
+
+- [ ] **Step 3: Implement the reducer cases**
+
+Replace the body of `reduce` in `state.ts`:
+
+```ts
+export function reduce(state: TreeState, action: TreeAction): TreeState {
+  switch (action.type) {
+    case 'VARIANT_CHOSEN': {
+      const picker = { ...state.picker, variant: action.variant };
+      switch (state.kind) {
+        case 'idle':      return { ...state, picker };
+        case 'placing':   return { ...state, picker, seed: action.seed };
+        case 'submitting':return { ...state, picker, seed: action.seed };
+        case 'resetting': return { ...state, picker };
+      }
+    }
+    case 'COLOR_CHOSEN': {
+      const picker = { ...state.picker, colorKey: action.colorKey };
+      return { ...state, picker };
+    }
+    default:
+      return state;
+  }
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: PASS — 8 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: picker actions (VARIANT_CHOSEN, COLOR_CHOSEN)"
+```
+
+---
+
+## Task 3: Reducer — attach selection (ATTACH_CLICKED, REROLL_CLICKED)
+
+`ATTACH_CLICKED` transitions `idle → placing` or overwrites the slot in `placing → placing`; no-op in `submitting`/`resetting`. `REROLL_CLICKED` is only valid in `placing`.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.ts`
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `state.test.ts`:
+
+```ts
+describe('ATTACH_CLICKED', () => {
+  test('from idle → placing with picker inherited, blocked false', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 5, attachIndex: 2, seed: 77 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 5, attachIndex: 2, seed: 77, blocked: false,
+    });
+  });
+
+  test('from placing → placing with new params, blocked reset to false', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 3, attachIndex: 1, seed: 55 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 3, attachIndex: 1, seed: 55, blocked: false,
+    });
+  });
+
+  test('from submitting: no-op (same reference returned)', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 9, attachIndex: 9, seed: 9 });
+    expect(next).toBe(s);
+  });
+
+  test('from resetting: no-op (same reference returned)', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 1, attachIndex: 0, seed: 1 });
+    expect(next).toBe(s);
+  });
+});
+
+describe('REROLL_CLICKED', () => {
+  test('from placing → placing with new variant + seed, blocked reset', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'claw', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 42, blocked: false,
+    });
+  });
+
+  test('from idle: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toBe(s);
+  });
+
+  test('from submitting: no-op', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toBe(s);
+  });
+});
+```
+
+- [ ] **Step 2: Verify they fail**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: 7 new failures.
+
+- [ ] **Step 3: Implement the reducer cases**
+
+Add `ATTACH_CLICKED` and `REROLL_CLICKED` cases to the `switch (action.type)` in `reduce`, above the `default`:
+
+```ts
+    case 'ATTACH_CLICKED': {
+      if (state.kind === 'idle' || state.kind === 'placing') {
+        return {
+          kind: 'placing',
+          picker: state.picker,
+          parentId: action.parentId,
+          attachIndex: action.attachIndex,
+          seed: action.seed,
+          blocked: false,
+        };
+      }
+      return state;
+    }
+    case 'REROLL_CLICKED': {
+      if (state.kind !== 'placing') return state;
+      return {
+        ...state,
+        picker: { ...state.picker, variant: action.variant },
+        seed: action.seed,
+        blocked: false,
+      };
+    }
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: PASS — 15 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: attach selection (ATTACH_CLICKED, REROLL_CLICKED)"
+```
+
+---
+
+## Task 4: Reducer — placement feedback (PLACEMENT_BLOCKED, PLACEMENT_OK)
+
+These are dispatched by the effects layer after `showGhost` runs. Only valid in `placing`.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.ts`
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `state.test.ts`:
+
+```ts
+describe('PLACEMENT_BLOCKED', () => {
+  test('in placing: sets blocked=true', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'PLACEMENT_BLOCKED' });
+    expect(next).toEqual({ ...s, blocked: true });
+  });
+
+  test('outside placing: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'PLACEMENT_BLOCKED' })).toBe(s);
+  });
+});
+
+describe('PLACEMENT_OK', () => {
+  test('in placing: sets blocked=false', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'PLACEMENT_OK' });
+    expect(next).toEqual({ ...s, blocked: false });
+  });
+
+  test('outside placing: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'PLACEMENT_OK' })).toBe(s);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail.**
+
+- [ ] **Step 3: Implement**
+
+Add cases to `reduce`:
+
+```ts
+    case 'PLACEMENT_BLOCKED': {
+      if (state.kind !== 'placing') return state;
+      return { ...state, blocked: true };
+    }
+    case 'PLACEMENT_OK': {
+      if (state.kind !== 'placing') return state;
+      return { ...state, blocked: false };
+    }
+```
+
+- [ ] **Step 4: Verify pass.** 19 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: placement feedback (PLACEMENT_BLOCKED, PLACEMENT_OK)"
+```
+
+---
+
+## Task 5: Reducer — commit flow (CANCEL, GROW, COMMIT_RESOLVED, COMMIT_REJECTED)
+
+- `CANCEL_CLICKED`: `placing → idle`, no-op elsewhere.
+- `GROW_CLICKED`: `placing` (blocked=false) → `submitting`; no-op elsewhere (including `placing` blocked=true).
+- `COMMIT_RESOLVED`: `submitting → idle`, no-op elsewhere.
+- `COMMIT_REJECTED`: `submitting → placing` with blocked=false, no-op elsewhere.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.ts`
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `state.test.ts`:
+
+```ts
+describe('CANCEL_CLICKED', () => {
+  test('from placing → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'CANCEL_CLICKED' });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('from idle/submitting/resetting: no-op', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const resetting: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(idle, { type: 'CANCEL_CLICKED' })).toBe(idle);
+    expect(reduce(submitting, { type: 'CANCEL_CLICKED' })).toBe(submitting);
+    expect(reduce(resetting, { type: 'CANCEL_CLICKED' })).toBe(resetting);
+  });
+});
+
+describe('GROW_CLICKED', () => {
+  test('from placing (blocked=false) → submitting with fields copied', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'GROW_CLICKED' });
+    expect(next).toEqual({
+      kind: 'submitting',
+      picker: s.picker,
+      parentId: 1, attachIndex: 0, seed: 10,
+    });
+  });
+
+  test('from placing (blocked=true): no-op', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    expect(reduce(s, { type: 'GROW_CLICKED' })).toBe(s);
+  });
+
+  test('from idle/submitting/resetting: no-op', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    expect(reduce(idle, { type: 'GROW_CLICKED' })).toBe(idle);
+    expect(reduce(submitting, { type: 'GROW_CLICKED' })).toBe(submitting);
+  });
+});
+
+describe('COMMIT_RESOLVED', () => {
+  test('from submitting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'COMMIT_RESOLVED' });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside submitting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'COMMIT_RESOLVED' })).toBe(s);
+  });
+});
+
+describe('COMMIT_REJECTED', () => {
+  test('from submitting → placing with blocked=false, fields carried', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: s.picker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    });
+  });
+
+  test('outside submitting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'COMMIT_REJECTED', error: 'x' })).toBe(s);
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail.**
+
+- [ ] **Step 3: Implement**
+
+Add cases to `reduce`:
+
+```ts
+    case 'CANCEL_CLICKED': {
+      if (state.kind !== 'placing') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'GROW_CLICKED': {
+      if (state.kind !== 'placing' || state.blocked) return state;
+      return {
+        kind: 'submitting',
+        picker: state.picker,
+        parentId: state.parentId,
+        attachIndex: state.attachIndex,
+        seed: state.seed,
+      };
+    }
+    case 'COMMIT_RESOLVED': {
+      if (state.kind !== 'submitting') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'COMMIT_REJECTED': {
+      if (state.kind !== 'submitting') return state;
+      return {
+        kind: 'placing',
+        picker: state.picker,
+        parentId: state.parentId,
+        attachIndex: state.attachIndex,
+        seed: state.seed,
+        blocked: false,
+      };
+    }
+```
+
+- [ ] **Step 4: Verify pass.** 27 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: commit flow (CANCEL, GROW, COMMIT_RESOLVED/REJECTED)"
+```
+
+---
+
+## Task 6: Reducer — reset flow (CLEAR, RESET_RESOLVED/REJECTED, TREE_RESET_EXTERNAL)
+
+- `CLEAR_CLICKED`: `idle`/`placing`/`submitting` → `resetting`, no-op in `resetting`.
+- `RESET_RESOLVED` / `RESET_REJECTED`: `resetting → idle`, no-op elsewhere.
+- `TREE_RESET_EXTERNAL`: any kind → `idle`, picker inherited.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.ts`
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `state.test.ts`:
+
+```ts
+describe('CLEAR_CLICKED', () => {
+  test('from idle → resetting with picker inherited', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from placing → resetting with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from submitting → resetting', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from resetting: no-op', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'CLEAR_CLICKED' })).toBe(s);
+  });
+});
+
+describe('RESET_RESOLVED', () => {
+  test('from resetting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'RESET_RESOLVED' }))
+      .toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside resetting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'RESET_RESOLVED' })).toBe(s);
+  });
+});
+
+describe('RESET_REJECTED', () => {
+  test('from resetting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'RESET_REJECTED', error: 'x' }))
+      .toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside resetting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'RESET_REJECTED', error: 'x' })).toBe(s);
+  });
+});
+
+describe('TREE_RESET_EXTERNAL', () => {
+  test('from any kind → idle with picker inherited', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const placing: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-lime' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'claw', colorKey: 'neon-violet' },
+      parentId: 2, attachIndex: 1, seed: 20,
+    };
+    const resetting: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'trident', colorKey: 'neon-orange' },
+    };
+    expect(reduce(idle, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: idle.picker });
+    expect(reduce(placing, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: placing.picker });
+    expect(reduce(submitting, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: submitting.picker });
+    expect(reduce(resetting, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: resetting.picker });
+  });
+});
+```
+
+- [ ] **Step 2: Verify fail.**
+
+- [ ] **Step 3: Implement**
+
+Add cases:
+
+```ts
+    case 'CLEAR_CLICKED': {
+      if (state.kind === 'resetting') return state;
+      return { kind: 'resetting', picker: state.picker };
+    }
+    case 'RESET_RESOLVED':
+    case 'RESET_REJECTED': {
+      if (state.kind !== 'resetting') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'TREE_RESET_EXTERNAL':
+      return { kind: 'idle', picker: state.picker };
+```
+
+- [ ] **Step 4: Verify pass.** 36 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/client/src/tree/state.ts packages/client/src/tree/state.test.ts
+git commit -m "Tree state: reset flow (CLEAR, RESET_*, TREE_RESET_EXTERNAL)"
+```
+
+---
+
+## Task 7: Reducer — exhaustive no-op coverage
+
+Add a parametrized test that asserts reference-equality for every (state, action) combination not covered above. This is the safety net.
+
+**Files:**
+- Modify: `packages/client/src/tree/state.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Append:
+
+```ts
+describe('reduce — no-op matrix', () => {
+  // Sample states of each kind, populated with deterministic field values.
+  const samples: Record<TreeState['kind'], TreeState> = {
+    idle: { kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+    placing: {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    },
+    submitting: {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    },
+    resetting: { kind: 'resetting', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+  };
+
+  // The `valid` matrix lists which action types produce a real transition
+  // (non-identity result) from each state kind.
+  const valid: Record<TreeState['kind'], readonly TreeAction['type'][]> = {
+    idle: ['VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL'],
+    placing: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'REROLL_CLICKED',
+      'PLACEMENT_BLOCKED', 'PLACEMENT_OK', 'CANCEL_CLICKED', 'GROW_CLICKED',
+      'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL',
+    ],
+    submitting: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN',
+      'COMMIT_RESOLVED', 'COMMIT_REJECTED',
+      'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL',
+    ],
+    resetting: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN',
+      'RESET_RESOLVED', 'RESET_REJECTED',
+      'TREE_RESET_EXTERNAL',
+    ],
+  };
+
+  // Every TreeAction shape with sample payload, enumerated once.
+  const allActions: TreeAction[] = [
+    { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 1 },
+    { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' },
+    { type: 'ATTACH_CLICKED', parentId: 1, attachIndex: 0, seed: 1 },
+    { type: 'REROLL_CLICKED', variant: 'wishbone', seed: 2 },
+    { type: 'PLACEMENT_BLOCKED' },
+    { type: 'PLACEMENT_OK' },
+    { type: 'CANCEL_CLICKED' },
+    { type: 'GROW_CLICKED' },
+    { type: 'COMMIT_RESOLVED' },
+    { type: 'COMMIT_REJECTED', error: 'x' },
+    { type: 'CLEAR_CLICKED' },
+    { type: 'RESET_RESOLVED' },
+    { type: 'RESET_REJECTED', error: 'x' },
+    { type: 'TREE_RESET_EXTERNAL' },
+  ];
+
+  for (const kind of Object.keys(samples) as Array<TreeState['kind']>) {
+    const state = samples[kind];
+    for (const action of allActions) {
+      const expectIdentity = !valid[kind].includes(action.type);
+      test(`${kind} + ${action.type} → ${expectIdentity ? 'identity' : 'transition'}`, () => {
+        const next = reduce(state, action);
+        if (expectIdentity) {
+          expect(next).toBe(state);
+        } else {
+          // For covered transitions we already assert specifics elsewhere;
+          // here just ensure we *didn't* return identity.
+          expect(next).not.toBe(state);
+        }
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Verify the tests pass**
+
+Run: `pnpm --filter @reef/client test src/tree/state.test.ts`
+Expected: PASS — 36 + 56 = 92 tests (4 kinds × 14 actions = 56 matrix tests).
+
+If any test fails, there's either a bug in the reducer or a miscategorization in the `valid` table. Fix before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree/state.test.ts
+git commit -m "Tree state: exhaustive no-op matrix — 56 identity assertions"
+```
+
+---
+
+## Task 8: Effects scaffold — createEffects factory + deps interface
+
+Set up the effect runner shell. Skeleton `apply` that does nothing yet — we'll add transition branches in subsequent tasks.
+
+**Files:**
+- Create: `packages/client/src/tree/effects.ts`
+
+- [ ] **Step 1: Implement the scaffold**
+
+```ts
+// packages/client/src/tree/effects.ts
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { TreeReef } from './reef.js';
+import type { TreePlacement } from './placement.js';
+import type { AttachIndicators } from './indicators.js';
+import type { TreePicker } from '../ui/treePicker.js';
+import type { TreeState, TreeAction } from './state.js';
+
+export interface EffectsDeps {
+  placement: TreePlacement;
+  treeReef: TreeReef;
+  indicators: AttachIndicators;
+  picker: TreePicker;
+  controls: OrbitControls;
+  hintEl: HTMLElement;
+  apiBase: string;
+  /** Called by async callbacks inside effects to drive state transitions. */
+  dispatch: (action: TreeAction) => void;
+  /** Factory for adding a fetched polyp set back into the reef. Called after
+   *  a successful reset so the re-seeded root renders. */
+  addPiecesAndRefresh: (polyps: import('@reef/shared').PublicTreePolyp[]) => void;
+}
+
+export interface Effects {
+  /**
+   * Fire side effects for a state transition. `action` is included because
+   * some transitions (notably `submitting → idle` and `resetting → idle`) can
+   * arrive via different actions and need different UI behavior:
+   *   - submitting → idle via COMMIT_RESOLVED: success hint
+   *   - submitting → idle via TREE_RESET_EXTERNAL: reset hint
+   *   - resetting → idle via RESET_RESOLVED: success hint
+   *   - resetting → idle via RESET_REJECTED: error hint (already set in reject callback)
+   */
+  apply(prev: TreeState, next: TreeState, action: TreeAction): void;
+}
+
+export function createEffects(_deps: EffectsDeps): Effects {
+  return {
+    apply(_prev: TreeState, _next: TreeState, _action: TreeAction): void {
+      // Filled in by subsequent tasks.
+    },
+  };
+}
+```
+
+The `addPiecesAndRefresh` dep exists because adding a polyp requires also installing sway/pulse effects, which is a concern owned by tree.ts (where `swayClock` lives). Exposing it as a dep avoids duplicating that logic here.
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm --filter @reef/client typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree/effects.ts
+git commit -m "Tree effects: createEffects scaffold + EffectsDeps interface"
+```
+
+---
+
+## Task 9: Effects — placement transitions
+
+Fills in the two biggest branches: any transition into `placing` with different params (call `showGhost`, dispatch `PLACEMENT_BLOCKED/OK`, update picker committable, update hint) and a pure `blocked` flip inside `placing` (just update button + hint).
+
+**Files:**
+- Modify: `packages/client/src/tree/effects.ts`
+
+- [ ] **Step 1: Implement the placement branches**
+
+Replace the body of `apply` in `effects.ts` with this full implementation (the commit/reset branches are no-ops for now, filled in later):
+
+```ts
+export function createEffects(deps: EffectsDeps): Effects {
+  return {
+    apply(prev: TreeState, next: TreeState, action: TreeAction): void {
+      // Entering placing from elsewhere, or changing slot/variant/seed/color
+      // within placing → re-show the ghost and refresh indicators hint.
+      if (
+        next.kind === 'placing' &&
+        (prev.kind !== 'placing' || hasPlacingIdentityChanged(prev, next))
+      ) {
+        const { variant, colorKey } = next.picker;
+        const ghost = deps.placement.showGhost(
+          variant,
+          next.seed,
+          colorKey,
+          next.parentId,
+          next.attachIndex,
+        );
+        if (ghost) {
+          deps.dispatch({ type: 'PLACEMENT_OK' });
+          deps.picker.setCommittable(true);
+          deps.hintEl.textContent = 'Happy with it? Click Grow.';
+        } else {
+          deps.dispatch({ type: 'PLACEMENT_BLOCKED' });
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'That spot is blocked. Try another dot or reroll.';
+        }
+        return;
+      }
+
+      // Pure blocked flip within placing (triggered by PLACEMENT_BLOCKED/OK
+      // dispatched after showGhost — which already ran above).
+      if (
+        next.kind === 'placing' && prev.kind === 'placing' &&
+        !hasPlacingIdentityChanged(prev, next) &&
+        prev.blocked !== next.blocked
+      ) {
+        deps.picker.setCommittable(!next.blocked);
+        return;
+      }
+
+      // Leaving placing for idle (cancel).
+      if (prev.kind === 'placing' && next.kind === 'idle' && action.type === 'CANCEL_CLICKED') {
+        deps.placement.reset();
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Cancelled. Click a glowing dot to try again.';
+        return;
+      }
+    },
+  };
+}
+
+/** True when the placing-state identity fields (slot + variant + seed + color)
+ *  changed between prev and next. Used to decide whether to re-show the ghost
+ *  vs. only updating the commit button for a pure blocked flip. */
+function hasPlacingIdentityChanged(
+  prev: TreeState & { kind: 'placing' },
+  next: TreeState & { kind: 'placing' },
+): boolean {
+  return (
+    prev.parentId !== next.parentId ||
+    prev.attachIndex !== next.attachIndex ||
+    prev.seed !== next.seed ||
+    prev.picker.variant !== next.picker.variant ||
+    prev.picker.colorKey !== next.picker.colorKey
+  );
+}
+```
+
+Note: `hasPlacingIdentityChanged` is declared at the module level (not inside `createEffects`) so it can be tested independently if desired.
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm --filter @reef/client typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree/effects.ts
+git commit -m "Tree effects: placement transitions (showGhost, blocked flip, cancel)"
+```
+
+---
+
+## Task 10: Effects — commit flow
+
+Adds branches for `placing → submitting` (call `submitTreePolyp`, attach resolve/reject handlers), `submitting → idle` (commit resolved), and `submitting → placing` (commit rejected).
+
+**Files:**
+- Modify: `packages/client/src/tree/effects.ts`
+
+- [ ] **Step 1: Add the commit-flow branches**
+
+Add `submitTreePolyp` import at the top of `effects.ts`:
+
+```ts
+import { submitTreePolyp } from './api.js';
+```
+
+Insert these branches in `apply`, after the placing-flow branches and before the final closing brace:
+
+```ts
+      // Grow: placing → submitting. Fire the POST and wire its resolution.
+      if (prev.kind === 'placing' && next.kind === 'submitting') {
+        deps.picker.setSubmitting(true);
+        submitTreePolyp(
+          {
+            variant: next.picker.variant,
+            seed: next.seed,
+            colorKey: next.picker.colorKey,
+            parentId: next.parentId,
+            attachIndex: next.attachIndex,
+          },
+          deps.apiBase,
+        ).then(
+          () => deps.dispatch({ type: 'COMMIT_RESOLVED' }),
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            deps.hintEl.textContent = `Grow failed: ${msg}`;
+            deps.dispatch({ type: 'COMMIT_REJECTED', error: msg });
+          },
+        );
+        return;
+      }
+
+      // Commit resolved: submitting → idle via COMMIT_RESOLVED.
+      // (submitting → idle can also happen via TREE_RESET_EXTERNAL; that case
+      // is handled by the external-reset branch in Task 11.)
+      if (
+        prev.kind === 'submitting' && next.kind === 'idle' &&
+        action.type === 'COMMIT_RESOLVED'
+      ) {
+        deps.placement.reset();
+        deps.picker.setSubmitting(false);
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Grown! Click another dot to plant again.';
+        return;
+      }
+
+      // Commit rejected: submitting → placing. Hint was set by the reject
+      // callback above; just unwind the submitting UI.
+      if (
+        prev.kind === 'submitting' && next.kind === 'placing' &&
+        action.type === 'COMMIT_REJECTED'
+      ) {
+        deps.picker.setSubmitting(false);
+        return;
+      }
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm --filter @reef/client typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree/effects.ts
+git commit -m "Tree effects: commit flow (submit, resolved, rejected)"
+```
+
+---
+
+## Task 11: Effects — reset flow + TREE_RESET_EXTERNAL
+
+Handles `* → resetting` (clear ghost immediately, call resetTree, re-populate on resolve), `resetting → idle` (hint update), and `* → idle` via `TREE_RESET_EXTERNAL` (placement reset only).
+
+**Files:**
+- Modify: `packages/client/src/tree/effects.ts`
+
+- [ ] **Step 1: Add the reset branches**
+
+Add `resetTree` and `fetchTree` to the api.js import at the top of `effects.ts`:
+
+```ts
+import { fetchTree, resetTree, submitTreePolyp } from './api.js';
+```
+
+Insert these branches in `apply`, after the commit-flow branches:
+
+```ts
+      // Clear: any → resetting. Wipe the ghost immediately, fire the API.
+      if (prev.kind !== 'resetting' && next.kind === 'resetting') {
+        deps.placement.reset();
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Clearing…';
+        resetTree(deps.apiBase).then(
+          async () => {
+            // Clear local reef, then re-fetch authoritative state.
+            deps.treeReef.clear();
+            deps.indicators.refresh([]);
+            try {
+              const { polyps } = await fetchTree(deps.apiBase);
+              deps.addPiecesAndRefresh(polyps);
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              deps.hintEl.textContent = `Clear: re-fetch failed — ${msg}`;
+            }
+            deps.dispatch({ type: 'RESET_RESOLVED' });
+          },
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            deps.hintEl.textContent = `Clear failed: ${msg}`;
+            deps.dispatch({ type: 'RESET_REJECTED', error: msg });
+          },
+        );
+        return;
+      }
+
+      // Resetting → idle via RESET_RESOLVED. Success hint.
+      if (
+        prev.kind === 'resetting' && next.kind === 'idle' &&
+        action.type === 'RESET_RESOLVED'
+      ) {
+        deps.hintEl.textContent = 'Cleared. Click a glowing dot to start growing.';
+        return;
+      }
+
+      // Resetting → idle via RESET_REJECTED. Error hint was already written
+      // by the reject callback above; no further work.
+      if (
+        prev.kind === 'resetting' && next.kind === 'idle' &&
+        action.type === 'RESET_REJECTED'
+      ) {
+        return;
+      }
+
+      // TREE_RESET_EXTERNAL: any → idle. The socket handler in tree.ts
+      // already called treeReef.clear() and indicators.refresh(); here we
+      // just drop any pending ghost and unwind submit UI if applicable.
+      //
+      // Four cases depending on `prev.kind`:
+      //   - placing/submitting: a remote user reset while we were interacting.
+      //   - resetting: our own local clear — the server's tree_reset echo
+      //     arrived before our HTTP resolve. Success hint.
+      //   - idle: nothing to do (no ghost, no UI to unwind).
+      if (next.kind === 'idle' && action.type === 'TREE_RESET_EXTERNAL') {
+        if (prev.kind === 'placing') {
+          deps.placement.reset();
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'Tree was reset by another user.';
+        } else if (prev.kind === 'submitting') {
+          deps.placement.reset();
+          deps.picker.setSubmitting(false);
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'Tree was reset by another user.';
+        } else if (prev.kind === 'resetting') {
+          deps.hintEl.textContent = 'Cleared. Click a glowing dot to start growing.';
+        }
+        // prev === 'idle': no-op.
+        return;
+      }
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm --filter @reef/client typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree/effects.ts
+git commit -m "Tree effects: reset flow (clear, re-fetch, external reset)"
+```
+
+---
+
+## Task 12: tree.ts rewrite — shell with state + dispatch
+
+Replaces `tree.ts` with a thin orchestrator. Single module-level `state`, single `dispatch` function, no more `pendingParentId`/`pendingAttachIndex`/`currentSeed`/`suppressNextClick`/`dragState` scattered across the file.
+
+This is the biggest single task. It replaces the whole file in one swap.
+
+**Files:**
+- Modify: `packages/client/src/tree.ts`
+
+- [ ] **Step 1: Rewrite tree.ts in full**
+
+Before editing: read the CURRENT `packages/client/src/tree.ts` in its entirety so you understand which imports, DOM setup, and toolbar wiring are already there. The rewrite below preserves all of that — scene setup, camera, renderer, controls, lighting, fog, bloom, spawnable creatures (shark/clownfish/add-fish buttons), socket, sway/pulse — and only replaces the placement-related event handling with the state machine.
+
+Replace the entire contents of `packages/client/src/tree.ts` with:
+
+```ts
+import {
+  PerspectiveCamera,
+  Raycaster,
+  Scene,
+  Vector2,
+  WebGLRenderer,
+  type Mesh,
+} from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { PublicTreePolyp } from '@reef/shared';
+import { installSway } from './scene/currentSway.js';
+import { installTreePulse } from './tree/pulse.js';
+import { readTreeConfig } from './tree/config.js';
+import {
+  createTreePedestal,
+  createBloomComposer,
+  createUnderwaterBackground,
+  createUnderwaterFog,
+  installUnderwaterLighting,
+} from './tree/scene.js';
+import { TreeReef } from './tree/reef.js';
+import { AttachIndicators } from './tree/indicators.js';
+import { TreePlacement } from './tree/placement.js';
+import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
+import { TREE_VARIANTS, TreePicker } from './ui/treePicker.js';
+import { computeOrbitPose } from './playground/autoOrbit.js';
+import { Shark } from './tree/shark.js';
+import { Clownfish } from './tree/clownfish.js';
+import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
+import { createEffects } from './tree/effects.js';
+
+// ------------------------------------------------------------------
+// Config + canvas
+// ------------------------------------------------------------------
+const config = readTreeConfig();
+const canvas = document.getElementById('gl') as HTMLCanvasElement;
+const modeBadge = document.getElementById('mode-badge')!;
+modeBadge.textContent = `${config.mode}${config.readonly ? ' · readonly' : ''}`;
+
+// ------------------------------------------------------------------
+// Renderer + scene
+// ------------------------------------------------------------------
+const renderer = new WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+
+const scene = new Scene();
+scene.background = createUnderwaterBackground();
+scene.fog = createUnderwaterFog();
+renderer.setClearColor(0x01060d, 1);
+
+installUnderwaterLighting(scene);
+scene.add(createTreePedestal());
+
+// ------------------------------------------------------------------
+// Camera + controls
+// ------------------------------------------------------------------
+const camera = new PerspectiveCamera(50, 1, 0.01, 20);
+camera.position.set(0.45, 0.2, 0);
+camera.lookAt(0, 0, 0);
+
+const controls = new OrbitControls(camera, canvas);
+controls.target.set(0, 0, 0);
+controls.minDistance = 0.2;
+controls.maxDistance = 1.2;
+controls.maxPolarAngle = Math.PI / 2 - 0.05;
+controls.enableDamping = true;
+
+const bloomSetup = createBloomComposer(renderer, scene, camera);
+
+// ------------------------------------------------------------------
+// Tree content + placement
+// ------------------------------------------------------------------
+const treeReef = new TreeReef();
+scene.add(treeReef.anchor);
+
+const attachIndicators = new AttachIndicators();
+scene.add(attachIndicators.group);
+
+const placement = new TreePlacement(treeReef);
+scene.add(placement.ghostAnchor);
+
+// ------------------------------------------------------------------
+// Sway/pulse effect installer (used on every newly-added piece).
+// ------------------------------------------------------------------
+const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
+const swayClock = { value: 0 };
+
+function installEffectsOnNewPieces(): void {
+  for (const { polyp, mesh } of treeReef.allPieces()) {
+    const flags = mesh.userData as Record<PropertyKey, unknown>;
+    if (!flags[SWAY_INSTALLED]) {
+      installSway(mesh as Mesh, swayClock);
+      flags[SWAY_INSTALLED] = true;
+    }
+    if (!flags[PULSE_INSTALLED]) {
+      installTreePulse(mesh as Mesh, swayClock, polyp.seed);
+      flags[PULSE_INSTALLED] = true;
+    }
+  }
+}
+
+function addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
+  const sorted = [...polyps].sort((a, b) => a.createdAt - b.createdAt);
+  for (const polyp of sorted) treeReef.addPiece(polyp);
+  installEffectsOnNewPieces();
+  attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+}
+
+// ------------------------------------------------------------------
+// Spawnable sea life — empty by default.
+// ------------------------------------------------------------------
+interface SwimmingCreature { update: (clockSec: number) => void; }
+const creatures: SwimmingCreature[] = [];
+function spawnShark(): void {
+  const s = new Shark({
+    orbitRadius: 0.25 + Math.random() * 0.15,
+    orbitHeight: 0.05 + Math.random() * 0.2,
+    orbitPeriodSec: 14 + Math.random() * 10,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(s.group);
+  creatures.push(s);
+}
+function spawnClownfish(): void {
+  const c = new Clownfish({
+    orbitRadius: 0.15 + Math.random() * 0.15,
+    orbitHeight: 0.04 + Math.random() * 0.2,
+    orbitPeriodSec: 5 + Math.random() * 6,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(c.group);
+  creatures.push(c);
+}
+
+// ------------------------------------------------------------------
+// Picker + state machine
+// ------------------------------------------------------------------
+const pickerRoot = document.getElementById('picker')!;
+const picker = new TreePicker(pickerRoot);
+const hintEl = document.getElementById('hint')!;
+
+const effects = createEffects({
+  placement, treeReef, indicators: attachIndicators, picker, controls,
+  hintEl, apiBase: config.apiBase,
+  dispatch: (action) => dispatch(action),
+  addPiecesAndRefresh,
+});
+
+let state: TreeState = initialState(picker.get());
+
+function dispatch(action: TreeAction): void {
+  const prev = state;
+  state = reduce(state, action);
+  if (state !== prev) effects.apply(prev, state, action);
+}
+
+// Wire picker → dispatch.
+picker.onChange((sel) => {
+  const current = state.picker;
+  if (sel.variant !== current.variant) {
+    const seed = Math.floor(Math.random() * 0xffffffff);
+    dispatch({ type: 'VARIANT_CHOSEN', variant: sel.variant, seed });
+  }
+  if (sel.colorKey !== current.colorKey) {
+    dispatch({ type: 'COLOR_CHOSEN', colorKey: sel.colorKey });
+  }
+});
+picker.onReroll(() => {
+  if (state.kind !== 'placing') return;
+  const options = TREE_VARIANTS.filter((v) => v !== state.picker.variant);
+  const variant = options[Math.floor(Math.random() * options.length)]!;
+  const seed = Math.floor(Math.random() * 0xffffffff);
+  dispatch({ type: 'REROLL_CLICKED', variant, seed });
+});
+picker.onCancel(() => dispatch({ type: 'CANCEL_CLICKED' }));
+picker.onCommit(() => dispatch({ type: 'GROW_CLICKED' }));
+
+// ------------------------------------------------------------------
+// Toolbar → dispatch / direct spawn
+// ------------------------------------------------------------------
+const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
+const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
+const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
+if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
+if (addSharkBtn) addSharkBtn.addEventListener('click', spawnShark);
+if (addClownfishBtn) addClownfishBtn.addEventListener('click', spawnClownfish);
+
+// ------------------------------------------------------------------
+// Pointer-drag: rotate ghost in place instead of orbiting while placing.
+// ------------------------------------------------------------------
+let dragState: { lastX: number; moved: boolean } | null = null;
+let suppressNextClick = false;
+const DRAG_THRESHOLD_PX = 3;
+const ROT_SENSITIVITY = 0.0055;
+
+canvas.addEventListener(
+  'pointerdown',
+  (ev) => {
+    if (state.kind !== 'placing') return;
+    if (config.mode !== 'screen') controls.enabled = false;
+    dragState = { lastX: ev.clientX, moved: false };
+    canvas.setPointerCapture(ev.pointerId);
+  },
+  { capture: true },
+);
+canvas.addEventListener('pointermove', (ev) => {
+  if (!dragState) return;
+  const dx = ev.clientX - dragState.lastX;
+  if (!dragState.moved && Math.abs(dx) > DRAG_THRESHOLD_PX) dragState.moved = true;
+  if (dragState.moved) {
+    placement.rotateGhost(dx * ROT_SENSITIVITY);
+    dragState.lastX = ev.clientX;
+  }
+});
+canvas.addEventListener('pointerup', (ev) => {
+  if (!dragState) return;
+  if (canvas.hasPointerCapture(ev.pointerId)) canvas.releasePointerCapture(ev.pointerId);
+  suppressNextClick = dragState.moved;
+  dragState = null;
+  if (config.mode !== 'screen') controls.enabled = true;
+});
+
+// ------------------------------------------------------------------
+// Click (attach-orb pick) — interactive mode only
+// ------------------------------------------------------------------
+if (config.mode === 'interactive') {
+  picker.show();
+  const raycaster = new Raycaster();
+  raycaster.params.Points = { threshold: 0.01 };
+
+  canvas.addEventListener('click', (ev) => {
+    if (suppressNextClick) { suppressNextClick = false; return; }
+    const rect = canvas.getBoundingClientRect();
+    const ndc = new Vector2(
+      ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+      -(((ev.clientY - rect.top) / rect.height) * 2 - 1),
+    );
+    raycaster.setFromCamera(ndc, camera);
+    const intersects = raycaster.intersectObjects(attachIndicators.group.children, false);
+    if (intersects.length === 0) {
+      if (state.kind === 'idle') {
+        hintEl.textContent = 'Click a glowing dot to attach your piece.';
+      }
+      return;
+    }
+    const hit = intersects[0]!;
+    const ud = hit.object.userData as { parentId?: number; attachIndex?: number };
+    if (ud.parentId === undefined || ud.attachIndex === undefined) return;
+    const seed = Math.floor(Math.random() * 0xffffffff);
+    dispatch({
+      type: 'ATTACH_CLICKED',
+      parentId: ud.parentId,
+      attachIndex: ud.attachIndex,
+      seed,
+    });
+  });
+}
+
+// ------------------------------------------------------------------
+// Resize
+// ------------------------------------------------------------------
+function resize(): void {
+  const w = window.innerWidth, h = window.innerHeight;
+  renderer.setSize(w, h, false);
+  bloomSetup.composer.setSize(w, h);
+  bloomSetup.bloomPass.resolution.set(w, h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resize);
+resize();
+
+// ------------------------------------------------------------------
+// Initial fetch
+// ------------------------------------------------------------------
+(async () => {
+  try {
+    const { polyps } = await fetchTree(config.apiBase);
+    addPiecesAndRefresh(polyps);
+    if (config.mode === 'interactive') {
+      hintEl.textContent = polyps.length
+        ? 'Click a glowing dot to attach your piece.'
+        : 'Click Clear and grow something new.';
+    }
+  } catch (e) {
+    console.error('[tree] Failed to load tree', e);
+    hintEl.textContent = 'Failed to load tree. Check the server.';
+  }
+})();
+
+// ------------------------------------------------------------------
+// WebSocket: tree content updates (idempotent on polyp id)
+// ------------------------------------------------------------------
+function buildTreeWsUrl(): string {
+  if (config.apiBase) {
+    return config.apiBase.replace(/^http/, 'ws') + '/ws/tree';
+  }
+  return defaultTreeWsUrl();
+}
+const socket = new TreeSocket(buildTreeWsUrl());
+socket.on((msg) => {
+  if (msg.type === 'tree_hello') {
+    // No-op; initial state was fetched via HTTP.
+  } else if (msg.type === 'tree_polyp_added') {
+    treeReef.addPiece(msg.polyp);
+    installEffectsOnNewPieces();
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  } else if (msg.type === 'tree_polyp_removed') {
+    treeReef.removePiece(msg.id);
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  } else if (msg.type === 'tree_reset') {
+    treeReef.clear();
+    attachIndicators.refresh([]);
+    dispatch({ type: 'TREE_RESET_EXTERNAL' });
+  }
+});
+socket.connect();
+
+// ------------------------------------------------------------------
+// Render loop
+// ------------------------------------------------------------------
+function loop(t: number): void {
+  const tSec = t / 1000;
+  swayClock.value = tSec;
+  for (const c of creatures) c.update(tSec);
+
+  if (config.mode === 'screen') {
+    const pose = computeOrbitPose(tSec);
+    camera.position.copy(pose.position);
+    camera.lookAt(pose.target);
+  } else {
+    controls.update();
+  }
+  bloomSetup.render();
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);
+```
+
+- [ ] **Step 2: Typecheck + tests**
+
+Run: `pnpm --filter @reef/client typecheck`
+Expected: clean.
+
+Run: `pnpm --filter @reef/client test`
+Expected: all existing tests still pass (nothing in tests imports from `tree.ts` directly — they target submodules that haven't changed). The state machine tests added in earlier tasks also pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/client/src/tree.ts
+git commit -m "Tree: rewrite tree.ts as thin state-machine orchestrator"
+```
+
+---
+
+## Task 13: Final verification — smoke test + full workspace check
+
+Run the whole suite and typechecks across packages, then validate the interactive flows in a browser.
+
+**Files:**
+- None modified.
+
+- [ ] **Step 1: Run the full workspace suite**
+
+```bash
+cd /Users/johncosta/dev/CoralReefAR
+pnpm -r typecheck
+pnpm -r test
+```
+
+Expected: all packages typecheck clean; all tests pass. The client count includes the 92 new reducer tests added in Tasks 1-7.
+
+- [ ] **Step 2: Manual browser smoke test**
+
+Server + client dev running:
+
+```bash
+pnpm --filter @reef/server dev
+pnpm --filter @reef/client dev
+```
+
+Open `http://localhost:5173/tree.html?api=http://localhost:8787`. Exercise each flow:
+
+- Initial load shows the seeded root with its attach indicators.
+- Click an attach indicator → ghost appears, Grow/Reroll/Cancel enabled.
+- Click Reroll → ghost changes variant (random non-current variant). Click Reroll 5x in a row → each produces a new ghost, no disappearance.
+- Click + drag on the canvas while ghost is showing → ghost rotates in place, camera does not orbit.
+- Release drag → subsequent pointer drags orbit the camera again (until ghost is pending).
+- Click a different attach indicator while ghost is shown → ghost moves to new slot.
+- Click Cancel → ghost disappears, orbit controls fully active.
+- Click attach → Grow → piece is committed, indicators refresh to include the new piece's slots.
+- Click Clear → ghost clears, tree wipes, new random Starburst root seeds, indicators refresh.
+- Click Add shark / Add clownfish → creatures spawn and begin their orbits.
+
+- [ ] **Step 3: Clean up stale stashed changes if any**
+
+Check `git status`. If there are modifications to files in `packages/client/src/tree/` from the in-flight material/env work, decide whether to keep them or revert:
+
+```bash
+git status --short
+```
+
+Expected: only deliberate changes from this plan. The material + environment upgrades from the prior session (MeshPhysicalMaterial swap in `material.ts`, gradient background + fog in `scene.ts`, indicator radius bump, shark/clownfish constructor params) are allowed to remain — they're orthogonal to the state machine.
+
+- [ ] **Step 4: Final commit if there were any follow-up fixes during verification**
+
+If you had to fix anything during smoke testing (e.g., missing hint text, a typo in an action name), commit it:
+
+```bash
+git add -p   # review hunk-by-hunk
+git commit -m "Tree: fixes from state-machine smoke testing"
+```
+
+Otherwise no commit needed — the refactor is complete.
+
+---
+
+## Follow-ups (not part of this plan)
+
+These were intentionally deferred per the spec:
+
+1. **Multi-branch per attach point** — schema migration + UI support.
+2. **Persisted drag yaw** — `attach_yaw` column + wiring at commit + apply in `TreeReef.addPiece`.
+3. **Indicator hit-test tuning** — radius constant already bumped; revisit if users still struggle.
+4. **Rejection UI** — currently `hintEl.textContent` shows errors; could upgrade to a toast.
+5. **Effects unit tests** — spec listed as optional. Add if the integration smoke test surfaces branches that were hard to reason about.

--- a/docs/superpowers/specs/2026-04-22-tree-state-machine-design.md
+++ b/docs/superpowers/specs/2026-04-22-tree-state-machine-design.md
@@ -44,9 +44,9 @@ Three layers with strict boundaries:
 
 **Layer 2 — Effect runner (`packages/client/src/tree/effects.ts`)**
 
-- `createEffects(deps): { apply(prev, next) }` factory.
+- `createEffects(deps): { apply(prev, next, action) }` factory.
 - Dependencies are injected so the runner can be tested or swapped: `placement`, `indicators`, `picker`, `controls`, `hintEl`, `apiBase`, `treeReef`, `dispatch`.
-- `apply(prev, next)` compares the two states and fires exactly the side effects implied by the transition. Runs synchronously.
+- `apply(prev, next, action)` fires the side effects implied by the transition. The action is included so transitions that share a `(prev, next)` pair but differ in meaning can be distinguished — notably `submitting → idle` (either COMMIT_RESOLVED or TREE_RESET_EXTERNAL) and `resetting → idle` (RESET_RESOLVED or RESET_REJECTED). Runs synchronously.
 - `placement.showGhost` is synchronous; its result (`mesh` or `null`) is immediately dispatched as `PLACEMENT_OK` or `PLACEMENT_BLOCKED`. That dispatch re-enters `apply`, which only updates commit-button/hint for a pure `blocked` flip — no infinite loop.
 - Only the explicit async calls (`submitTreePolyp`, `resetTree`) defer and dispatch their terminal actions (`COMMIT_RESOLVED`/`REJECTED`, `RESET_RESOLVED`/`REJECTED`) on resolution.
 

--- a/docs/superpowers/specs/2026-04-22-tree-state-machine-design.md
+++ b/docs/superpowers/specs/2026-04-22-tree-state-machine-design.md
@@ -1,0 +1,284 @@
+# Tree Placement State Machine — Design Spec
+
+## Context
+
+The tree-mode client (`packages/client/src/tree.ts`) has grown organically since v0.5.0. State is spread across several module-level mutable variables:
+
+- `pendingParentId`, `pendingAttachIndex`, `currentSeed` — owned by `tree.ts`
+- `placement.pending`, `placement.ghost` — owned by `TreePlacement`
+- `dragState`, `suppressNextClick` — pointer-drag scratch
+- `picker.state` — owned by `TreePicker`
+
+Multiple listeners (canvas click, `onChange`, `onReroll`, `onCancel`, `onCommit`, pointerdown/up, `clearBtn`, socket handler) read and write these fields with overlapping responsibilities. Concrete bug patterns observed so far:
+
+- Reroll-twice: `setVariant` fired `onChange` which called `showGhost` with the stale seed, then reroll's explicit `showGhost` fired with the new seed. Both `showGhost` calls could reject on collision, leaving the user with no ghost and a dangling `pendingParentId`.
+- Drag-rotate had to add `suppressNextClick` as a fourth piece of state to prevent clicks that were actually drags from re-attaching to the same slot.
+- Cross-client socket echoes (e.g., `tree_polyp_added` from an own submit) were handled in the same code path as remote updates, with ad-hoc "is this our pending piece?" matching.
+
+A deterministic state machine gives us one place to express what transitions are legal, one place to fire side effects, and exhaustive unit tests on the reducer with zero Three.js or DOM cost.
+
+## Goals
+
+1. Make invalid states unrepresentable via a TypeScript discriminated union.
+2. Centralize transitions in a pure reducer for deterministic testing.
+3. Eliminate ad-hoc module-level mutable flags in `tree.ts`.
+4. Decouple "what the state is" from "what side effects fire" — bugs in either layer are isolated.
+
+## Non-goals
+
+- Changes to generator, `TreeReef`, `TreePlacement`, `TreePicker`, or `AttachIndicators` internals. Their public APIs are preserved.
+- The "2+ branches per attach point" feature (requires schema migration; separate design).
+- Indicator hit-test sizing (a simple constant bump; do separately if still needed after the refactor).
+- The material + environment polish already in flight (orthogonal; stays as-is).
+
+## Architecture
+
+Three layers with strict boundaries:
+
+**Layer 1 — Pure state (`packages/client/src/tree/state.ts`)**
+
+- `TreeState` discriminated union.
+- `TreeAction` discriminated union covering every user + network event that changes state.
+- `reduce(state: TreeState, action: TreeAction): TreeState` — pure, deterministic, no imports from `three`, no DOM access, no network. Same input always yields same output.
+- `initialState(picker: PickerSelection): TreeState` — factory for the starting idle state.
+
+**Layer 2 — Effect runner (`packages/client/src/tree/effects.ts`)**
+
+- `createEffects(deps): { apply(prev, next) }` factory.
+- Dependencies are injected so the runner can be tested or swapped: `placement`, `indicators`, `picker`, `controls`, `hintEl`, `apiBase`, `treeReef`, `dispatch`.
+- `apply(prev, next)` compares the two states and fires exactly the side effects implied by the transition. Runs synchronously.
+- `placement.showGhost` is synchronous; its result (`mesh` or `null`) is immediately dispatched as `PLACEMENT_OK` or `PLACEMENT_BLOCKED`. That dispatch re-enters `apply`, which only updates commit-button/hint for a pure `blocked` flip — no infinite loop.
+- Only the explicit async calls (`submitTreePolyp`, `resetTree`) defer and dispatch their terminal actions (`COMMIT_RESOLVED`/`REJECTED`, `RESET_RESOLVED`/`REJECTED`) on resolution.
+
+**Layer 3 — Orchestration (`packages/client/src/tree.ts`)**
+
+- Owns DOM element references, the `Scene`, `renderer`, `controls`, `placement`, `reef`, `picker`, `indicators`, `socket`, toolbar button listeners, and the render loop.
+- One module-level `state: TreeState` variable.
+- One `dispatch(action: TreeAction)` function: runs the reducer, then `effects.apply(prev, next)`.
+- Every DOM event and socket message handler does exactly one thing: build an action and dispatch it.
+- Pointer-drag ghost rotation stays local (a `dragState` closure) since it's imperative visual manipulation not logical state; it reads `state.kind === 'placing'` to decide whether to engage.
+
+## State
+
+```ts
+export interface PickerSelection {
+  variant: TreeVariant;
+  colorKey: string;
+}
+
+export type TreeState =
+  | { kind: 'idle'; picker: PickerSelection }
+  | {
+      kind: 'placing';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+      blocked: boolean;
+    }
+  | {
+      kind: 'submitting';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+    }
+  | { kind: 'resetting'; picker: PickerSelection };
+```
+
+Field meanings:
+
+- `picker` — the user's current variant + color selection. Always present, carries across all transitions so picker UI is consistent.
+- `parentId`, `attachIndex` — where the pending child will attach (`(parent_id, attach_index)` pair).
+- `seed` — the random integer used to generate the mesh. Regenerated on variant change and reroll; preserved across color change (same shape, different hue).
+- `blocked` (placing only) — `true` when the current placement collides with an existing piece (`showGhost` returned null). Grow button is disabled; user can still reroll, cancel, or pick a different attach slot.
+
+## Actions
+
+```ts
+export type TreeAction =
+  // Picker UI changes (always legal)
+  | { type: 'VARIANT_CHOSEN'; variant: TreeVariant; seed: number }
+  | { type: 'COLOR_CHOSEN'; colorKey: string }
+  // Attach point selection
+  | { type: 'ATTACH_CLICKED'; parentId: number; attachIndex: number; seed: number }
+  | { type: 'REROLL_CLICKED'; variant: TreeVariant; seed: number }
+  // Placement feedback from effects layer
+  | { type: 'PLACEMENT_BLOCKED' }
+  | { type: 'PLACEMENT_OK' }
+  // Commit flow
+  | { type: 'CANCEL_CLICKED' }
+  | { type: 'GROW_CLICKED' }
+  | { type: 'COMMIT_RESOLVED' }
+  | { type: 'COMMIT_REJECTED'; error: string }
+  // Reset flow
+  | { type: 'CLEAR_CLICKED' }
+  | { type: 'RESET_RESOLVED' }
+  | { type: 'RESET_REJECTED'; error: string }
+  // Remote reset: another client (or our own echo) reset the tree. No API
+  // call fires for this — server has already done the work. Placement state
+  // snaps to idle from any kind.
+  | { type: 'TREE_RESET_EXTERNAL' };
+```
+
+All random values (seeds, reroll variants) are sampled by the caller before dispatch so the reducer stays pure. The reducer ignores a `seed` field on actions where the resulting state doesn't need it (e.g., `VARIANT_CHOSEN` while idle just updates the picker).
+
+## Transitions
+
+The reducer returns an unchanged state for any (state, action) pair not listed below. This makes illegal events silent no-ops — the UI surface (button disabled, indicator hidden, etc.) is the primary gate; the reducer is the safety net.
+
+| From state | Action | To state | Payload carried / computed |
+|---|---|---|---|
+| any | `VARIANT_CHOSEN` | same kind | `picker.variant ← action.variant`. If in `placing`/`submitting`, also `seed ← action.seed`. |
+| any | `COLOR_CHOSEN` | same kind | `picker.colorKey ← action.colorKey`. |
+| `idle` | `ATTACH_CLICKED` | `placing` | inherits `picker`; `parentId/attachIndex/seed` from action; `blocked: false`. |
+| `placing` | `ATTACH_CLICKED` | `placing` | inherits `picker`; updates `parentId/attachIndex/seed` from action; `blocked: false`. |
+| `placing` | `REROLL_CLICKED` | `placing` | `picker.variant ← action.variant`; `seed ← action.seed`; `blocked: false`. |
+| `placing` | `PLACEMENT_BLOCKED` | `placing` | `blocked: true`. |
+| `placing` | `PLACEMENT_OK` | `placing` | `blocked: false`. |
+| `placing` | `CANCEL_CLICKED` | `idle` | inherits `picker`. |
+| `placing` (blocked=false) | `GROW_CLICKED` | `submitting` | copies `picker/parentId/attachIndex/seed`. |
+| `placing` (blocked=true) | `GROW_CLICKED` | unchanged | no-op. |
+| `submitting` | `COMMIT_RESOLVED` | `idle` | inherits `picker`. |
+| `submitting` | `COMMIT_REJECTED` | `placing` | inherits all submitting fields; `blocked: false` (server may know something we don't — let user retry or reroll). |
+| `idle`/`placing`/`submitting` | `CLEAR_CLICKED` | `resetting` | inherits `picker`. |
+| `resetting` | `RESET_RESOLVED` | `idle` | inherits `picker`. |
+| `resetting` | `RESET_REJECTED` | `idle` | inherits `picker`. |
+| any | `TREE_RESET_EXTERNAL` | `idle` | inherits `picker`. No API call fires. |
+
+Notes on intentional no-ops:
+
+- `CANCEL_CLICKED` while `idle`, `submitting`, or `resetting` → no-op. Cancel has no meaning outside placing.
+- `GROW_CLICKED` outside `placing` → no-op.
+- `REROLL_CLICKED` outside `placing` → no-op.
+- `ATTACH_CLICKED` during `submitting` or `resetting` → no-op. Buttons should be disabled by effects layer, but reducer is also defensive.
+- `CLEAR_CLICKED` during `resetting` → no-op. Server call is already in flight.
+- `PLACEMENT_BLOCKED/OK` outside `placing` → no-op. Late feedback from an effect that's no longer relevant (e.g., user canceled between the `showGhost` call and the blocked/ok dispatch). In practice `showGhost` is synchronous, so this is mostly defensive.
+- `RESET_RESOLVED`/`RESET_REJECTED` outside `resetting` → no-op. Late response arriving after `TREE_RESET_EXTERNAL` already moved us to idle.
+- `COMMIT_RESOLVED`/`COMMIT_REJECTED` outside `submitting` → no-op. E.g., user clicked Clear after Grow — server response for the (now-superseded) commit lands while we're in `resetting`; safely ignored.
+
+## Side effects (effects.ts)
+
+The effect runner looks at `(prev, next)` and fires the set of side effects the transition implies. Ordered for each transition so the UI never sees an intermediate inconsistent state.
+
+- `* → placing` (fresh attach or slot change) **or** `placing → placing` with changed `parentId`/`attachIndex`/`variant`/`seed`/`colorKey`:
+  1. `placement.showGhost(variant, seed, colorKey, parentId, attachIndex)` → mesh or null.
+  2. Dispatch `PLACEMENT_BLOCKED` (if null) or `PLACEMENT_OK` (otherwise).
+  3. `picker.setCommittable(!blocked)`.
+  4. `hintEl.textContent` updates accordingly.
+
+- `placing → placing` with only `blocked` flipping (pure PLACEMENT_BLOCKED/OK): update commit button + hint only.
+
+- `placing → idle` (cancel): `placement.reset()`, `picker.setCommittable(false)`, hint.
+
+- `placing → submitting` (grow):
+  1. `picker.setSubmitting(true)`.
+  2. `submitTreePolyp({ variant, seed, colorKey, parentId, attachIndex })`.
+  3. On resolve → dispatch `COMMIT_RESOLVED`.
+  4. On reject → write the error to `hintEl.textContent` first (error string is in scope in this callback), then dispatch `COMMIT_REJECTED { error }`. The subsequent `apply(submitting, placing)` doesn't need to know the error — it's already on screen.
+
+- `submitting → idle` (commit resolved): `placement.reset()`, `picker.setSubmitting(false)`, `picker.setCommittable(false)`, success hint.
+
+- `submitting → placing` (commit rejected): `picker.setSubmitting(false)`. Hint was already set by the async reject callback above; don't overwrite.
+
+- `* → resetting` (user clicked Clear):
+  1. `placement.reset()` and `picker.setCommittable(false)` immediately so any in-flight ghost disappears and the UI feels responsive before the network trip resolves.
+  2. `resetTree(apiBase)` kicks off.
+  3. On resolve → `treeReef.clear()`, `fetchTree()`, add returned polyps via `treeReef.addPiece`, `indicators.refresh()`, dispatch `RESET_RESOLVED`.
+  4. On reject → dispatch `RESET_REJECTED`. No local mutation beyond step 1 — hint shows the error. User can retry.
+
+- `resetting → idle` (either `RESET_RESOLVED` or `RESET_REJECTED`): hint update (success or error, respectively). No further API call.
+
+- `* → idle` via `TREE_RESET_EXTERNAL`: `placement.reset()`. No API call, no `treeReef.clear()` — the socket handler that dispatched this action already took care of reef cleanup (see socket section below).
+
+Orbit controls, pointer-drag tracking, and the socket handler remain in `tree.ts` since they're UI concerns that read `state.kind` but don't own it.
+
+## Socket message handling
+
+The WebSocket listener stays in `tree.ts`. Each message handler does exactly one tree-content mutation on `treeReef` / `indicators` (reef content is owned by the socket handler, not the state machine) and, where relevant, dispatches a state-machine action for the placement cursor.
+
+- `tree_polyp_added` → `treeReef.addPiece(polyp)`; install sway/pulse on the new mesh; `indicators.refresh()`. Idempotent on `polyp.id`, so duplicate echoes are safe.
+- `tree_polyp_removed` → `treeReef.removePiece(id)`; `indicators.refresh()`.
+- `tree_reset` → `treeReef.clear()`; `indicators.refresh()`; **dispatch `TREE_RESET_EXTERNAL`** so the state machine snaps to idle. Do NOT dispatch `CLEAR_CLICKED` (that would trigger another API call). The follow-up `tree_polyp_added` broadcast (server re-seeds a Starburst after reset) populates the empty reef with the new root.
+- `tree_hello` → ignored (log only).
+
+Rationale: tree content (which polyps exist) is owned by `treeReef` and fed directly from the socket; it's idempotent and doesn't need the state machine as an intermediary. The state machine only tracks the placement cursor — what ghost is the user aiming, what buttons are enabled. Reset is the single case where the two concerns touch, and `TREE_RESET_EXTERNAL` exists explicitly to route that without triggering an effect-layer API call.
+
+## File layout
+
+New:
+
+- `packages/client/src/tree/state.ts` — types + reducer, ~130 lines.
+- `packages/client/src/tree/state.test.ts` — ~40 tests, ~250 lines.
+- `packages/client/src/tree/effects.ts` — `createEffects` factory + transition-based side effect routing, ~150 lines.
+
+Modified:
+
+- `packages/client/src/tree.ts` — rewritten. Current is ~430 lines with many mutable flags and nested handlers; target is ~180 lines of wiring.
+
+Unchanged (public APIs preserved):
+
+- `packages/client/src/tree/{reef,placement,indicators,variants,material,pulse,scene,config,api,shark,clownfish,fishParts}.ts`
+- `packages/client/src/ui/treePicker.ts`
+- All existing tests (material, placement, reef, variants, pulse, indicators, shark, clownfish, collision, config, api).
+
+## Testing strategy
+
+**state.test.ts** — full reducer coverage.
+
+For each state kind:
+
+- Every listed legal action produces the expected next state (field-by-field assertions).
+- Every unlisted action returns the same state reference (`expect(reduce(s, a)).toBe(s)` — reference equality).
+
+Specific behaviors:
+
+- `VARIANT_CHOSEN` in `idle` updates `picker.variant` and ignores `seed` (no seed field exists on idle).
+- `VARIANT_CHOSEN` in `placing` updates both `picker.variant` and `seed`.
+- `VARIANT_CHOSEN` in `submitting` updates `picker.variant` and `seed` — harmless during submit; becomes relevant on `COMMIT_REJECTED` so the retry uses the new selection.
+- `COLOR_CHOSEN` never changes `seed` (same shape, different hue).
+- `ATTACH_CLICKED` in `placing` preserves `picker`, replaces `parentId/attachIndex/seed`, clears `blocked`.
+- `REROLL_CLICKED` only transitions from `placing` (no-op in others).
+- `GROW_CLICKED` in `placing` with `blocked: true` returns unchanged state (reference-equal).
+- `CLEAR_CLICKED` works from `idle`, `placing`, and `submitting`; no-op in `resetting`.
+- `COMMIT_REJECTED` carries all fields back to `placing` with `blocked: false`.
+- `TREE_RESET_EXTERNAL` from any kind → idle with inherited picker.
+- All unlisted (state, action) pairs return the same reference (identity).
+
+Target: ~40-50 unit tests, all pure (no Three.js/DOM imports).
+
+**effects.test.ts (optional)** — happy-path integration with mocked deps. A few tests to verify:
+
+- `idle → placing`: `placement.showGhost` called with correct args.
+- `placing (blocked=true) → submitting`: guarded by reducer, but also verify effects don't call submit if somehow invoked (defensive).
+- `submitting → idle`: `placement.reset` and `picker.setSubmitting(false)` both called.
+
+Skip if reducer coverage is thorough enough.
+
+## Migration plan
+
+1. Add `state.ts` + `state.test.ts`. Land green.
+2. Add `effects.ts` (no tests yet, just wire it).
+3. Add new `tree.ts` alongside the old logic (keep imports separate) — in a single commit, swap the orchestration over. Delete old scaffolding.
+4. Run `pnpm -r test` + typecheck.
+5. Manual smoke in browser: click attach → ghost; reroll ×5 → new ghost each time; cancel → orbit resumes; grow → piece appears; clear → fresh root; add shark/clownfish buttons still work; drag-rotate still rotates ghost; pointer-up re-enables orbit.
+6. Update any existing tests that referenced the old mutable flags (unlikely; the existing tests target sub-modules that are unchanged).
+
+## Risks
+
+- **Socket race with submit**: server may broadcast `tree_polyp_added` before or after our HTTP response resolves. The state machine transitions `submitting → idle` on HTTP resolve; the broadcast adds the piece to `treeReef` regardless. `treeReef.addPiece` is idempotent on `id`, so the piece lands exactly once. Safe.
+
+- **Rapid click spam**: multiple `ATTACH_CLICKED` before the first `PLACEMENT_BLOCKED/OK` arrives. Each action overwrites the placing state; each `showGhost` disposes the previous ghost via `placement.reset()`. Late `PLACEMENT_BLOCKED/OK` events may apply to a stale slot; they still produce valid states (blocked either way), and the effect layer re-runs showGhost on next legitimate transition. Acceptable.
+
+- **Clear during submit**: server may still insert the submit then immediately soft-delete via reset. Net result is an empty tree plus the fresh seeded Starburst. Fine.
+
+- **Local clear + remote echo**: after our own `resetTree` resolves and we dispatch `RESET_RESOLVED`, the server's subsequent `tree_reset` broadcast arrives. Socket handler dispatches `TREE_RESET_EXTERNAL`, which is a no-op at that point (we're already in `idle`), and calls `treeReef.clear()` on a reef that's also already clear. Both operations are idempotent; no double-cleanup issue.
+
+- **Dispatch inside effects**: `effects.apply` can dispatch follow-up actions (e.g., `PLACEMENT_BLOCKED` after showGhost). This introduces re-entrant dispatch. Guard by ensuring `dispatch` serializes — apply the reducer and effects synchronously before returning. No queue needed since actions fire from discrete events; the re-entrant path terminates after at most one recursion (effect's dispatch leads to a terminal state change that doesn't re-dispatch).
+
+## Open follow-ups (separate designs)
+
+1. **2+ branches per attach point**: schema migration (`tree_polyps.attach_sub_index` column or similar), uniqueness constraint revision, client rendering with angular offset per sub-index. Separate design once core refactor lands.
+2. **Persisted drag yaw**: add `attach_yaw REAL NOT NULL DEFAULT 0` column. Drag-rotate stores to state, sent at commit, applied in `TreeReef.addPiece`'s world matrix.
+3. **Indicator hit-test**: bump radius constant or use raycast Threshold — quick tuning, not architectural.
+4. **Rejection UI**: visible error toast/banner when `COMMIT_REJECTED` fires; currently just hintEl text.

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -143,7 +143,7 @@ const picker = new TreePicker(pickerRoot);
 const hintEl = document.getElementById('hint')!;
 
 const effects = createEffects({
-  placement, treeReef, indicators: attachIndicators, picker, controls,
+  placement, treeReef, indicators: attachIndicators, picker,
   hintEl, apiBase: config.apiBase,
   dispatch: (action) => dispatch(action),
   addPiecesAndRefresh,

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -8,27 +8,26 @@ import {
 } from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { PublicTreePolyp } from '@reef/shared';
-import { installLighting } from './scene/lighting.js';
 import { installSway } from './scene/currentSway.js';
 import { installTreePulse } from './tree/pulse.js';
 import { readTreeConfig } from './tree/config.js';
-import { createTreePedestal, createBloomComposer } from './tree/scene.js';
+import {
+  createTreePedestal,
+  createBloomComposer,
+  createUnderwaterBackground,
+  createUnderwaterFog,
+  installUnderwaterLighting,
+} from './tree/scene.js';
 import { TreeReef } from './tree/reef.js';
 import { AttachIndicators } from './tree/indicators.js';
 import { TreePlacement } from './tree/placement.js';
-import { fetchTree, submitTreePolyp, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
+import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
 import { TREE_VARIANTS, TreePicker } from './ui/treePicker.js';
 import { computeOrbitPose } from './playground/autoOrbit.js';
-import { FishSchool } from './sim/fish.js';
 import { Shark } from './tree/shark.js';
 import { Clownfish } from './tree/clownfish.js';
-import type { PointsMaterial } from 'three';
-
-// ------------------------------------------------------------------
-// Sentinel symbols so sway/pulse are installed at most once per mesh.
-// ------------------------------------------------------------------
-const SWAY_INSTALLED = Symbol('sway-installed');
-const PULSE_INSTALLED = Symbol('pulse-installed');
+import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
+import { createEffects } from './tree/effects.js';
 
 // ------------------------------------------------------------------
 // Config + canvas
@@ -45,10 +44,11 @@ const renderer = new WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
 
 const scene = new Scene();
-scene.background = null;
+scene.background = createUnderwaterBackground();
+scene.fog = createUnderwaterFog();
 renderer.setClearColor(0x01060d, 1);
 
-installLighting(scene);
+installUnderwaterLighting(scene);
 scene.add(createTreePedestal());
 
 // ------------------------------------------------------------------
@@ -65,13 +65,10 @@ controls.maxDistance = 1.2;
 controls.maxPolarAngle = Math.PI / 2 - 0.05;
 controls.enableDamping = true;
 
-// ------------------------------------------------------------------
-// Bloom composer
-// ------------------------------------------------------------------
 const bloomSetup = createBloomComposer(renderer, scene, camera);
 
 // ------------------------------------------------------------------
-// Tree objects
+// Tree content + placement
 // ------------------------------------------------------------------
 const treeReef = new TreeReef();
 scene.add(treeReef.anchor);
@@ -83,40 +80,12 @@ const placement = new TreePlacement(treeReef);
 scene.add(placement.ghostAnchor);
 
 // ------------------------------------------------------------------
-// Fish + shark + clownfish
+// Sway/pulse effect installer (used on every newly-added piece).
 // ------------------------------------------------------------------
-// Tiny background school: reuse FishSchool but retint to a pale cool white
-// that reads against the dark/bloom scene (landscape's yellow looks dingy
-// here). Count is lower + radius tighter since the tree's visible mass is
-// smaller than the landscape reef's.
-const fish = new FishSchool(40, 0.55);
-(fish.points.material as PointsMaterial).color.setHex(0xbfe8ff);
-(fish.points.material as PointsMaterial).needsUpdate = true;
-scene.add(fish.points);
-
-// One lone shark making slow laps on a wide orbit.
-const shark = new Shark();
-scene.add(shark.group);
-
-// One bright clownfish orbiting opposite the shark on a tighter path.
-const clownfish = new Clownfish();
-scene.add(clownfish.group);
-
-// ------------------------------------------------------------------
-// Shared clock for sway/pulse animations
-// ------------------------------------------------------------------
+const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
 const swayClock = { value: 0 };
 
-// ------------------------------------------------------------------
-// Sway/pulse helpers
-// ------------------------------------------------------------------
-
-/**
- * Walk all pieces in treeReef and install sway/pulse on any new meshes.
- * Uses the tree-specific pulse (higher baseline, larger amplitude) so the
- * Avatar-bioluminescent glow is visibly breathing rather than sitting at
- * the dim landscape baseline.
- */
 function installEffectsOnNewPieces(): void {
   for (const { polyp, mesh } of treeReef.allPieces()) {
     const flags = mesh.userData as Record<PropertyKey, unknown>;
@@ -131,20 +100,164 @@ function installEffectsOnNewPieces(): void {
   }
 }
 
+function addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
+  const sorted = [...polyps].sort((a, b) => a.createdAt - b.createdAt);
+  for (const polyp of sorted) treeReef.addPiece(polyp);
+  installEffectsOnNewPieces();
+  attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+}
+
 // ------------------------------------------------------------------
-// Picker (tree variant)
+// Spawnable sea life — empty by default.
+// ------------------------------------------------------------------
+interface SwimmingCreature { update: (clockSec: number) => void; }
+const creatures: SwimmingCreature[] = [];
+function spawnShark(): void {
+  const s = new Shark({
+    orbitRadius: 0.25 + Math.random() * 0.15,
+    orbitHeight: 0.05 + Math.random() * 0.2,
+    orbitPeriodSec: 14 + Math.random() * 10,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(s.group);
+  creatures.push(s);
+}
+function spawnClownfish(): void {
+  const c = new Clownfish({
+    orbitRadius: 0.15 + Math.random() * 0.15,
+    orbitHeight: 0.04 + Math.random() * 0.2,
+    orbitPeriodSec: 5 + Math.random() * 6,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(c.group);
+  creatures.push(c);
+}
+
+// ------------------------------------------------------------------
+// Picker + state machine
 // ------------------------------------------------------------------
 const pickerRoot = document.getElementById('picker')!;
 const picker = new TreePicker(pickerRoot);
 const hintEl = document.getElementById('hint')!;
 
-let currentSeed = Math.floor(Math.random() * 0xffffffff);
+const effects = createEffects({
+  placement, treeReef, indicators: attachIndicators, picker, controls,
+  hintEl, apiBase: config.apiBase,
+  dispatch: (action) => dispatch(action),
+  addPiecesAndRefresh,
+});
+
+let state: TreeState = initialState(picker.get());
+
+function dispatch(action: TreeAction): void {
+  const prev = state;
+  state = reduce(state, action);
+  if (state !== prev) effects.apply(prev, state, action);
+}
+
+// Wire picker → dispatch.
+picker.onChange((sel) => {
+  const current = state.picker;
+  if (sel.variant !== current.variant) {
+    const seed = Math.floor(Math.random() * 0xffffffff);
+    dispatch({ type: 'VARIANT_CHOSEN', variant: sel.variant, seed });
+  }
+  if (sel.colorKey !== current.colorKey) {
+    dispatch({ type: 'COLOR_CHOSEN', colorKey: sel.colorKey });
+  }
+});
+picker.onReroll(() => {
+  if (state.kind !== 'placing') return;
+  const options = TREE_VARIANTS.filter((v) => v !== state.picker.variant);
+  const variant = options[Math.floor(Math.random() * options.length)]!;
+  const seed = Math.floor(Math.random() * 0xffffffff);
+  dispatch({ type: 'REROLL_CLICKED', variant, seed });
+});
+picker.onCancel(() => dispatch({ type: 'CANCEL_CLICKED' }));
+picker.onCommit(() => dispatch({ type: 'GROW_CLICKED' }));
 
 // ------------------------------------------------------------------
-// Pending attach slot — set on click, cleared on commit/cancel
+// Toolbar → dispatch / direct spawn
 // ------------------------------------------------------------------
-let pendingParentId: number | null = null;
-let pendingAttachIndex = 0;
+const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
+const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
+const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
+if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
+if (addSharkBtn) addSharkBtn.addEventListener('click', spawnShark);
+if (addClownfishBtn) addClownfishBtn.addEventListener('click', spawnClownfish);
+
+// ------------------------------------------------------------------
+// Pointer-drag: rotate ghost in place instead of orbiting while placing.
+// ------------------------------------------------------------------
+let dragState: { lastX: number; moved: boolean } | null = null;
+let suppressNextClick = false;
+const DRAG_THRESHOLD_PX = 3;
+const ROT_SENSITIVITY = 0.0055;
+
+canvas.addEventListener(
+  'pointerdown',
+  (ev) => {
+    if (state.kind !== 'placing') return;
+    if (config.mode !== 'screen') controls.enabled = false;
+    dragState = { lastX: ev.clientX, moved: false };
+    canvas.setPointerCapture(ev.pointerId);
+  },
+  { capture: true },
+);
+canvas.addEventListener('pointermove', (ev) => {
+  if (!dragState) return;
+  const dx = ev.clientX - dragState.lastX;
+  if (!dragState.moved && Math.abs(dx) > DRAG_THRESHOLD_PX) dragState.moved = true;
+  if (dragState.moved) {
+    placement.rotateGhost(dx * ROT_SENSITIVITY);
+    dragState.lastX = ev.clientX;
+  }
+});
+canvas.addEventListener('pointerup', (ev) => {
+  if (!dragState) return;
+  if (canvas.hasPointerCapture(ev.pointerId)) canvas.releasePointerCapture(ev.pointerId);
+  suppressNextClick = dragState.moved;
+  dragState = null;
+  if (config.mode !== 'screen') controls.enabled = true;
+});
+
+// ------------------------------------------------------------------
+// Click (attach-orb pick) — interactive mode only
+// ------------------------------------------------------------------
+if (config.mode === 'interactive') {
+  picker.show();
+  const raycaster = new Raycaster();
+  raycaster.params.Points = { threshold: 0.01 };
+
+  canvas.addEventListener('click', (ev) => {
+    if (suppressNextClick) { suppressNextClick = false; return; }
+    const rect = canvas.getBoundingClientRect();
+    const ndc = new Vector2(
+      ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+      -(((ev.clientY - rect.top) / rect.height) * 2 - 1),
+    );
+    raycaster.setFromCamera(ndc, camera);
+    const intersects = raycaster.intersectObjects(attachIndicators.group.children, false);
+    if (intersects.length === 0) {
+      if (state.kind === 'idle') {
+        hintEl.textContent = 'Click a glowing dot to attach your piece.';
+      }
+      return;
+    }
+    const hit = intersects[0]!;
+    const ud = hit.object.userData as { parentId?: number; attachIndex?: number };
+    if (ud.parentId === undefined || ud.attachIndex === undefined) return;
+    const seed = Math.floor(Math.random() * 0xffffffff);
+    dispatch({
+      type: 'ATTACH_CLICKED',
+      parentId: ud.parentId,
+      attachIndex: ud.attachIndex,
+      seed,
+    });
+  });
+}
 
 // ------------------------------------------------------------------
 // Resize
@@ -161,217 +274,58 @@ window.addEventListener('resize', resize);
 resize();
 
 // ------------------------------------------------------------------
-// Interactive mode: click handler + picker wiring
-// ------------------------------------------------------------------
-if (config.mode === 'interactive') {
-  picker.show();
-
-  const raycaster = new Raycaster();
-  // Make raycaster threshold generous enough to pick small indicator spheres.
-  raycaster.params.Points = { threshold: 0.01 };
-
-  canvas.addEventListener('click', (e) => {
-    const rect = canvas.getBoundingClientRect();
-    const ndc = new Vector2(
-      ((e.clientX - rect.left) / rect.width) * 2 - 1,
-      -(((e.clientY - rect.top) / rect.height) * 2 - 1),
-    );
-
-    raycaster.setFromCamera(ndc, camera);
-    const intersects = raycaster.intersectObjects(attachIndicators.group.children, false);
-    if (intersects.length === 0) {
-      hintEl.textContent = 'Click a glowing dot to attach your piece.';
-      return;
-    }
-
-    const hit = intersects[0]!;
-    const ud = hit.object.userData as { parentId?: number; attachIndex?: number };
-    if (ud.parentId === undefined || ud.attachIndex === undefined) return;
-
-    pendingParentId = ud.parentId;
-    pendingAttachIndex = ud.attachIndex;
-    currentSeed = Math.floor(Math.random() * 0xffffffff);
-
-    const s = picker.get();
-    const ghost = placement.showGhost(
-      s.variant,
-      currentSeed,
-      s.colorKey,
-      pendingParentId,
-      pendingAttachIndex,
-    );
-
-    if (ghost) {
-      picker.setCommittable(true);
-      hintEl.textContent = 'Happy with it? Click Grow.';
-    } else {
-      hintEl.textContent = 'That spot is blocked. Try another dot.';
-    }
-  });
-
-  picker.onChange(({ variant, colorKey }) => {
-    if (pendingParentId === null) return;
-    const ghost = placement.showGhost(
-      variant,
-      currentSeed,
-      colorKey,
-      pendingParentId,
-      pendingAttachIndex,
-    );
-    picker.setCommittable(!!ghost);
-    if (!ghost) hintEl.textContent = 'That spot is blocked. Try another dot.';
-  });
-
-  picker.onReroll(() => {
-    if (pendingParentId === null) return;
-    // Pick a new variant different from the current one. Variant geometry is
-    // deterministic from its constants (seed is stored but not consumed by
-    // the generator), so rerolling only the seed would be a visual no-op.
-    const current = picker.get().variant;
-    const options = TREE_VARIANTS.filter((v) => v !== current);
-    const nextVariant = options[Math.floor(Math.random() * options.length)]!;
-    picker.setVariant(nextVariant);
-    currentSeed = Math.floor(Math.random() * 0xffffffff);
-    const s = picker.get();
-    const ghost = placement.showGhost(
-      s.variant,
-      currentSeed,
-      s.colorKey,
-      pendingParentId,
-      pendingAttachIndex,
-    );
-    picker.setCommittable(!!ghost);
-  });
-
-  picker.onCancel(() => {
-    placement.reset();
-    pendingParentId = null;
-    picker.setCommittable(false);
-    hintEl.textContent = 'Cancelled. Click a dot to try again.';
-  });
-
-  picker.onCommit(async () => {
-    if (config.readonly) {
-      hintEl.textContent = 'Readonly mode — Grow is disabled.';
-      return;
-    }
-    const pending = placement.getPending();
-    if (!pending) return;
-
-    picker.setSubmitting(true);
-    try {
-      await submitTreePolyp(
-        {
-          variant: pending.variant,
-          seed: pending.seed,
-          colorKey: pending.colorKey,
-          parentId: pending.parentId,
-          attachIndex: pending.attachIndex,
-        },
-        config.apiBase,
-      );
-      // The socket echo (tree_polyp_added) will call treeReef.addPiece and
-      // placement.reset(). No need to add the piece locally here — let the
-      // server broadcast drive it (consistent with the playground pattern).
-      picker.setSubmitting(false);
-      picker.setCommittable(false);
-      hintEl.textContent = 'Grown! Click another dot to plant again.';
-      pendingParentId = null;
-    } catch (e) {
-      picker.setSubmitting(false);
-      hintEl.textContent = 'Server rejected the piece. Check the console.';
-      console.error(e);
-    }
-  });
-}
-
-if (config.mode === 'screen') {
-  picker.hide();
-  (document.getElementById('picker') as HTMLElement).classList.add('hidden');
-  controls.enabled = false;
-}
-
-// ------------------------------------------------------------------
-// WebSocket
-// ------------------------------------------------------------------
-function buildTreeWsUrl(): string {
-  if (!config.apiBase) return defaultTreeWsUrl();
-  const u = new URL(config.apiBase);
-  const proto = u.protocol === 'https:' ? 'wss' : 'ws';
-  return `${proto}://${u.host}/ws/tree`;
-}
-
-const socket = new TreeSocket(buildTreeWsUrl());
-socket.on((msg) => {
-  if (msg.type === 'tree_hello') {
-    console.log(`[tree] connected — server has ${msg.polypCount} piece(s)`);
-  } else if (msg.type === 'tree_polyp_added') {
-    // Avoid double-adding if the addPiece call throws on duplicate.
-    try {
-      addAndRefresh(msg.polyp);
-    } catch (err) {
-      // Parent might not be registered yet in a race — log and ignore.
-      console.warn('[tree] tree_polyp_added could not add piece', err);
-      return;
-    }
-    // If this matches the current pending ghost, resolve it.
-    const pending = placement.getPending();
-    if (
-      pending &&
-      pending.parentId === msg.polyp.parentId &&
-      pending.attachIndex === msg.polyp.attachIndex &&
-      pending.variant === msg.polyp.variant &&
-      pending.seed === msg.polyp.seed
-    ) {
-      placement.reset();
-    }
-  } else if (msg.type === 'tree_polyp_removed') {
-    treeReef.removePiece(msg.id);
-    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
-  }
-});
-
-function addAndRefresh(polyp: PublicTreePolyp): void {
-  treeReef.addPiece(polyp);
-  installEffectsOnNewPieces();
-  attachIndicators.refresh(treeReef.getAvailableAttachPoints());
-}
-
-// ------------------------------------------------------------------
 // Initial fetch
 // ------------------------------------------------------------------
-async function loadInitial(): Promise<void> {
+(async () => {
   try {
-    const state = await fetchTree(config.apiBase);
-    // Sort ascending so parents are always inserted before children.
-    const sorted = [...state.polyps].sort((a, b) => a.createdAt - b.createdAt);
-    for (const polyp of sorted) {
-      treeReef.addPiece(polyp);
-    }
-    installEffectsOnNewPieces();
-    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
-    if (hintEl && config.mode === 'interactive') {
-      hintEl.textContent = 'Click a glowing dot to attach your piece.';
+    const { polyps } = await fetchTree(config.apiBase);
+    addPiecesAndRefresh(polyps);
+    if (config.mode === 'interactive') {
+      hintEl.textContent = polyps.length
+        ? 'Click a glowing dot to attach your piece.'
+        : 'Click Clear and grow something new.';
     }
   } catch (e) {
     console.error('[tree] Failed to load tree', e);
+    hintEl.textContent = 'Failed to load tree. Check the server.';
   }
+})();
+
+// ------------------------------------------------------------------
+// WebSocket: tree content updates (idempotent on polyp id)
+// ------------------------------------------------------------------
+function buildTreeWsUrl(): string {
+  if (config.apiBase) {
+    return config.apiBase.replace(/^http/, 'ws') + '/ws/tree';
+  }
+  return defaultTreeWsUrl();
 }
+const socket = new TreeSocket(buildTreeWsUrl());
+socket.on((msg) => {
+  if (msg.type === 'tree_hello') {
+    // No-op; initial state was fetched via HTTP.
+  } else if (msg.type === 'tree_polyp_added') {
+    treeReef.addPiece(msg.polyp);
+    installEffectsOnNewPieces();
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  } else if (msg.type === 'tree_polyp_removed') {
+    treeReef.removePiece(msg.id);
+    attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  } else if (msg.type === 'tree_reset') {
+    treeReef.clear();
+    attachIndicators.refresh([]);
+    dispatch({ type: 'TREE_RESET_EXTERNAL' });
+  }
+});
+socket.connect();
 
 // ------------------------------------------------------------------
 // Render loop
 // ------------------------------------------------------------------
-let lastT = 0;
 function loop(t: number): void {
   const tSec = t / 1000;
-  const dt = lastT === 0 ? 0 : Math.min(tSec - lastT, 0.1);
-  lastT = tSec;
-
   swayClock.value = tSec;
-
-  fish.update(dt);
-  shark.update(tSec);
-  clownfish.update(tSec);
+  for (const c of creatures) c.update(tSec);
 
   if (config.mode === 'screen') {
     const pose = computeOrbitPose(tSec);
@@ -380,11 +334,7 @@ function loop(t: number): void {
   } else {
     controls.update();
   }
-
   bloomSetup.render();
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);
-
-void loadInitial();
-socket.connect();

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -10,15 +10,19 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { PublicTreePolyp } from '@reef/shared';
 import { installLighting } from './scene/lighting.js';
 import { installSway } from './scene/currentSway.js';
-import { installPulse } from './scene/pulse.js';
+import { installTreePulse } from './tree/pulse.js';
 import { readTreeConfig } from './tree/config.js';
 import { createTreePedestal, createBloomComposer } from './tree/scene.js';
 import { TreeReef } from './tree/reef.js';
 import { AttachIndicators } from './tree/indicators.js';
 import { TreePlacement } from './tree/placement.js';
 import { fetchTree, submitTreePolyp, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
-import { TreePicker } from './ui/treePicker.js';
+import { TREE_VARIANTS, TreePicker } from './ui/treePicker.js';
 import { computeOrbitPose } from './playground/autoOrbit.js';
+import { FishSchool } from './sim/fish.js';
+import { Shark } from './tree/shark.js';
+import { Clownfish } from './tree/clownfish.js';
+import type { PointsMaterial } from 'three';
 
 // ------------------------------------------------------------------
 // Sentinel symbols so sway/pulse are installed at most once per mesh.
@@ -79,6 +83,26 @@ const placement = new TreePlacement(treeReef);
 scene.add(placement.ghostAnchor);
 
 // ------------------------------------------------------------------
+// Fish + shark + clownfish
+// ------------------------------------------------------------------
+// Tiny background school: reuse FishSchool but retint to a pale cool white
+// that reads against the dark/bloom scene (landscape's yellow looks dingy
+// here). Count is lower + radius tighter since the tree's visible mass is
+// smaller than the landscape reef's.
+const fish = new FishSchool(40, 0.55);
+(fish.points.material as PointsMaterial).color.setHex(0xbfe8ff);
+(fish.points.material as PointsMaterial).needsUpdate = true;
+scene.add(fish.points);
+
+// One lone shark making slow laps on a wide orbit.
+const shark = new Shark();
+scene.add(shark.group);
+
+// One bright clownfish orbiting opposite the shark on a tighter path.
+const clownfish = new Clownfish();
+scene.add(clownfish.group);
+
+// ------------------------------------------------------------------
 // Shared clock for sway/pulse animations
 // ------------------------------------------------------------------
 const swayClock = { value: 0 };
@@ -89,9 +113,9 @@ const swayClock = { value: 0 };
 
 /**
  * Walk all pieces in treeReef and install sway/pulse on any new meshes.
- * Tree emissive baseline is higher (see Task 15), so pulse amplitude
- * is applied at the same rate — the higher baseline is set in the
- * material itself; installPulse drives around it.
+ * Uses the tree-specific pulse (higher baseline, larger amplitude) so the
+ * Avatar-bioluminescent glow is visibly breathing rather than sitting at
+ * the dim landscape baseline.
  */
 function installEffectsOnNewPieces(): void {
   for (const { polyp, mesh } of treeReef.allPieces()) {
@@ -101,7 +125,7 @@ function installEffectsOnNewPieces(): void {
       flags[SWAY_INSTALLED] = true;
     }
     if (!flags[PULSE_INSTALLED]) {
-      installPulse(mesh as Mesh, swayClock, polyp.seed);
+      installTreePulse(mesh as Mesh, swayClock, polyp.seed);
       flags[PULSE_INSTALLED] = true;
     }
   }
@@ -200,6 +224,13 @@ if (config.mode === 'interactive') {
 
   picker.onReroll(() => {
     if (pendingParentId === null) return;
+    // Pick a new variant different from the current one. Variant geometry is
+    // deterministic from its constants (seed is stored but not consumed by
+    // the generator), so rerolling only the seed would be a visual no-op.
+    const current = picker.get().variant;
+    const options = TREE_VARIANTS.filter((v) => v !== current);
+    const nextVariant = options[Math.floor(Math.random() * options.length)]!;
+    picker.setVariant(nextVariant);
     currentSeed = Math.floor(Math.random() * 0xffffffff);
     const s = picker.get();
     const ghost = placement.showGhost(
@@ -330,11 +361,20 @@ async function loadInitial(): Promise<void> {
 // ------------------------------------------------------------------
 // Render loop
 // ------------------------------------------------------------------
+let lastT = 0;
 function loop(t: number): void {
-  swayClock.value = t / 1000;
+  const tSec = t / 1000;
+  const dt = lastT === 0 ? 0 : Math.min(tSec - lastT, 0.1);
+  lastT = tSec;
+
+  swayClock.value = tSec;
+
+  fish.update(dt);
+  shark.update(tSec);
+  clownfish.update(tSec);
 
   if (config.mode === 'screen') {
-    const pose = computeOrbitPose(t / 1000);
+    const pose = computeOrbitPose(tSec);
     camera.position.copy(pose.position);
     camera.lookAt(pose.target);
   } else {

--- a/packages/client/src/tree/api.ts
+++ b/packages/client/src/tree/api.ts
@@ -19,6 +19,15 @@ export async function submitTreePolyp(input: TreePolypInput, apiBase = ''): Prom
   return r.json() as Promise<PublicTreePolyp>;
 }
 
+export async function resetTree(apiBase = ''): Promise<{ polyps: PublicTreePolyp[] }> {
+  const r = await fetch(`${apiBase}/api/tree/reset`, { method: 'POST' });
+  if (!r.ok) {
+    const detail = await r.text().catch(() => '');
+    throw new Error(`resetTree ${r.status}${detail ? ` ${detail}` : ''}`);
+  }
+  return r.json() as Promise<{ polyps: PublicTreePolyp[] }>;
+}
+
 /**
  * Reconnecting WebSocket with exponential backoff. Capped at 30s between
  * tries. Fires every server message to each registered handler.

--- a/packages/client/src/tree/clownfish.test.ts
+++ b/packages/client/src/tree/clownfish.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { Clownfish } from './clownfish.js';
+
+describe('Clownfish', () => {
+  test('has body + 3 stripes + dorsal + 2 pectoral fins + tail node', () => {
+    const c = new Clownfish();
+    // body + 3 stripes + dorsal + 2 pectoral + tail-node = 8 children.
+    expect(c.group.children.length).toBe(8);
+  });
+
+  test('update(0) places the clownfish on the +X side of its orbit', () => {
+    const c = new Clownfish();
+    c.update(0);
+    expect(c.group.position.x).toBeGreaterThan(0);
+  });
+
+  test('orbit runs opposite to the shark (z decreases from t=0 as time advances)', () => {
+    const c = new Clownfish();
+    c.update(0);
+    const z0 = c.group.position.z;
+    c.update(0.5);
+    expect(c.group.position.z).toBeLessThan(z0);
+  });
+
+  test('update moves the clownfish over time', () => {
+    const c = new Clownfish();
+    c.update(0);
+    const a = c.group.position.clone();
+    c.update(1.5);
+    expect(a.distanceTo(c.group.position)).toBeGreaterThan(0.01);
+  });
+});

--- a/packages/client/src/tree/clownfish.ts
+++ b/packages/client/src/tree/clownfish.ts
@@ -8,12 +8,21 @@ import {
 } from 'three';
 import { createFin } from './fishParts.js';
 
-const ORBIT_RADIUS = 0.22;
-const ORBIT_HEIGHT = 0.1;
-const ORBIT_PERIOD_SEC = 7;
+const DEFAULT_ORBIT_RADIUS = 0.22;
+const DEFAULT_ORBIT_HEIGHT = 0.1;
+const DEFAULT_ORBIT_PERIOD_SEC = 7;
 
 const BODY_RADIUS = 0.007;
 const BODY_LENGTH = 0.028;
+
+export interface ClownfishOrbitParams {
+  orbitRadius?: number;
+  orbitHeight?: number;
+  orbitPeriodSec?: number;
+  phaseRad?: number;
+  /** +1 clockwise (viewed from +Y), -1 counter-clockwise. Defaults to -1. */
+  direction?: 1 | -1;
+}
 
 const BODY_COLOR = 0xff7028;   // saturated orange
 const STRIPE_COLOR = 0xffffff; // white bands
@@ -27,8 +36,18 @@ const FIN_COLOR = 0x1a1a1a;    // near-black fin edges (real clownfish)
 export class Clownfish {
   readonly group = new Group();
   private readonly tailNode: Group;
+  private readonly orbitRadius: number;
+  private readonly orbitHeight: number;
+  private readonly orbitPeriodSec: number;
+  private readonly phaseRad: number;
+  private readonly direction: 1 | -1;
 
-  constructor() {
+  constructor(params: ClownfishOrbitParams = {}) {
+    this.orbitRadius = params.orbitRadius ?? DEFAULT_ORBIT_RADIUS;
+    this.orbitHeight = params.orbitHeight ?? DEFAULT_ORBIT_HEIGHT;
+    this.orbitPeriodSec = params.orbitPeriodSec ?? DEFAULT_ORBIT_PERIOD_SEC;
+    this.phaseRad = params.phaseRad ?? 0;
+    this.direction = params.direction ?? -1;
     // Body: orange elongated sphere, slight taper via Y scale < 1.
     const bodyGeom = new SphereGeometry(BODY_RADIUS, 18, 12);
     const bodyMat = new MeshStandardMaterial({
@@ -110,21 +129,24 @@ export class Clownfish {
   }
 
   update(clockSec: number): void {
-    const angle = -(clockSec / ORBIT_PERIOD_SEC) * Math.PI * 2;
-    const x = Math.cos(angle) * ORBIT_RADIUS;
-    const z = Math.sin(angle) * ORBIT_RADIUS;
-    const yBob = Math.sin(clockSec * 1.7) * 0.012;
-    this.group.position.set(x, ORBIT_HEIGHT + yBob, z);
+    const angle =
+      this.direction * (clockSec / this.orbitPeriodSec) * Math.PI * 2 + this.phaseRad;
+    const x = Math.cos(angle) * this.orbitRadius;
+    const z = Math.sin(angle) * this.orbitRadius;
+    const yBob = Math.sin(clockSec * 1.7 + this.phaseRad) * 0.012;
+    this.group.position.set(x, this.orbitHeight + yBob, z);
 
-    const ahead = -((clockSec + 0.05) / ORBIT_PERIOD_SEC) * Math.PI * 2;
+    const ahead =
+      this.direction * ((clockSec + 0.05) / this.orbitPeriodSec) * Math.PI * 2 +
+      this.phaseRad;
     const lookTarget = new Vector3(
-      Math.cos(ahead) * ORBIT_RADIUS,
-      ORBIT_HEIGHT + yBob,
-      Math.sin(ahead) * ORBIT_RADIUS,
+      Math.cos(ahead) * this.orbitRadius,
+      this.orbitHeight + yBob,
+      Math.sin(ahead) * this.orbitRadius,
     );
     this.group.lookAt(lookTarget);
 
     // Faster, livelier tail wag than the shark.
-    this.tailNode.rotation.y = Math.sin(clockSec * 6.5) * 0.35;
+    this.tailNode.rotation.y = Math.sin(clockSec * 6.5 + this.phaseRad) * 0.35;
   }
 }

--- a/packages/client/src/tree/clownfish.ts
+++ b/packages/client/src/tree/clownfish.ts
@@ -1,0 +1,130 @@
+import {
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  SphereGeometry,
+  Vector3,
+} from 'three';
+import { createFin } from './fishParts.js';
+
+const ORBIT_RADIUS = 0.22;
+const ORBIT_HEIGHT = 0.1;
+const ORBIT_PERIOD_SEC = 7;
+
+const BODY_RADIUS = 0.007;
+const BODY_LENGTH = 0.028;
+
+const BODY_COLOR = 0xff7028;   // saturated orange
+const STRIPE_COLOR = 0xffffff; // white bands
+const FIN_COLOR = 0x1a1a1a;    // near-black fin edges (real clownfish)
+
+/**
+ * A single bright clownfish with a tapered body, three white stripe rings,
+ * a forked caudal fin, a dorsal fin, and a tail-wag animation. Orbits
+ * opposite the shark at a tighter radius.
+ */
+export class Clownfish {
+  readonly group = new Group();
+  private readonly tailNode: Group;
+
+  constructor() {
+    // Body: orange elongated sphere, slight taper via Y scale < 1.
+    const bodyGeom = new SphereGeometry(BODY_RADIUS, 18, 12);
+    const bodyMat = new MeshStandardMaterial({
+      color: BODY_COLOR,
+      emissive: 0xff5a18,
+      emissiveIntensity: 0.38,
+      roughness: 0.5,
+    });
+    const body = new Mesh(bodyGeom, bodyMat);
+    body.scale.set(1, 0.92, BODY_LENGTH / (BODY_RADIUS * 2));
+    this.group.add(body);
+
+    // White stripe rings (classic clownfish three-band pattern).
+    const stripeMat = new MeshStandardMaterial({
+      color: STRIPE_COLOR,
+      emissive: STRIPE_COLOR,
+      emissiveIntensity: 0.42,
+      roughness: 0.5,
+    });
+    const stripeGeom = new CylinderGeometry(
+      BODY_RADIUS * 1.02,
+      BODY_RADIUS * 1.02,
+      BODY_RADIUS * 0.38,
+      14,
+    );
+    stripeGeom.rotateX(Math.PI / 2);
+    for (const frac of [-0.3, 0.0, 0.35]) {
+      const stripe = new Mesh(stripeGeom, stripeMat);
+      stripe.position.z = BODY_LENGTH * frac;
+      this.group.add(stripe);
+    }
+
+    // Dorsal fin (short, rounded on the triangle's apex).
+    const dorsal = createFin({
+      width: BODY_RADIUS * 1.1,
+      height: BODY_RADIUS * 1.0,
+      color: BODY_COLOR,
+      emissive: FIN_COLOR,
+      emissiveIntensity: 0.1,
+      sweepBack: 0.4,
+    });
+    dorsal.rotation.set(0, Math.PI / 2, 0);
+    dorsal.position.set(0, BODY_RADIUS * 0.85, -BODY_LENGTH * 0.05);
+    this.group.add(dorsal);
+
+    // Pectoral fins (tiny, on sides).
+    for (const side of [-1, 1] as const) {
+      const pec = createFin({
+        width: BODY_RADIUS * 0.6,
+        height: BODY_RADIUS * 0.9,
+        color: BODY_COLOR,
+        emissive: FIN_COLOR,
+        emissiveIntensity: 0.1,
+        sweepBack: 0.35,
+      });
+      pec.rotation.set(Math.PI / 2, 0, side === 1 ? 0 : Math.PI);
+      pec.position.set(side * BODY_RADIUS * 0.7, -BODY_RADIUS * 0.1, -BODY_LENGTH * 0.1);
+      this.group.add(pec);
+    }
+
+    // Caudal (tail) fin: forked like a real clownfish. Built from two
+    // triangles that share a base to simulate the V-shape.
+    this.tailNode = new Group();
+    this.tailNode.position.z = BODY_LENGTH * 0.5;
+    for (const yDir of [1, -1] as const) {
+      const lobe = createFin({
+        width: BODY_RADIUS * 0.9,
+        height: BODY_RADIUS * 1.3,
+        color: BODY_COLOR,
+        emissive: FIN_COLOR,
+        emissiveIntensity: 0.1,
+        sweepBack: 0.55,
+      });
+      lobe.rotation.set(0, Math.PI / 2, yDir === 1 ? 0 : Math.PI);
+      lobe.position.set(0, yDir * BODY_RADIUS * 0.25, 0);
+      this.tailNode.add(lobe);
+    }
+    this.group.add(this.tailNode);
+  }
+
+  update(clockSec: number): void {
+    const angle = -(clockSec / ORBIT_PERIOD_SEC) * Math.PI * 2;
+    const x = Math.cos(angle) * ORBIT_RADIUS;
+    const z = Math.sin(angle) * ORBIT_RADIUS;
+    const yBob = Math.sin(clockSec * 1.7) * 0.012;
+    this.group.position.set(x, ORBIT_HEIGHT + yBob, z);
+
+    const ahead = -((clockSec + 0.05) / ORBIT_PERIOD_SEC) * Math.PI * 2;
+    const lookTarget = new Vector3(
+      Math.cos(ahead) * ORBIT_RADIUS,
+      ORBIT_HEIGHT + yBob,
+      Math.sin(ahead) * ORBIT_RADIUS,
+    );
+    this.group.lookAt(lookTarget);
+
+    // Faster, livelier tail wag than the shark.
+    this.tailNode.rotation.y = Math.sin(clockSec * 6.5) * 0.35;
+  }
+}

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -1,5 +1,4 @@
 // packages/client/src/tree/effects.ts
-import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import type { TreeReef } from './reef.js';
 import type { TreePlacement } from './placement.js';
 import type { AttachIndicators } from './indicators.js';
@@ -12,7 +11,6 @@ export interface EffectsDeps {
   treeReef: TreeReef;
   indicators: AttachIndicators;
   picker: TreePicker;
-  controls: OrbitControls;
   hintEl: HTMLElement;
   apiBase: string;
   /** Called by async callbacks inside effects to drive state transitions. */

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -1,0 +1,43 @@
+// packages/client/src/tree/effects.ts
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { TreeReef } from './reef.js';
+import type { TreePlacement } from './placement.js';
+import type { AttachIndicators } from './indicators.js';
+import type { TreePicker } from '../ui/treePicker.js';
+import type { TreeState, TreeAction } from './state.js';
+
+export interface EffectsDeps {
+  placement: TreePlacement;
+  treeReef: TreeReef;
+  indicators: AttachIndicators;
+  picker: TreePicker;
+  controls: OrbitControls;
+  hintEl: HTMLElement;
+  apiBase: string;
+  /** Called by async callbacks inside effects to drive state transitions. */
+  dispatch: (action: TreeAction) => void;
+  /** Factory for adding a fetched polyp set back into the reef. Called after
+   *  a successful reset so the re-seeded root renders. */
+  addPiecesAndRefresh: (polyps: import('@reef/shared').PublicTreePolyp[]) => void;
+}
+
+export interface Effects {
+  /**
+   * Fire side effects for a state transition. `action` is included because
+   * some transitions (notably `submitting → idle` and `resetting → idle`) can
+   * arrive via different actions and need different UI behavior:
+   *   - submitting → idle via COMMIT_RESOLVED: success hint
+   *   - submitting → idle via TREE_RESET_EXTERNAL: reset hint
+   *   - resetting → idle via RESET_RESOLVED: success hint
+   *   - resetting → idle via RESET_REJECTED: error hint (already set in reject callback)
+   */
+  apply(prev: TreeState, next: TreeState, action: TreeAction): void;
+}
+
+export function createEffects(_deps: EffectsDeps): Effects {
+  return {
+    apply(_prev: TreeState, _next: TreeState, _action: TreeAction): void {
+      // Filled in by subsequent tasks.
+    },
+  };
+}

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -5,7 +5,7 @@ import type { TreePlacement } from './placement.js';
 import type { AttachIndicators } from './indicators.js';
 import type { TreePicker } from '../ui/treePicker.js';
 import type { TreeState, TreeAction } from './state.js';
-import { submitTreePolyp } from './api.js';
+import { fetchTree, resetTree, submitTreePolyp } from './api.js';
 
 export interface EffectsDeps {
   placement: TreePlacement;
@@ -127,6 +127,78 @@ export function createEffects(deps: EffectsDeps): Effects {
         action.type === 'COMMIT_REJECTED'
       ) {
         deps.picker.setSubmitting(false);
+        return;
+      }
+
+      // Clear: any → resetting. Wipe the ghost immediately, fire the API.
+      if (prev.kind !== 'resetting' && next.kind === 'resetting') {
+        deps.placement.reset();
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Clearing…';
+        resetTree(deps.apiBase).then(
+          async () => {
+            // Clear local reef, then re-fetch authoritative state.
+            deps.treeReef.clear();
+            deps.indicators.refresh([]);
+            try {
+              const { polyps } = await fetchTree(deps.apiBase);
+              deps.addPiecesAndRefresh(polyps);
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              deps.hintEl.textContent = `Clear: re-fetch failed — ${msg}`;
+            }
+            deps.dispatch({ type: 'RESET_RESOLVED' });
+          },
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            deps.hintEl.textContent = `Clear failed: ${msg}`;
+            deps.dispatch({ type: 'RESET_REJECTED', error: msg });
+          },
+        );
+        return;
+      }
+
+      // Resetting → idle via RESET_RESOLVED. Success hint.
+      if (
+        prev.kind === 'resetting' && next.kind === 'idle' &&
+        action.type === 'RESET_RESOLVED'
+      ) {
+        deps.hintEl.textContent = 'Cleared. Click a glowing dot to start growing.';
+        return;
+      }
+
+      // Resetting → idle via RESET_REJECTED. Error hint was already written
+      // by the reject callback above; no further work.
+      if (
+        prev.kind === 'resetting' && next.kind === 'idle' &&
+        action.type === 'RESET_REJECTED'
+      ) {
+        return;
+      }
+
+      // TREE_RESET_EXTERNAL: any → idle. The socket handler in tree.ts
+      // already called treeReef.clear() and indicators.refresh(); here we
+      // just drop any pending ghost and unwind submit UI if applicable.
+      //
+      // Four cases depending on `prev.kind`:
+      //   - placing/submitting: a remote user reset while we were interacting.
+      //   - resetting: our own local clear — the server's tree_reset echo
+      //     arrived before our HTTP resolve. Success hint.
+      //   - idle: nothing to do (no ghost, no UI to unwind).
+      if (next.kind === 'idle' && action.type === 'TREE_RESET_EXTERNAL') {
+        if (prev.kind === 'placing') {
+          deps.placement.reset();
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'Tree was reset by another user.';
+        } else if (prev.kind === 'submitting') {
+          deps.placement.reset();
+          deps.picker.setSubmitting(false);
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'Tree was reset by another user.';
+        } else if (prev.kind === 'resetting') {
+          deps.hintEl.textContent = 'Cleared. Click a glowing dot to start growing.';
+        }
+        // prev === 'idle': no-op.
         return;
       }
     },

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -5,6 +5,7 @@ import type { TreePlacement } from './placement.js';
 import type { AttachIndicators } from './indicators.js';
 import type { TreePicker } from '../ui/treePicker.js';
 import type { TreeState, TreeAction } from './state.js';
+import { submitTreePolyp } from './api.js';
 
 export interface EffectsDeps {
   placement: TreePlacement;
@@ -79,6 +80,53 @@ export function createEffects(deps: EffectsDeps): Effects {
         deps.placement.reset();
         deps.picker.setCommittable(false);
         deps.hintEl.textContent = 'Cancelled. Click a glowing dot to try again.';
+        return;
+      }
+
+      // Grow: placing → submitting. Fire the POST and wire its resolution.
+      if (prev.kind === 'placing' && next.kind === 'submitting') {
+        deps.picker.setSubmitting(true);
+        submitTreePolyp(
+          {
+            variant: next.picker.variant,
+            seed: next.seed,
+            colorKey: next.picker.colorKey,
+            parentId: next.parentId,
+            attachIndex: next.attachIndex,
+          },
+          deps.apiBase,
+        ).then(
+          () => deps.dispatch({ type: 'COMMIT_RESOLVED' }),
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            deps.hintEl.textContent = `Grow failed: ${msg}`;
+            deps.dispatch({ type: 'COMMIT_REJECTED', error: msg });
+          },
+        );
+        return;
+      }
+
+      // Commit resolved: submitting → idle via COMMIT_RESOLVED.
+      // (submitting → idle can also happen via TREE_RESET_EXTERNAL; that case
+      // is handled by the external-reset branch in Task 11.)
+      if (
+        prev.kind === 'submitting' && next.kind === 'idle' &&
+        action.type === 'COMMIT_RESOLVED'
+      ) {
+        deps.placement.reset();
+        deps.picker.setSubmitting(false);
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Grown! Click another dot to plant again.';
+        return;
+      }
+
+      // Commit rejected: submitting → placing. Hint was set by the reject
+      // callback above; just unwind the submitting UI.
+      if (
+        prev.kind === 'submitting' && next.kind === 'placing' &&
+        action.type === 'COMMIT_REJECTED'
+      ) {
+        deps.picker.setSubmitting(false);
         return;
       }
     },

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -34,10 +34,69 @@ export interface Effects {
   apply(prev: TreeState, next: TreeState, action: TreeAction): void;
 }
 
-export function createEffects(_deps: EffectsDeps): Effects {
+export function createEffects(deps: EffectsDeps): Effects {
   return {
-    apply(_prev: TreeState, _next: TreeState, _action: TreeAction): void {
-      // Filled in by subsequent tasks.
+    apply(prev: TreeState, next: TreeState, action: TreeAction): void {
+      // Entering placing from elsewhere, or changing slot/variant/seed/color
+      // within placing → re-show the ghost and refresh indicators hint.
+      if (
+        next.kind === 'placing' &&
+        (prev.kind !== 'placing' || hasPlacingIdentityChanged(prev, next))
+      ) {
+        const { variant, colorKey } = next.picker;
+        const ghost = deps.placement.showGhost(
+          variant,
+          next.seed,
+          colorKey,
+          next.parentId,
+          next.attachIndex,
+        );
+        if (ghost) {
+          deps.dispatch({ type: 'PLACEMENT_OK' });
+          deps.picker.setCommittable(true);
+          deps.hintEl.textContent = 'Happy with it? Click Grow.';
+        } else {
+          deps.dispatch({ type: 'PLACEMENT_BLOCKED' });
+          deps.picker.setCommittable(false);
+          deps.hintEl.textContent = 'That spot is blocked. Try another dot or reroll.';
+        }
+        return;
+      }
+
+      // Pure blocked flip within placing (triggered by PLACEMENT_BLOCKED/OK
+      // dispatched after showGhost — which already ran above).
+      if (
+        next.kind === 'placing' && prev.kind === 'placing' &&
+        !hasPlacingIdentityChanged(prev, next) &&
+        prev.blocked !== next.blocked
+      ) {
+        deps.picker.setCommittable(!next.blocked);
+        return;
+      }
+
+      // Leaving placing for idle (cancel).
+      if (prev.kind === 'placing' && next.kind === 'idle' && action.type === 'CANCEL_CLICKED') {
+        deps.placement.reset();
+        deps.picker.setCommittable(false);
+        deps.hintEl.textContent = 'Cancelled. Click a glowing dot to try again.';
+        return;
+      }
     },
   };
+}
+
+/** True when the placing-state identity fields (slot + variant + seed + color)
+ *  changed between prev and next. Used to decide whether to re-show the ghost
+ *  vs. only updating the commit button for a pure blocked flip. */
+function hasPlacingIdentityChanged(
+  prev: TreeState & { kind: 'placing' },
+  next: TreeState & { kind: 'placing' },
+): boolean {
+  return (
+    prev.parentId !== next.parentId ||
+    prev.attachIndex !== next.attachIndex ||
+    prev.seed !== next.seed ||
+    prev.picker.variant !== next.picker.variant ||
+    prev.picker.colorKey !== next.picker.colorKey
+  );
 }

--- a/packages/client/src/tree/fishParts.ts
+++ b/packages/client/src/tree/fishParts.ts
@@ -1,0 +1,51 @@
+import {
+  DoubleSide,
+  Mesh,
+  MeshStandardMaterial,
+  Shape,
+  ShapeGeometry,
+} from 'three';
+
+export interface FinOptions {
+  /** Width at the base. */
+  width: number;
+  /** Height from base to apex. */
+  height: number;
+  /** Solid color. */
+  color: number;
+  /** Emissive tint. Defaults to `color` dimmed; set to 0 to disable. */
+  emissive?: number;
+  /** Emissive intensity. */
+  emissiveIntensity?: number;
+  /** Horizontal offset of apex from base-mid as a fraction of width. */
+  sweepBack?: number;
+}
+
+/**
+ * Creates a triangular fin in the local XY plane with its base centered on
+ * the local X axis and the apex pointing along +Y. Normal is +Z, rendered
+ * double-sided so the fin reads from either angle. Callers rotate/position
+ * the returned Mesh to attach it to a body.
+ */
+export function createFin(opts: FinOptions): Mesh {
+  const {
+    width, height, color,
+    emissive = color,
+    emissiveIntensity = 0.25,
+    sweepBack = 0.15,
+  } = opts;
+  const shape = new Shape();
+  shape.moveTo(-width / 2, 0);
+  shape.lineTo(width / 2, 0);
+  shape.lineTo(width * sweepBack, height);
+  shape.closePath();
+  const geom = new ShapeGeometry(shape);
+  const mat = new MeshStandardMaterial({
+    color,
+    emissive,
+    emissiveIntensity,
+    roughness: 0.6,
+    side: DoubleSide,
+  });
+  return new Mesh(geom, mat);
+}

--- a/packages/client/src/tree/indicators.ts
+++ b/packages/client/src/tree/indicators.ts
@@ -7,7 +7,7 @@ export interface AttachSlot {
   worldNormal: Vector3;
 }
 
-const INDICATOR_RADIUS = 0.004;
+const INDICATOR_RADIUS = 0.007;
 const INDICATOR_SEGMENTS = 12;
 
 function makeIndicatorMesh(): Mesh {

--- a/packages/client/src/tree/indicators.ts
+++ b/packages/client/src/tree/indicators.ts
@@ -12,12 +12,15 @@ const INDICATOR_SEGMENTS = 12;
 
 function makeIndicatorMesh(): Mesh {
   const geom = new SphereGeometry(INDICATOR_RADIUS, INDICATOR_SEGMENTS, INDICATOR_SEGMENTS);
+  // Cool-blue tint + low emissive so the orbs read as subtle "clickable
+  // hints" rather than dominant bright-white spots. Kept below the bloom
+  // threshold so they don't pick up halos from the post-processing pass.
   const mat = new MeshStandardMaterial({
-    color: 0xffffff,
-    emissive: 0xffffff,
-    emissiveIntensity: 1.2,
-    transparent: false,
-    opacity: 1,
+    color: 0x7aa4c4,
+    emissive: 0x2f5a7a,
+    emissiveIntensity: 0.25,
+    transparent: true,
+    opacity: 0.55,
   });
   return new Mesh(geom, mat);
 }

--- a/packages/client/src/tree/material.test.ts
+++ b/packages/client/src/tree/material.test.ts
@@ -1,36 +1,58 @@
 import { describe, expect, test } from 'vitest';
-import { Color, MeshStandardMaterial } from 'three';
+import { BufferGeometry, Color, Mesh, MeshPhysicalMaterial } from 'three';
 import { applyTreeMaterial } from './material.js';
 
+function makeMesh(): Mesh {
+  return new Mesh(new BufferGeometry());
+}
+
 describe('applyTreeMaterial', () => {
-  test('sets a slight translucency (Avatar wet-emissive aesthetic)', () => {
-    const m = new MeshStandardMaterial();
-    applyTreeMaterial(m, '#ff1ad9');
-    expect(m.transparent).toBe(true);
-    expect(m.opacity).toBeGreaterThan(0.6);
-    expect(m.opacity).toBeLessThan(0.95);
+  test('replaces the mesh material with a MeshPhysicalMaterial', () => {
+    const mesh = makeMesh();
+    applyTreeMaterial(mesh, '#ff1ad9');
+    expect(mesh.material).toBeInstanceOf(MeshPhysicalMaterial);
+  });
+
+  test('sets a slight translucency (Avatar wet-coral aesthetic)', () => {
+    const mesh = makeMesh();
+    applyTreeMaterial(mesh, '#ff1ad9');
+    const mat = mesh.material as MeshPhysicalMaterial;
+    expect(mat.transparent).toBe(true);
+    expect(mat.opacity).toBeGreaterThan(0.6);
+    expect(mat.opacity).toBeLessThan(0.95);
   });
 
   test('emissive is set to the provided palette hex (not the default white)', () => {
-    const m = new MeshStandardMaterial();
-    applyTreeMaterial(m, '#2dffe4');
+    const mesh = makeMesh();
+    applyTreeMaterial(mesh, '#2dffe4');
+    const mat = mesh.material as MeshPhysicalMaterial;
     const expected = new Color('#2dffe4');
-    expect(m.emissive.r).toBeCloseTo(expected.r, 5);
-    expect(m.emissive.g).toBeCloseTo(expected.g, 5);
-    expect(m.emissive.b).toBeCloseTo(expected.b, 5);
+    expect(mat.emissive.r).toBeCloseTo(expected.r, 5);
+    expect(mat.emissive.g).toBeCloseTo(expected.g, 5);
+    expect(mat.emissive.b).toBeCloseTo(expected.b, 5);
   });
 
-  test('vertexColors remain enabled (piece color is per-vertex)', () => {
-    const m = new MeshStandardMaterial({ vertexColors: true });
-    applyTreeMaterial(m, '#ff1ad9');
-    expect(m.vertexColors).toBe(true);
+  test('vertexColors enabled so per-vertex color drives per-piece hue', () => {
+    const mesh = makeMesh();
+    applyTreeMaterial(mesh, '#ff1ad9');
+    const mat = mesh.material as MeshPhysicalMaterial;
+    expect(mat.vertexColors).toBe(true);
+  });
+
+  test('has clearcoat + transmission for the wet look', () => {
+    const mesh = makeMesh();
+    applyTreeMaterial(mesh, '#ff1ad9');
+    const mat = mesh.material as MeshPhysicalMaterial;
+    expect(mat.clearcoat).toBeGreaterThan(0);
+    expect(mat.transmission).toBeGreaterThan(0);
   });
 
   test('different palette hexes produce different emissive colors', () => {
-    const a = new MeshStandardMaterial();
-    const b = new MeshStandardMaterial();
-    applyTreeMaterial(a, '#ff1ad9'); // magenta
-    applyTreeMaterial(b, '#b0ff3a'); // lime
-    expect(a.emissive.getHex()).not.toBe(b.emissive.getHex());
+    const a = makeMesh();
+    const b = makeMesh();
+    applyTreeMaterial(a, '#ff1ad9');
+    applyTreeMaterial(b, '#b0ff3a');
+    expect((a.material as MeshPhysicalMaterial).emissive.getHex())
+      .not.toBe((b.material as MeshPhysicalMaterial).emissive.getHex());
   });
 });

--- a/packages/client/src/tree/material.test.ts
+++ b/packages/client/src/tree/material.test.ts
@@ -3,31 +3,34 @@ import { Color, MeshStandardMaterial } from 'three';
 import { applyTreeMaterial } from './material.js';
 
 describe('applyTreeMaterial', () => {
-  test('sets opacity to 1 (fully opaque — Avatar aesthetic)', () => {
-    const m = new MeshStandardMaterial({ color: 0xff00ff });
-    applyTreeMaterial(m);
-    expect(m.opacity).toBe(1);
-    expect(m.transparent).toBe(false);
+  test('sets a slight translucency (Avatar wet-emissive aesthetic)', () => {
+    const m = new MeshStandardMaterial();
+    applyTreeMaterial(m, '#ff1ad9');
+    expect(m.transparent).toBe(true);
+    expect(m.opacity).toBeGreaterThan(0.6);
+    expect(m.opacity).toBeLessThan(0.95);
   });
 
-  test('emissive matches the material color', () => {
-    const m = new MeshStandardMaterial({ color: 0x2dffe4 });
-    applyTreeMaterial(m);
-    const expected = new Color(0x2dffe4);
+  test('emissive is set to the provided palette hex (not the default white)', () => {
+    const m = new MeshStandardMaterial();
+    applyTreeMaterial(m, '#2dffe4');
+    const expected = new Color('#2dffe4');
     expect(m.emissive.r).toBeCloseTo(expected.r, 5);
     expect(m.emissive.g).toBeCloseTo(expected.g, 5);
     expect(m.emissive.b).toBeCloseTo(expected.b, 5);
   });
 
-  test('emissive intensity is high enough to read as fluorescent', () => {
-    const m = new MeshStandardMaterial();
-    applyTreeMaterial(m);
-    expect(m.emissiveIntensity).toBeGreaterThanOrEqual(0.9);
-  });
-
   test('vertexColors remain enabled (piece color is per-vertex)', () => {
     const m = new MeshStandardMaterial({ vertexColors: true });
-    applyTreeMaterial(m);
+    applyTreeMaterial(m, '#ff1ad9');
     expect(m.vertexColors).toBe(true);
+  });
+
+  test('different palette hexes produce different emissive colors', () => {
+    const a = new MeshStandardMaterial();
+    const b = new MeshStandardMaterial();
+    applyTreeMaterial(a, '#ff1ad9'); // magenta
+    applyTreeMaterial(b, '#b0ff3a'); // lime
+    expect(a.emissive.getHex()).not.toBe(b.emissive.getHex());
   });
 });

--- a/packages/client/src/tree/material.ts
+++ b/packages/client/src/tree/material.ts
@@ -1,16 +1,14 @@
-import type { MeshStandardMaterial } from 'three';
-
-export const TREE_EMISSIVE_INTENSITY = 1.0;
+import { Color, type MeshStandardMaterial } from 'three';
 
 /**
- * Avatar-bioluminescent aesthetic: fully opaque, emissive matches the
- * surface color, vertex colors still drive per-piece hue. Downstream a
- * bloom post-processing pass turns the emissive into halos.
+ * Avatar-bioluminescent aesthetic: slight translucency + emissive tinted to
+ * the piece's palette hex (not a flat white, which would desaturate the
+ * vertex colors under the bloom pass). The pulse helper overrides
+ * emissiveIntensity per frame; the color set here is what glows.
  */
-export function applyTreeMaterial(mat: MeshStandardMaterial): void {
-  mat.transparent = false;
-  mat.opacity = 1;
-  mat.emissive.copy(mat.color);
-  mat.emissiveIntensity = TREE_EMISSIVE_INTENSITY;
+export function applyTreeMaterial(mat: MeshStandardMaterial, emissiveHex: string): void {
+  mat.transparent = true;
+  mat.opacity = 0.78;
+  mat.emissive = new Color(emissiveHex);
   mat.needsUpdate = true;
 }

--- a/packages/client/src/tree/material.ts
+++ b/packages/client/src/tree/material.ts
@@ -1,14 +1,31 @@
-import { Color, type MeshStandardMaterial } from 'three';
+import { Color, MeshPhysicalMaterial, type Mesh } from 'three';
 
 /**
- * Avatar-bioluminescent aesthetic: slight translucency + emissive tinted to
- * the piece's palette hex (not a flat white, which would desaturate the
- * vertex colors under the bloom pass). The pulse helper overrides
- * emissiveIntensity per frame; the color set here is what glows.
+ * Avatar-bioluminescent + wet-coral aesthetic: swaps the mesh's material in
+ * place with a MeshPhysicalMaterial configured for a slightly translucent,
+ * clear-coated surface. Vertex colors carry the per-piece hue; `emissive`
+ * is tinted to the palette hex so the bloom pass produces colored halos
+ * rather than washed-out whites. The pulse helper overrides
+ * `emissiveIntensity` per frame for the breathing effect.
  */
-export function applyTreeMaterial(mat: MeshStandardMaterial, emissiveHex: string): void {
-  mat.transparent = true;
-  mat.opacity = 0.78;
-  mat.emissive = new Color(emissiveHex);
-  mat.needsUpdate = true;
+export function applyTreeMaterial(mesh: Mesh, emissiveHex: string): void {
+  const prev = mesh.material as { dispose?: () => void };
+  if (prev && typeof prev.dispose === 'function') prev.dispose();
+
+  const color = new Color(emissiveHex);
+  mesh.material = new MeshPhysicalMaterial({
+    vertexColors: true,
+    color: 0xffffff,            // let vertex colors carry the hue unmodified
+    emissive: color,
+    emissiveIntensity: 0.35,    // pulse overrides this per frame
+    roughness: 0.32,
+    metalness: 0.0,
+    clearcoat: 0.7,             // wet-looking top coat
+    clearcoatRoughness: 0.22,
+    transmission: 0.12,         // subtle see-through for edges
+    thickness: 0.01,
+    ior: 1.33,                  // water-like refraction
+    transparent: true,
+    opacity: 0.88,
+  });
 }

--- a/packages/client/src/tree/placement.ts
+++ b/packages/client/src/tree/placement.ts
@@ -63,8 +63,7 @@ export class TreePlacement {
     })(this.reef.allWorldBoxes());
 
     if (wouldCollide(worldBox, otherBoxes)) {
-      generated.mesh.geometry.dispose();
-      (generated.mesh.material as { dispose: () => void }).dispose();
+      disposeMeshDeep(generated.mesh);
       return null;
     }
 
@@ -87,8 +86,7 @@ export class TreePlacement {
   reset(): void {
     if (this.ghost) {
       this.ghostAnchor.remove(this.ghost);
-      this.ghost.geometry.dispose();
-      (this.ghost.material as { dispose: () => void }).dispose();
+      disposeMeshDeep(this.ghost);
       this.ghost = null;
     }
     this.pending = null;
@@ -97,4 +95,35 @@ export class TreePlacement {
   getPending(): PendingTreePiece | null {
     return this.pending;
   }
+
+  /**
+   * Spin the current ghost around its local +Y axis (which is aligned with
+   * the parent's attach-point normal by construction in showGhost). Lets the
+   * user orient the piece before committing — e.g. aim a Forked piece's two
+   * branches in a specific direction. No-op when no ghost is pending.
+   */
+  rotateGhost(deltaRad: number): void {
+    if (!this.ghost) return;
+    this.ghost.rotateY(deltaRad);
+  }
+}
+
+/**
+ * Disposes a mesh + any Mesh children (e.g. the joint sphere added by
+ * generateTreeVariantMesh). Without this, rerolling a ghost leaks the child
+ * geometry/material each time.
+ */
+function disposeMeshDeep(mesh: Mesh): void {
+  mesh.traverse((obj) => {
+    if ((obj as Mesh).isMesh) {
+      const m = obj as Mesh;
+      m.geometry.dispose();
+      const mat = m.material as { dispose: () => void } | { dispose: () => void }[];
+      if (Array.isArray(mat)) {
+        for (const x of mat) x.dispose();
+      } else {
+        mat.dispose();
+      }
+    }
+  });
 }

--- a/packages/client/src/tree/pulse.test.ts
+++ b/packages/client/src/tree/pulse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import {
+  TREE_AMPLITUDE,
+  TREE_BASELINE,
+  TREE_PERIOD_SEC,
+  treePulseIntensity,
+} from './pulse.js';
+
+describe('treePulseIntensity', () => {
+  test('baseline is brighter than the landscape pulse so the Avatar glow reads', () => {
+    // Regression guard: the tree pulse should not silently drift back to the
+    // landscape's dim baseline (0.2). If someone refactors toward a shared
+    // helper, this test flags the reduction.
+    expect(TREE_BASELINE).toBeGreaterThan(0.25);
+    expect(TREE_AMPLITUDE).toBeGreaterThanOrEqual(0.15);
+  });
+
+  test('at t=0 with seed=0 intensity equals baseline', () => {
+    expect(treePulseIntensity(0, 0)).toBeCloseTo(TREE_BASELINE);
+  });
+
+  test('stays inside [baseline - amplitude, baseline + amplitude]', () => {
+    for (let seed = 0; seed < 0xffffffff; seed += 0x11111111) {
+      for (let t = 0; t < 20; t += 0.1) {
+        const v = treePulseIntensity(t, seed);
+        expect(v).toBeGreaterThanOrEqual(TREE_BASELINE - TREE_AMPLITUDE - 1e-9);
+        expect(v).toBeLessThanOrEqual(TREE_BASELINE + TREE_AMPLITUDE + 1e-9);
+      }
+    }
+  });
+
+  test('different seeds produce different phases at the same instant', () => {
+    const seedA = 0;
+    const seedB = 0x7fffffff;
+    const a = treePulseIntensity(1, seedA);
+    const b = treePulseIntensity(1, seedB);
+    expect(a + b).toBeCloseTo(2 * TREE_BASELINE, 2);
+  });
+
+  test('completes a full cycle over TREE_PERIOD_SEC', () => {
+    const start = treePulseIntensity(0, 0);
+    const oneCycle = treePulseIntensity(TREE_PERIOD_SEC, 0);
+    expect(oneCycle).toBeCloseTo(start, 6);
+  });
+
+  test('quarter-period advance hits the peak for seed=0', () => {
+    const peak = treePulseIntensity(TREE_PERIOD_SEC / 4, 0);
+    expect(peak).toBeCloseTo(TREE_BASELINE + TREE_AMPLITUDE, 6);
+  });
+});

--- a/packages/client/src/tree/pulse.ts
+++ b/packages/client/src/tree/pulse.ts
@@ -1,0 +1,22 @@
+import type { Mesh, MeshStandardMaterial } from 'three';
+
+// Tree-mode bioluminescent pulse: higher baseline + larger amplitude than the
+// landscape pulse so the Avatar-style glow reads as clearly alive under the
+// bloom pass. Each piece phase-shifts off its own seed so a cluster looks
+// organic instead of synchronized.
+export const TREE_BASELINE = 0.4;
+export const TREE_AMPLITUDE = 0.2;
+export const TREE_PERIOD_SEC = 3;
+
+export function treePulseIntensity(clockSec: number, seed: number): number {
+  const phase = ((seed >>> 0) / 0xffffffff) * Math.PI * 2;
+  const omega = (2 * Math.PI) / TREE_PERIOD_SEC;
+  return TREE_BASELINE + TREE_AMPLITUDE * Math.sin(clockSec * omega + phase);
+}
+
+export function installTreePulse(mesh: Mesh, clock: { value: number }, seed: number): void {
+  const mat = mesh.material as MeshStandardMaterial;
+  mesh.onBeforeRender = (): void => {
+    mat.emissiveIntensity = treePulseIntensity(clock.value, seed);
+  };
+}

--- a/packages/client/src/tree/reef.ts
+++ b/packages/client/src/tree/reef.ts
@@ -108,18 +108,23 @@ export class TreeReef {
     if (!entry) return;
 
     this.anchor.remove(entry.mesh);
-    entry.mesh.geometry.dispose();
-    if (Array.isArray(entry.mesh.material)) {
-      for (const m of entry.mesh.material) m.dispose();
-    } else {
-      entry.mesh.material.dispose();
-    }
+    disposeMeshTree(entry.mesh);
 
     this.byId.delete(id);
 
     if (entry.polyp.parentId !== null) {
       this.claimedSlots.delete(`${entry.polyp.parentId}/${entry.polyp.attachIndex}`);
     }
+  }
+
+  /** Removes every registered piece. Used by the reset flow. */
+  clear(): void {
+    for (const entry of this.byId.values()) {
+      this.anchor.remove(entry.mesh);
+      disposeMeshTree(entry.mesh);
+    }
+    this.byId.clear();
+    this.claimedSlots.clear();
   }
 
   getPiece(id: number): Mesh | undefined {
@@ -182,4 +187,20 @@ export class TreeReef {
 
     return out;
   }
+}
+
+/** Disposes a mesh plus every Mesh descendant (e.g. the joint sphere child
+ *  added by generateTreeVariantMesh). Avoids geometry/material leaks. */
+function disposeMeshTree(root: Mesh): void {
+  root.traverse((obj) => {
+    if ((obj as Mesh).isMesh) {
+      const m = obj as Mesh;
+      m.geometry.dispose();
+      if (Array.isArray(m.material)) {
+        for (const mat of m.material) mat.dispose();
+      } else {
+        (m.material as { dispose: () => void }).dispose();
+      }
+    }
+  });
 }

--- a/packages/client/src/tree/scene.ts
+++ b/packages/client/src/tree/scene.ts
@@ -1,8 +1,14 @@
 import {
+  AmbientLight,
+  CanvasTexture,
   CylinderGeometry,
+  DirectionalLight,
+  FogExp2,
+  HemisphereLight,
   Mesh,
   MeshStandardMaterial,
   Scene,
+  SRGBColorSpace,
   Vector2,
   type PerspectiveCamera,
   type WebGLRenderer,
@@ -13,6 +19,51 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 
 const PEDESTAL_RADIUS = 0.15;
 const PEDESTAL_HEIGHT = 0.04;
+
+/**
+ * Vertical-gradient background simulating a water column — a faint teal glow
+ * up top (closer to the surface) fading to near-black at the seafloor. Gives
+ * the coral a sense of depth and context without needing a skybox.
+ */
+export function createUnderwaterBackground(): CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = 4;
+  canvas.height = 512;
+  const ctx = canvas.getContext('2d')!;
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  grad.addColorStop(0.0, '#0b1f2c');
+  grad.addColorStop(0.45, '#03101a');
+  grad.addColorStop(1.0, '#01060d');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const tex = new CanvasTexture(canvas);
+  tex.colorSpace = SRGBColorSpace;
+  return tex;
+}
+
+/**
+ * Underwater-mood lighting: dim teal ambient + cool hemisphere for
+ * bounce, plus a cooler key light from above simulating dappled sunlight
+ * filtered through water. Replaces the default landscape lighting so the
+ * tree reads as submerged rather than on a dry pedestal.
+ */
+export function installUnderwaterLighting(scene: Scene): void {
+  scene.add(new AmbientLight(0x1a3c52, 0.45));
+  scene.add(new HemisphereLight(0x4ab0d8, 0x081220, 0.7));
+  const key = new DirectionalLight(0xbfe4ff, 1.0);
+  key.position.set(0.2, 1.0, 0.3);
+  scene.add(key);
+}
+
+/**
+ * Exponential fog tuned for the tree's small world scale (pieces ~0.1m,
+ * pedestal at ~0.3m radius). A bit of fog at close range softens the
+ * pieces into the background; density is deliberately mild so the coral
+ * doesn't disappear at the intended viewing distance.
+ */
+export function createUnderwaterFog(): FogExp2 {
+  return new FogExp2(0x02101c, 1.6);
+}
 
 export function createTreePedestal(): Mesh {
   const geom = new CylinderGeometry(PEDESTAL_RADIUS, PEDESTAL_RADIUS, PEDESTAL_HEIGHT, 64);

--- a/packages/client/src/tree/scene.ts
+++ b/packages/client/src/tree/scene.ts
@@ -37,9 +37,13 @@ export function createBloomComposer(
   composer.addPass(new RenderPass(scene, camera));
   const bloomPass = new UnrealBloomPass(
     new Vector2(renderer.domElement.width, renderer.domElement.height),
-    1.2,  // strength
-    0.6,  // radius
-    0.4,  // threshold
+    // Low threshold so mid-pulse pieces reliably halo (the persistent "slight
+    // glow" around branches). Strength stays modest so the glow doesn't
+    // overpower the surface color. Raise threshold if pieces look washed-out;
+    // lower strength if the glow feels too strong.
+    0.55, // strength
+    0.5,  // radius
+    0.3,  // threshold
   );
   composer.addPass(bloomPass);
   return {

--- a/packages/client/src/tree/shark.test.ts
+++ b/packages/client/src/tree/shark.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { Mesh } from 'three';
+import { Shark } from './shark.js';
+
+describe('Shark', () => {
+  test('constructs with body + belly + dorsal + 2 pectoral fins + tail node', () => {
+    const s = new Shark();
+    // body, belly, dorsal, left pectoral, right pectoral, tail node = 6 children.
+    expect(s.group.children.length).toBe(6);
+    // First child is a Mesh (the body).
+    expect(s.group.children[0]).toBeInstanceOf(Mesh);
+  });
+
+  test('update(0) places the shark on the +X side of its orbit', () => {
+    const s = new Shark();
+    s.update(0);
+    expect(s.group.position.x).toBeGreaterThan(0);
+    expect(s.group.position.z).toBeCloseTo(0, 5);
+  });
+
+  test('orbit position is periodic — a full period returns to the start', () => {
+    const s = new Shark();
+    s.update(0);
+    const start = s.group.position.clone();
+    // Period is 18s (kept internal; large enough to be well outside landing
+    // numerical error for this test).
+    s.update(18);
+    expect(s.group.position.x).toBeCloseTo(start.x, 4);
+    expect(s.group.position.z).toBeCloseTo(start.z, 4);
+  });
+
+  test('update(t) moves the shark smoothly over time (not stuck)', () => {
+    const s = new Shark();
+    s.update(0);
+    const a = s.group.position.clone();
+    s.update(2);
+    const b = s.group.position.clone();
+    expect(a.distanceTo(b)).toBeGreaterThan(0.01);
+  });
+});

--- a/packages/client/src/tree/shark.ts
+++ b/packages/client/src/tree/shark.ts
@@ -7,12 +7,22 @@ import {
 } from 'three';
 import { createFin } from './fishParts.js';
 
-const ORBIT_RADIUS = 0.32;
-const ORBIT_HEIGHT = 0.14;
-const ORBIT_PERIOD_SEC = 18;
+const DEFAULT_ORBIT_RADIUS = 0.32;
+const DEFAULT_ORBIT_HEIGHT = 0.14;
+const DEFAULT_ORBIT_PERIOD_SEC = 18;
 
 const BODY_RADIUS = 0.012;
 const BODY_LENGTH = 0.075;
+
+export interface SharkOrbitParams {
+  orbitRadius?: number;
+  orbitHeight?: number;
+  orbitPeriodSec?: number;
+  /** Starting offset in radians so multiple sharks don't stack. */
+  phaseRad?: number;
+  /** +1 clockwise (viewed from +Y), -1 counter-clockwise. */
+  direction?: 1 | -1;
+}
 
 const BODY_COLOR = 0x1a2837;
 const BELLY_COLOR = 0xc8d4df;
@@ -26,8 +36,18 @@ const EMISSIVE = 0x3a6b8c;
 export class Shark {
   readonly group = new Group();
   private readonly tailNode: Group;
+  private readonly orbitRadius: number;
+  private readonly orbitHeight: number;
+  private readonly orbitPeriodSec: number;
+  private readonly phaseRad: number;
+  private readonly direction: 1 | -1;
 
-  constructor() {
+  constructor(params: SharkOrbitParams = {}) {
+    this.orbitRadius = params.orbitRadius ?? DEFAULT_ORBIT_RADIUS;
+    this.orbitHeight = params.orbitHeight ?? DEFAULT_ORBIT_HEIGHT;
+    this.orbitPeriodSec = params.orbitPeriodSec ?? DEFAULT_ORBIT_PERIOD_SEC;
+    this.phaseRad = params.phaseRad ?? 0;
+    this.direction = params.direction ?? 1;
     const bodyMat = new MeshStandardMaterial({
       color: BODY_COLOR,
       emissive: EMISSIVE,
@@ -108,11 +128,17 @@ export class Shark {
   }
 
   update(clockSec: number): void {
-    const angle = (clockSec / ORBIT_PERIOD_SEC) * Math.PI * 2;
-    const x = Math.cos(angle) * ORBIT_RADIUS;
-    const z = Math.sin(angle) * ORBIT_RADIUS;
-    this.group.position.set(x, ORBIT_HEIGHT, z);
-    const tangent = new Vector3(-Math.sin(angle), 0, Math.cos(angle));
+    const angle =
+      this.direction * (clockSec / this.orbitPeriodSec) * Math.PI * 2 + this.phaseRad;
+    const x = Math.cos(angle) * this.orbitRadius;
+    const z = Math.sin(angle) * this.orbitRadius;
+    this.group.position.set(x, this.orbitHeight, z);
+    // Tangent of motion at the current angle, sign depends on orbit direction.
+    const tangent = new Vector3(
+      -Math.sin(angle) * this.direction,
+      0,
+      Math.cos(angle) * this.direction,
+    );
     this.group.lookAt(this.group.position.clone().add(tangent));
 
     // Tail wag — slow sinuous sway, just a few degrees either side.

--- a/packages/client/src/tree/shark.ts
+++ b/packages/client/src/tree/shark.ts
@@ -1,0 +1,121 @@
+import {
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  SphereGeometry,
+  Vector3,
+} from 'three';
+import { createFin } from './fishParts.js';
+
+const ORBIT_RADIUS = 0.32;
+const ORBIT_HEIGHT = 0.14;
+const ORBIT_PERIOD_SEC = 18;
+
+const BODY_RADIUS = 0.012;
+const BODY_LENGTH = 0.075;
+
+const BODY_COLOR = 0x1a2837;
+const BELLY_COLOR = 0xc8d4df;
+const EMISSIVE = 0x3a6b8c;
+
+/**
+ * A lone shark cruising slowly around the tree. Elongated tapered body with
+ * dorsal + pectoral + caudal fins, and a subtle tail wag in sync with its
+ * swim cadence.
+ */
+export class Shark {
+  readonly group = new Group();
+  private readonly tailNode: Group;
+
+  constructor() {
+    const bodyMat = new MeshStandardMaterial({
+      color: BODY_COLOR,
+      emissive: EMISSIVE,
+      emissiveIntensity: 0.32,
+      roughness: 0.65,
+      metalness: 0.1,
+    });
+
+    // Body: stretched sphere along local -Z so lookAt orients the snout
+    // forward. Keeping it as a single primitive keeps the silhouette
+    // recognizable from distance without tanking perf.
+    const bodyGeom = new SphereGeometry(BODY_RADIUS, 20, 14);
+    const body = new Mesh(bodyGeom, bodyMat);
+    body.scale.set(1, 0.8, BODY_LENGTH / (BODY_RADIUS * 2));
+    this.group.add(body);
+
+    // Lighter belly: a smaller sphere tucked under the body to read as a
+    // pale underside.
+    const bellyMat = new MeshStandardMaterial({
+      color: BELLY_COLOR,
+      emissive: BELLY_COLOR,
+      emissiveIntensity: 0.12,
+      roughness: 0.7,
+    });
+    const belly = new Mesh(bodyGeom, bellyMat);
+    belly.scale.set(0.85, 0.45, (BODY_LENGTH / (BODY_RADIUS * 2)) * 0.95);
+    belly.position.y = -BODY_RADIUS * 0.35;
+    this.group.add(belly);
+
+    // Dorsal fin (top, behind center).
+    const dorsal = createFin({
+      width: BODY_RADIUS * 1.4,
+      height: BODY_RADIUS * 2.2,
+      color: BODY_COLOR,
+      emissive: EMISSIVE,
+      emissiveIntensity: 0.2,
+      sweepBack: 0.35,
+    });
+    // Stand fin vertical, width along local Z (body axis), normal along X.
+    dorsal.rotation.set(0, Math.PI / 2, 0);
+    dorsal.position.set(0, BODY_RADIUS * 0.75, BODY_LENGTH * 0.05);
+    this.group.add(dorsal);
+
+    // Pectoral fins (sides, swept back).
+    for (const side of [-1, 1] as const) {
+      const pec = createFin({
+        width: BODY_RADIUS * 1.3,
+        height: BODY_RADIUS * 1.6,
+        color: BODY_COLOR,
+        emissive: EMISSIVE,
+        emissiveIntensity: 0.15,
+        sweepBack: 0.5,
+      });
+      // Horizontal, sticking out laterally. Rotated so fin is in XZ plane with
+      // apex pointing outward along +X; then flip for each side.
+      pec.rotation.set(Math.PI / 2, 0, side === 1 ? 0 : Math.PI);
+      pec.position.set(side * BODY_RADIUS * 0.55, -BODY_RADIUS * 0.15, -BODY_LENGTH * 0.12);
+      this.group.add(pec);
+    }
+
+    // Caudal (tail) fin: wrapped in a node so we can wag it without moving
+    // the body. Shark tail is heterocercal — upper lobe larger than lower —
+    // approximated here with a single tall triangle skewed upward.
+    this.tailNode = new Group();
+    this.tailNode.position.z = BODY_LENGTH * 0.45;
+    const tail = createFin({
+      width: BODY_RADIUS * 1.1,
+      height: BODY_RADIUS * 2.6,
+      color: BODY_COLOR,
+      emissive: EMISSIVE,
+      emissiveIntensity: 0.22,
+      sweepBack: 0.6, // apex skewed back → shark-like slant
+    });
+    tail.rotation.set(0, Math.PI / 2, 0);
+    tail.position.set(0, -BODY_RADIUS * 0.25, 0);
+    this.tailNode.add(tail);
+    this.group.add(this.tailNode);
+  }
+
+  update(clockSec: number): void {
+    const angle = (clockSec / ORBIT_PERIOD_SEC) * Math.PI * 2;
+    const x = Math.cos(angle) * ORBIT_RADIUS;
+    const z = Math.sin(angle) * ORBIT_RADIUS;
+    this.group.position.set(x, ORBIT_HEIGHT, z);
+    const tangent = new Vector3(-Math.sin(angle), 0, Math.cos(angle));
+    this.group.lookAt(this.group.position.clone().add(tangent));
+
+    // Tail wag — slow sinuous sway, just a few degrees either side.
+    this.tailNode.rotation.y = Math.sin(clockSec * 3.2) * 0.22;
+  }
+}

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -166,3 +166,37 @@ describe('REROLL_CLICKED', () => {
     expect(next).toBe(s);
   });
 });
+
+describe('PLACEMENT_BLOCKED', () => {
+  test('in placing: sets blocked=true', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'PLACEMENT_BLOCKED' });
+    expect(next).toEqual({ ...s, blocked: true });
+  });
+
+  test('outside placing: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'PLACEMENT_BLOCKED' })).toBe(s);
+  });
+});
+
+describe('PLACEMENT_OK', () => {
+  test('in placing: sets blocked=false', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'PLACEMENT_OK' });
+    expect(next).toEqual({ ...s, blocked: false });
+  });
+
+  test('outside placing: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'PLACEMENT_OK' })).toBe(s);
+  });
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -200,3 +200,105 @@ describe('PLACEMENT_OK', () => {
     expect(reduce(s, { type: 'PLACEMENT_OK' })).toBe(s);
   });
 });
+
+describe('CANCEL_CLICKED', () => {
+  test('from placing → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'CANCEL_CLICKED' });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('from idle/submitting/resetting: no-op', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const resetting: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(idle, { type: 'CANCEL_CLICKED' })).toBe(idle);
+    expect(reduce(submitting, { type: 'CANCEL_CLICKED' })).toBe(submitting);
+    expect(reduce(resetting, { type: 'CANCEL_CLICKED' })).toBe(resetting);
+  });
+});
+
+describe('GROW_CLICKED', () => {
+  test('from placing (blocked=false) → submitting with fields copied', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'GROW_CLICKED' });
+    expect(next).toEqual({
+      kind: 'submitting',
+      picker: s.picker,
+      parentId: 1, attachIndex: 0, seed: 10,
+    });
+  });
+
+  test('from placing (blocked=true): no-op', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    expect(reduce(s, { type: 'GROW_CLICKED' })).toBe(s);
+  });
+
+  test('from idle/submitting/resetting: no-op', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    expect(reduce(idle, { type: 'GROW_CLICKED' })).toBe(idle);
+    expect(reduce(submitting, { type: 'GROW_CLICKED' })).toBe(submitting);
+  });
+});
+
+describe('COMMIT_RESOLVED', () => {
+  test('from submitting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'COMMIT_RESOLVED' });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside submitting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'COMMIT_RESOLVED' })).toBe(s);
+  });
+});
+
+describe('COMMIT_REJECTED', () => {
+  test('from submitting → placing with blocked=false, fields carried', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: s.picker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    });
+  });
+
+  test('outside submitting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'COMMIT_REJECTED', error: 'x' })).toBe(s);
+  });
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -398,3 +398,77 @@ describe('TREE_RESET_EXTERNAL', () => {
       .toEqual({ kind: 'idle', picker: resetting.picker });
   });
 });
+
+describe('reduce — no-op matrix', () => {
+  // Sample states of each kind, populated with deterministic field values.
+  const samples: Record<TreeState['kind'], TreeState> = {
+    idle: { kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+    placing: {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    },
+    submitting: {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    },
+    resetting: { kind: 'resetting', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+  };
+
+  // The `valid` matrix lists which action types produce a real transition
+  // (non-identity result) from each state kind.
+  const valid: Record<TreeState['kind'], readonly TreeAction['type'][]> = {
+    idle: ['VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL'],
+    placing: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'REROLL_CLICKED',
+      'PLACEMENT_BLOCKED', 'PLACEMENT_OK', 'CANCEL_CLICKED', 'GROW_CLICKED',
+      'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL',
+    ],
+    submitting: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN',
+      'COMMIT_RESOLVED', 'COMMIT_REJECTED',
+      'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL',
+    ],
+    resetting: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN',
+      'RESET_RESOLVED', 'RESET_REJECTED',
+      'TREE_RESET_EXTERNAL',
+    ],
+  };
+
+  // Every TreeAction shape with sample payload, enumerated once.
+  const allActions: TreeAction[] = [
+    { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 1 },
+    { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' },
+    { type: 'ATTACH_CLICKED', parentId: 1, attachIndex: 0, seed: 1 },
+    { type: 'REROLL_CLICKED', variant: 'wishbone', seed: 2 },
+    { type: 'PLACEMENT_BLOCKED' },
+    { type: 'PLACEMENT_OK' },
+    { type: 'CANCEL_CLICKED' },
+    { type: 'GROW_CLICKED' },
+    { type: 'COMMIT_RESOLVED' },
+    { type: 'COMMIT_REJECTED', error: 'x' },
+    { type: 'CLEAR_CLICKED' },
+    { type: 'RESET_RESOLVED' },
+    { type: 'RESET_REJECTED', error: 'x' },
+    { type: 'TREE_RESET_EXTERNAL' },
+  ];
+
+  for (const kind of Object.keys(samples) as Array<TreeState['kind']>) {
+    const state = samples[kind];
+    for (const action of allActions) {
+      const expectIdentity = !valid[kind].includes(action.type);
+      test(`${kind} + ${action.type} → ${expectIdentity ? 'identity' : 'transition'}`, () => {
+        const next = reduce(state, action);
+        if (expectIdentity) {
+          expect(next).toBe(state);
+        } else {
+          // For covered transitions we already assert specifics elsewhere;
+          // here just ensure we *didn't* return identity.
+          expect(next).not.toBe(state);
+        }
+      });
+    }
+  }
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -19,3 +19,73 @@ describe('reduce default behavior', () => {
     expect(reduce(s, a)).toBe(s);
   });
 });
+
+describe('VARIANT_CHOSEN', () => {
+  test('in idle: updates picker.variant, seed ignored', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 123 });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'claw', colorKey: 'neon-cyan' } });
+  });
+
+  test('in placing: updates both picker.variant and seed', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'wishbone', seed: 99 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 99, blocked: false,
+    });
+  });
+
+  test('in submitting: updates picker.variant and seed', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'trident', seed: 42 });
+    expect(next).toEqual({
+      kind: 'submitting',
+      picker: { variant: 'trident', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 42,
+    });
+  });
+
+  test('in resetting: updates picker.variant; no seed field exists', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'starburst', seed: 7 });
+    expect(next).toEqual({
+      kind: 'resetting',
+      picker: { variant: 'starburst', colorKey: 'neon-cyan' },
+    });
+  });
+});
+
+describe('COLOR_CHOSEN', () => {
+  test('in idle: updates picker.colorKey', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-magenta' } });
+  });
+
+  test('in placing: preserves seed, updates picker.colorKey only', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-lime' });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-lime' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    });
+  });
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -89,3 +89,80 @@ describe('COLOR_CHOSEN', () => {
     });
   });
 });
+
+describe('ATTACH_CLICKED', () => {
+  test('from idle → placing with picker inherited, blocked false', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 5, attachIndex: 2, seed: 77 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 5, attachIndex: 2, seed: 77, blocked: false,
+    });
+  });
+
+  test('from placing → placing with new params, blocked reset to false', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 3, attachIndex: 1, seed: 55 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
+      parentId: 3, attachIndex: 1, seed: 55, blocked: false,
+    });
+  });
+
+  test('from submitting: no-op (same reference returned)', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 9, attachIndex: 9, seed: 9 });
+    expect(next).toBe(s);
+  });
+
+  test('from resetting: no-op (same reference returned)', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 1, attachIndex: 0, seed: 1 });
+    expect(next).toBe(s);
+  });
+});
+
+describe('REROLL_CLICKED', () => {
+  test('from placing → placing with new variant + seed, blocked reset', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+    };
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toEqual({
+      kind: 'placing',
+      picker: { variant: 'claw', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 42, blocked: false,
+    });
+  });
+
+  test('from idle: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toBe(s);
+  });
+
+  test('from submitting: no-op', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
+    expect(next).toBe(s);
+  });
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -302,3 +302,99 @@ describe('COMMIT_REJECTED', () => {
     expect(reduce(s, { type: 'COMMIT_REJECTED', error: 'x' })).toBe(s);
   });
 });
+
+describe('CLEAR_CLICKED', () => {
+  test('from idle → resetting with picker inherited', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from placing → resetting with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from submitting → resetting', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10,
+    };
+    const next = reduce(s, { type: 'CLEAR_CLICKED' });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+  });
+
+  test('from resetting: no-op', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'CLEAR_CLICKED' })).toBe(s);
+  });
+});
+
+describe('RESET_RESOLVED', () => {
+  test('from resetting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'RESET_RESOLVED' }))
+      .toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside resetting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'RESET_RESOLVED' })).toBe(s);
+  });
+});
+
+describe('RESET_REJECTED', () => {
+  test('from resetting → idle with picker inherited', () => {
+    const s: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+    };
+    expect(reduce(s, { type: 'RESET_REJECTED', error: 'x' }))
+      .toEqual({ kind: 'idle', picker: s.picker });
+  });
+
+  test('outside resetting: no-op', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(s, { type: 'RESET_REJECTED', error: 'x' })).toBe(s);
+  });
+});
+
+describe('TREE_RESET_EXTERNAL', () => {
+  test('from any kind → idle with picker inherited', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    const placing: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'wishbone', colorKey: 'neon-lime' },
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+    };
+    const submitting: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'claw', colorKey: 'neon-violet' },
+      parentId: 2, attachIndex: 1, seed: 20,
+    };
+    const resetting: TreeState = {
+      kind: 'resetting',
+      picker: { variant: 'trident', colorKey: 'neon-orange' },
+    };
+    expect(reduce(idle, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: idle.picker });
+    expect(reduce(placing, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: placing.picker });
+    expect(reduce(submitting, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: submitting.picker });
+    expect(reduce(resetting, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: resetting.picker });
+  });
+});

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { initialState, reduce, type TreeAction, type TreeState } from './state.js';
+
+describe('initialState', () => {
+  test('returns idle with the provided picker selection', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(s.kind).toBe('idle');
+    if (s.kind === 'idle') {
+      expect(s.picker).toEqual({ variant: 'forked', colorKey: 'neon-cyan' });
+    }
+  });
+});
+
+describe('reduce default behavior', () => {
+  test('any unhandled action returns the same state reference', () => {
+    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    // At this stage no actions are implemented; any action should be a no-op.
+    const a: TreeAction = { type: 'CANCEL_CLICKED' };
+    expect(reduce(s, a)).toBe(s);
+  });
+});

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -118,6 +118,17 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         blocked: false,
       };
     }
+    case 'CLEAR_CLICKED': {
+      if (state.kind === 'resetting') return state;
+      return { kind: 'resetting', picker: state.picker };
+    }
+    case 'RESET_RESOLVED':
+    case 'RESET_REJECTED': {
+      if (state.kind !== 'resetting') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'TREE_RESET_EXTERNAL':
+      return { kind: 'idle', picker: state.picker };
     default:
       return state;
   }

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -81,6 +81,14 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         blocked: false,
       };
     }
+    case 'PLACEMENT_BLOCKED': {
+      if (state.kind !== 'placing') return state;
+      return { ...state, blocked: true };
+    }
+    case 'PLACEMENT_OK': {
+      if (state.kind !== 'placing') return state;
+      return { ...state, blocked: false };
+    }
     default:
       return state;
   }

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -44,6 +44,22 @@ export function initialState(picker: PickerSelection): TreeState {
   return { kind: 'idle', picker };
 }
 
-export function reduce(state: TreeState, _action: TreeAction): TreeState {
-  return state;
+export function reduce(state: TreeState, action: TreeAction): TreeState {
+  switch (action.type) {
+    case 'VARIANT_CHOSEN': {
+      const picker = { ...state.picker, variant: action.variant };
+      switch (state.kind) {
+        case 'idle':      return { ...state, picker };
+        case 'placing':   return { ...state, picker, seed: action.seed };
+        case 'submitting':return { ...state, picker, seed: action.seed };
+        case 'resetting': return { ...state, picker };
+      }
+    }
+    case 'COLOR_CHOSEN': {
+      const picker = { ...state.picker, colorKey: action.colorKey };
+      return { ...state, picker };
+    }
+    default:
+      return state;
+  }
 }

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -59,6 +59,28 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
       const picker = { ...state.picker, colorKey: action.colorKey };
       return { ...state, picker };
     }
+    case 'ATTACH_CLICKED': {
+      if (state.kind === 'idle' || state.kind === 'placing') {
+        return {
+          kind: 'placing',
+          picker: state.picker,
+          parentId: action.parentId,
+          attachIndex: action.attachIndex,
+          seed: action.seed,
+          blocked: false,
+        };
+      }
+      return state;
+    }
+    case 'REROLL_CLICKED': {
+      if (state.kind !== 'placing') return state;
+      return {
+        ...state,
+        picker: { ...state.picker, variant: action.variant },
+        seed: action.seed,
+        blocked: false,
+      };
+    }
     default:
       return state;
   }

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -1,0 +1,49 @@
+import type { TreeVariant } from '@reef/shared';
+
+export interface PickerSelection {
+  variant: TreeVariant;
+  colorKey: string;
+}
+
+export type TreeState =
+  | { kind: 'idle'; picker: PickerSelection }
+  | {
+      kind: 'placing';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+      blocked: boolean;
+    }
+  | {
+      kind: 'submitting';
+      picker: PickerSelection;
+      parentId: number;
+      attachIndex: number;
+      seed: number;
+    }
+  | { kind: 'resetting'; picker: PickerSelection };
+
+export type TreeAction =
+  | { type: 'VARIANT_CHOSEN'; variant: TreeVariant; seed: number }
+  | { type: 'COLOR_CHOSEN'; colorKey: string }
+  | { type: 'ATTACH_CLICKED'; parentId: number; attachIndex: number; seed: number }
+  | { type: 'REROLL_CLICKED'; variant: TreeVariant; seed: number }
+  | { type: 'PLACEMENT_BLOCKED' }
+  | { type: 'PLACEMENT_OK' }
+  | { type: 'CANCEL_CLICKED' }
+  | { type: 'GROW_CLICKED' }
+  | { type: 'COMMIT_RESOLVED' }
+  | { type: 'COMMIT_REJECTED'; error: string }
+  | { type: 'CLEAR_CLICKED' }
+  | { type: 'RESET_RESOLVED' }
+  | { type: 'RESET_REJECTED'; error: string }
+  | { type: 'TREE_RESET_EXTERNAL' };
+
+export function initialState(picker: PickerSelection): TreeState {
+  return { kind: 'idle', picker };
+}
+
+export function reduce(state: TreeState, _action: TreeAction): TreeState {
+  return state;
+}

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -89,6 +89,35 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
       if (state.kind !== 'placing') return state;
       return { ...state, blocked: false };
     }
+    case 'CANCEL_CLICKED': {
+      if (state.kind !== 'placing') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'GROW_CLICKED': {
+      if (state.kind !== 'placing' || state.blocked) return state;
+      return {
+        kind: 'submitting',
+        picker: state.picker,
+        parentId: state.parentId,
+        attachIndex: state.attachIndex,
+        seed: state.seed,
+      };
+    }
+    case 'COMMIT_RESOLVED': {
+      if (state.kind !== 'submitting') return state;
+      return { kind: 'idle', picker: state.picker };
+    }
+    case 'COMMIT_REJECTED': {
+      if (state.kind !== 'submitting') return state;
+      return {
+        kind: 'placing',
+        picker: state.picker,
+        parentId: state.parentId,
+        attachIndex: state.attachIndex,
+        seed: state.seed,
+        blocked: false,
+      };
+    }
     default:
       return state;
   }

--- a/packages/client/src/tree/variants.test.ts
+++ b/packages/client/src/tree/variants.test.ts
@@ -18,12 +18,14 @@ describe('generateTreeVariantMesh', () => {
     expect(result.attachPointsLocal).toHaveLength(ATTACH_COUNTS[variant]);
   });
 
-  test('applies Avatar material preset (opacity 1 + high emissive)', () => {
+  test('applies Avatar material preset (slightly transparent + palette-tinted emissive)', () => {
     const result = generateTreeVariantMesh({ variant: 'starburst', seed: 1, colorKey: 'neon-cyan' });
     const mat = result.mesh.material as MeshStandardMaterial;
-    expect(mat.opacity).toBe(1);
-    expect(mat.transparent).toBe(false);
-    expect(mat.emissiveIntensity).toBeGreaterThanOrEqual(0.9);
+    expect(mat.transparent).toBe(true);
+    expect(mat.opacity).toBeGreaterThan(0.6);
+    expect(mat.opacity).toBeLessThan(0.95);
+    // Emissive should match the neon-cyan palette hex (#2dffe4), not default white.
+    expect(mat.emissive.getHexString()).toBe('2dffe4');
   });
 
   test('returns a Box3 bounding box', () => {

--- a/packages/client/src/tree/variants.ts
+++ b/packages/client/src/tree/variants.ts
@@ -1,6 +1,6 @@
 import { Box3, MeshStandardMaterial, Vector3 } from 'three';
 import type { Mesh } from 'three';
-import type { AttachPoint, TreeVariant } from '@reef/shared';
+import { paletteByKey, type AttachPoint, type TreeVariant } from '@reef/shared';
 import { generateTreeVariant } from '@reef/generator';
 import { polypMesh } from '../scene/meshAdapter.js';
 import { applyTreeMaterial } from './material.js';
@@ -19,7 +19,8 @@ export function generateTreeVariantMesh(input: {
   const { mesh: meshData, attachPoints, boundingBox: bb } = generateTreeVariant(input);
 
   const mesh = polypMesh(meshData);
-  applyTreeMaterial(mesh.material as MeshStandardMaterial);
+  const hex = paletteByKey(input.colorKey).hex;
+  applyTreeMaterial(mesh.material as MeshStandardMaterial, hex);
 
   const boundingBox = new Box3(
     new Vector3(bb.min.x, bb.min.y, bb.min.z),

--- a/packages/client/src/tree/variants.ts
+++ b/packages/client/src/tree/variants.ts
@@ -1,5 +1,11 @@
-import { Box3, MeshStandardMaterial, Vector3 } from 'three';
-import type { Mesh } from 'three';
+import {
+  Box3,
+  Color,
+  Mesh,
+  MeshPhysicalMaterial,
+  SphereGeometry,
+  Vector3,
+} from 'three';
 import { paletteByKey, type AttachPoint, type TreeVariant } from '@reef/shared';
 import { generateTreeVariant } from '@reef/generator';
 import { polypMesh } from '../scene/meshAdapter.js';
@@ -11,6 +17,12 @@ export interface TreeMeshResult {
   boundingBox: Box3;
 }
 
+// Radius of the "joint" sphere dropped at each piece's local origin so the
+// disc edges of parent-tip / child-base frustums blend smoothly. Conservative
+// value — slightly larger than the max trunk-base radius across variants
+// (~0.008) so it fully covers the hard edge without ballooning the silhouette.
+const JOINT_RADIUS = 0.009;
+
 export function generateTreeVariantMesh(input: {
   variant: TreeVariant;
   seed: number;
@@ -20,7 +32,27 @@ export function generateTreeVariantMesh(input: {
 
   const mesh = polypMesh(meshData);
   const hex = paletteByKey(input.colorKey).hex;
-  applyTreeMaterial(mesh.material as MeshStandardMaterial, hex);
+  applyTreeMaterial(mesh, hex);
+
+  // Joint sphere at local (0,0,0). When the piece is placed at a parent's
+  // attach point, the sphere sits over the seam where the parent's tip
+  // frustum meets this piece's base frustum, rounding the connection.
+  // Matches the main mesh's physical-material aesthetic so the join doesn't
+  // read as a different material.
+  const jointColor = new Color(hex);
+  const jointMat = new MeshPhysicalMaterial({
+    color: jointColor,
+    emissive: jointColor,
+    emissiveIntensity: 0.35,
+    transparent: true,
+    opacity: 0.9,
+    roughness: 0.4,
+    metalness: 0.0,
+    clearcoat: 0.6,
+    clearcoatRoughness: 0.25,
+  });
+  const joint = new Mesh(new SphereGeometry(JOINT_RADIUS, 14, 10), jointMat);
+  mesh.add(joint);
 
   const boundingBox = new Box3(
     new Vector3(bb.min.x, bb.min.y, bb.min.z),

--- a/packages/client/src/ui/treePicker.ts
+++ b/packages/client/src/ui/treePicker.ts
@@ -42,6 +42,14 @@ export class TreePicker {
   onChange(l: TreePickerListener): void { this.listeners.push(l); }
   get(): TreePickerState { return this.state; }
 
+  setVariant(variant: TreeVariant): void {
+    if (!TREE_VARIANTS.includes(variant)) return;
+    if (this.state.variant === variant) return;
+    this.state = { ...this.state, variant };
+    this.highlight();
+    this.emit();
+  }
+
   setCommittable(ok: boolean): void {
     this.growBtn.disabled = !ok;
     this.rerollBtn.disabled = !ok;

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -15,11 +15,27 @@
       background: rgba(0,0,0,0.35); border-radius: 3px;
       pointer-events: none;
     }
+    #toolbar {
+      position: fixed; top: 12px; right: 12px; display: flex; gap: 6px;
+      font: 500 12px/1 system-ui, sans-serif;
+    }
+    #toolbar button {
+      padding: 6px 10px; color: #cfe; background: rgba(10,20,32,0.75);
+      border: 1px solid rgba(120,180,220,0.25); border-radius: 4px;
+      cursor: pointer;
+    }
+    #toolbar button:hover { background: rgba(20,40,60,0.85); }
+    #toolbar button:active { transform: translateY(1px); }
   </style>
 </head>
 <body>
   <canvas id="gl"></canvas>
   <div id="mode-badge"></div>
+  <div id="toolbar" aria-label="Tree controls">
+    <button id="clearBtn" type="button">Clear</button>
+    <button id="addSharkBtn" type="button">Add shark</button>
+    <button id="addClownfishBtn" type="button">Add clownfish</button>
+  </div>
   <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
     <div class="picker-row" role="group" aria-label="Variant">
       <button type="button" data-variant="forked">Forked</button>

--- a/packages/generator/src/tree/variant.ts
+++ b/packages/generator/src/tree/variant.ts
@@ -49,6 +49,54 @@ function colorG(c: ColorInput): number { return Array.isArray(c) ? (c as readonl
 function colorB(c: ColorInput): number { return Array.isArray(c) ? (c as readonly number[])[2]! : (c as Vec3Obj).z; }
 
 /**
+ * Deterministic PRNG (mulberry32). Takes an integer seed, returns a stateful
+ * function that yields floats in [0, 1). Used to give each piece a unique but
+ * reproducible shape — variant geometry used to be identical across pieces
+ * because `seed` was ignored; now it drives dimensional jitter and surface
+ * noise so the reef doesn't read as repeated stamps.
+ */
+export function seededRand(seed: number): () => number {
+  let state = (seed | 0) >>> 0;
+  return (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 0x1_0000_0000;
+  };
+}
+
+/**
+ * Returns `base` multiplied by a random factor in [1 - pct, 1 + pct]. Handy
+ * for per-piece constant jitter — e.g. `jitter(rand, TRUNK_HEIGHT, 0.12)` for
+ * ±12% variation on a variant's trunk height.
+ */
+export function jitter(rand: () => number, base: number, pct: number): number {
+  return base * (1 - pct + rand() * pct * 2);
+}
+
+export interface EmitFrustumOpts {
+  /** Seed for the per-vertex surface noise. If absent, geometry is smooth. */
+  seed?: number;
+  /** Per-vertex radial jitter as a fraction of local radius (bumps around the circumference). */
+  noiseAmplitude?: number;
+  /**
+   * Number of intermediate rings along the frustum axis, on top of the two
+   * endpoint rings. 0 = smooth taper (bottom ring + top ring only, the
+   * original behavior). 4+ produces visible length-wise modulation so each
+   * frustum has ribs/pinches rather than a perfectly linear taper — the
+   * look of real coral skeletons.
+   */
+  lengthSubdivisions?: number;
+  /**
+   * Ring-level radial modulation as a fraction of local radius. Applied
+   * once per ring so entire rings inflate/deflate together, creating bands
+   * of thicker and thinner sections along the branch.
+   */
+  ridgeAmplitude?: number;
+}
+
+/**
  * Append an open-ended frustum (truncated cone) to the given geometry arrays.
  *
  * Orientation is arbitrary — `from`/`to` can point in any direction. The ring
@@ -70,6 +118,7 @@ export function emitFrustum(
   r1: number,
   color: ColorInput,
   segments: number,
+  opts: EmitFrustumOpts = {},
 ): void {
   const ax = to.x - from.x;
   const ay = to.y - from.y;
@@ -100,30 +149,61 @@ export function emitFrustum(
   const cr = colorR(color), cg = colorG(color), cb = colorB(color);
   const baseIdx = positions.length / 3;
 
-  for (let i = 0; i < segments; i++) {
-    const theta = (i / segments) * Math.PI * 2;
-    const ct = Math.cos(theta), st = Math.sin(theta);
-    const nx = ux * ct + vx * st;
-    const ny = uy * ct + vy * st;
-    const nz = uz * ct + vz * st;
+  const vertexAmp = opts.noiseAmplitude ?? 0;
+  const ridgeAmp = opts.ridgeAmplitude ?? 0;
+  const lenSubs = Math.max(0, Math.floor(opts.lengthSubdivisions ?? 0));
+  const rings = lenSubs + 2; // endpoints + subdivisions
+  const hasNoise = opts.seed !== undefined && (vertexAmp > 0 || ridgeAmp > 0);
+  const rand = hasNoise ? seededRand(opts.seed!) : null;
 
-    // Bottom vertex (at "from", radius r0)
-    positions.push(from.x + nx * r0, from.y + ny * r0, from.z + nz * r0);
-    normals.push(nx, ny, nz);
-    colors.push(cr, cg, cb);
-
-    // Top vertex (at "to", radius r1)
-    positions.push(to.x + nx * r1, to.y + ny * r1, to.z + nz * r1);
-    normals.push(nx, ny, nz);
-    colors.push(cr, cg, cb);
+  // Compute a per-ring radial scale once so an entire ring expands/contracts
+  // together. Reads as a "rib" or "pinch" along the branch. Endpoint rings
+  // are left unperturbed so child pieces attach cleanly at the tip.
+  const ringScales = new Array<number>(rings).fill(1);
+  if (rand && ridgeAmp > 0) {
+    for (let k = 1; k < rings - 1; k++) {
+      ringScales[k] = 1 + (rand() - 0.5) * 2 * ridgeAmp;
+    }
   }
 
-  for (let i = 0; i < segments; i++) {
-    const a = baseIdx + i * 2;
-    const b = baseIdx + i * 2 + 1;
-    const c = baseIdx + ((i + 1) % segments) * 2;
-    const d = baseIdx + ((i + 1) % segments) * 2 + 1;
-    indices.push(a, b, d, a, d, c);
+  // Emit `rings` rings of `segments` vertices each, walking along the frustum
+  // axis. Each ring: radius = lerp(r0, r1) * ringScale * (1 + per-vertex noise).
+  for (let k = 0; k < rings; k++) {
+    const t = k / (rings - 1);
+    const axisX = from.x + (to.x - from.x) * t;
+    const axisY = from.y + (to.y - from.y) * t;
+    const axisZ = from.z + (to.z - from.z) * t;
+    const ringR = (r0 + (r1 - r0) * t) * ringScales[k]!;
+
+    for (let i = 0; i < segments; i++) {
+      const theta = (i / segments) * Math.PI * 2;
+      const ct = Math.cos(theta), st = Math.sin(theta);
+      const nx = ux * ct + vx * st;
+      const ny = uy * ct + vy * st;
+      const nz = uz * ct + vz * st;
+
+      const vj = rand && vertexAmp > 0 ? (rand() - 0.5) * 2 * vertexAmp : 0;
+      const rr = ringR * (1 + vj);
+
+      positions.push(axisX + nx * rr, axisY + ny * rr, axisZ + nz * rr);
+      normals.push(nx, ny, nz);
+      colors.push(cr, cg, cb);
+    }
+  }
+
+  // Stitch consecutive rings with quad strips. Ring k occupies vertices
+  // [baseIdx + k*segments, baseIdx + (k+1)*segments).
+  for (let k = 0; k < rings - 1; k++) {
+    const ringA = baseIdx + k * segments;
+    const ringB = baseIdx + (k + 1) * segments;
+    for (let i = 0; i < segments; i++) {
+      const iNext = (i + 1) % segments;
+      const a = ringA + i;
+      const b = ringB + i;
+      const c = ringA + iNext;
+      const d = ringB + iNext;
+      indices.push(a, b, d, a, d, c);
+    }
   }
 }
 

--- a/packages/generator/src/tree/variants/claw.ts
+++ b/packages/generator/src/tree/variants/claw.ts
@@ -1,5 +1,11 @@
 import type { VariantGenerateInput, VariantOutput } from '../variant.js';
-import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import {
+  tipAttachPoint,
+  emitFrustum,
+  computeAABB,
+  seededRand,
+  jitter,
+} from '../variant.js';
 import { colorVec3 } from '../../species/_common.js';
 
 const STRAIGHT_SEG_LENGTH = 0.03;
@@ -10,9 +16,10 @@ const TRUNK_TIP_RADIUS = 0.005;
 const CLAW_LENGTH = 0.025;
 const CLAW_BASE_RADIUS = 0.005;
 const CLAW_TIP_RADIUS = 0.002;
-const BEND_ANGLE = Math.PI / 3;              // 60° off vertical at the midpoint
-const CLAW_SPLIT_ANGLE = Math.PI / 8;        // ~22° fork angle between the two tips
-const SEGMENTS = 6;
+const BEND_ANGLE = Math.PI / 3;
+const CLAW_SPLIT_ANGLE = Math.PI / 8;
+const SEGMENTS = 10;
+const NOISE_AMP = 0.12;
 
 export function generateClaw(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -21,45 +28,79 @@ export function generateClaw(input: VariantGenerateInput): VariantOutput {
   const indices: number[] = [];
   const color = colorVec3(input.colorKey);
 
+  const rand = seededRand(input.seed);
+  const straightLen = jitter(rand, STRAIGHT_SEG_LENGTH, 0.12);
+  const bentLen = jitter(rand, BENT_SEG_LENGTH, 0.15);
+  const bendAngle = jitter(rand, BEND_ANGLE, 0.1);
+  const splitAngle = jitter(rand, CLAW_SPLIT_ANGLE, 0.2);
+  const splitAsymmetry = jitter(rand, 1, 0.18);
+  const clawLenA = jitter(rand, CLAW_LENGTH, 0.15);
+  const clawLenB = jitter(rand, CLAW_LENGTH, 0.15);
+
   // Segment 1: straight up from origin to midpoint.
   const midBase = { x: 0, y: 0, z: 0 };
-  const midApex = { x: 0, y: STRAIGHT_SEG_LENGTH, z: 0 };
-  emitFrustum(positions, normals, colors, indices,
-    midBase, midApex, TRUNK_BASE_RADIUS, TRUNK_MID_RADIUS, color, SEGMENTS);
+  const midApex = { x: 0, y: straightLen, z: 0 };
+  emitFrustum(
+    positions, normals, colors, indices,
+    midBase, midApex,
+    jitter(rand, TRUNK_BASE_RADIUS, 0.1),
+    jitter(rand, TRUNK_MID_RADIUS, 0.1),
+    color, SEGMENTS,
+    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+  );
 
-  // Segment 2: bent — from midApex in a direction tilted BEND_ANGLE off vertical toward +X.
-  const bentDir = { x: Math.sin(BEND_ANGLE), y: Math.cos(BEND_ANGLE), z: 0 };
+  // Segment 2: bent.
+  const bentDir = { x: Math.sin(bendAngle), y: Math.cos(bendAngle), z: 0 };
   const bentEnd = {
-    x: midApex.x + bentDir.x * BENT_SEG_LENGTH,
-    y: midApex.y + bentDir.y * BENT_SEG_LENGTH,
+    x: midApex.x + bentDir.x * bentLen,
+    y: midApex.y + bentDir.y * bentLen,
     z: 0,
   };
-  emitFrustum(positions, normals, colors, indices,
-    midApex, bentEnd, TRUNK_MID_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS);
+  emitFrustum(
+    positions, normals, colors, indices,
+    midApex, bentEnd,
+    jitter(rand, TRUNK_MID_RADIUS, 0.1),
+    jitter(rand, TRUNK_TIP_RADIUS, 0.1),
+    color, SEGMENTS,
+    { seed: input.seed * 7 + 2, noiseAmplitude: NOISE_AMP },
+  );
 
-  // Two claw tips splitting from bentEnd — symmetric around the bentDir axis in XY plane.
-  // Rotate bentDir by ±CLAW_SPLIT_ANGLE around the Z axis.
+  // Two claw tips with asymmetric split angles.
   const rot = (angle: number) => ({
     x: Math.cos(angle) * bentDir.x - Math.sin(angle) * bentDir.y,
     y: Math.sin(angle) * bentDir.x + Math.cos(angle) * bentDir.y,
     z: 0,
   });
-  const dirA = rot(+CLAW_SPLIT_ANGLE);
-  const dirB = rot(-CLAW_SPLIT_ANGLE);
+  const angleA = splitAngle;
+  const angleB = -splitAngle * splitAsymmetry;
+  const dirA = rot(angleA);
+  const dirB = rot(angleB);
   const tipA = {
-    x: bentEnd.x + dirA.x * CLAW_LENGTH,
-    y: bentEnd.y + dirA.y * CLAW_LENGTH,
+    x: bentEnd.x + dirA.x * clawLenA,
+    y: bentEnd.y + dirA.y * clawLenA,
     z: 0,
   };
   const tipB = {
-    x: bentEnd.x + dirB.x * CLAW_LENGTH,
-    y: bentEnd.y + dirB.y * CLAW_LENGTH,
+    x: bentEnd.x + dirB.x * clawLenB,
+    y: bentEnd.y + dirB.y * clawLenB,
     z: 0,
   };
-  emitFrustum(positions, normals, colors, indices,
-    bentEnd, tipA, CLAW_BASE_RADIUS, CLAW_TIP_RADIUS, color, SEGMENTS);
-  emitFrustum(positions, normals, colors, indices,
-    bentEnd, tipB, CLAW_BASE_RADIUS, CLAW_TIP_RADIUS, color, SEGMENTS);
+  emitFrustum(
+    positions, normals, colors, indices,
+    bentEnd, tipA,
+    jitter(rand, CLAW_BASE_RADIUS, 0.1),
+    jitter(rand, CLAW_TIP_RADIUS, 0.15),
+    color, SEGMENTS,
+    { seed: input.seed * 11 + 3, noiseAmplitude: NOISE_AMP },
+  );
+  emitFrustum(
+    positions, normals, colors, indices,
+    bentEnd, tipB,
+    jitter(rand, CLAW_BASE_RADIUS, 0.1),
+    jitter(rand, CLAW_TIP_RADIUS, 0.15),
+    color, SEGMENTS,
+    { seed: input.seed * 13 + 4, noiseAmplitude: NOISE_AMP },
+  );
 
   return {
     mesh: {

--- a/packages/generator/src/tree/variants/forked.ts
+++ b/packages/generator/src/tree/variants/forked.ts
@@ -1,5 +1,11 @@
 import type { VariantGenerateInput, VariantOutput } from '../variant.js';
-import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import {
+  tipAttachPoint,
+  emitFrustum,
+  computeAABB,
+  seededRand,
+  jitter,
+} from '../variant.js';
 import { colorVec3 } from '../../species/_common.js';
 
 const TRUNK_BASE_RADIUS = 0.008;
@@ -9,7 +15,8 @@ const BRANCH_LENGTH = 0.045;
 const BRANCH_BASE_RADIUS = 0.006;
 const BRANCH_TIP_RADIUS = 0.003;
 const BRANCH_ANGLE = Math.PI / 6; // 30°
-const SEGMENTS = 6;
+const SEGMENTS = 10;
+const NOISE_AMP = 0.12;
 
 export function generateForked(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -18,33 +25,54 @@ export function generateForked(input: VariantGenerateInput): VariantOutput {
   const indices: number[] = [];
   const color = colorVec3(input.colorKey);
 
-  // Trunk: frustum from (0,0,0) up to (0, TRUNK_HEIGHT, 0).
+  // Per-piece dimensional jitter: each rolled constant gets ±% of its base
+  // so no two pieces of the same variant look identical.
+  const rand = seededRand(input.seed);
+  const trunkHeight = jitter(rand, TRUNK_HEIGHT, 0.1);
+  const branchLength = jitter(rand, BRANCH_LENGTH, 0.15);
+  const branchAngle = jitter(rand, BRANCH_ANGLE, 0.12);
+  const angleAsymmetry = jitter(rand, 1, 0.15); // branches don't mirror exactly
+  const trunkBaseR = jitter(rand, TRUNK_BASE_RADIUS, 0.1);
+  const trunkTipR = jitter(rand, TRUNK_TIP_RADIUS, 0.1);
+  const branchBaseR = jitter(rand, BRANCH_BASE_RADIUS, 0.1);
+  const branchTipR = jitter(rand, BRANCH_TIP_RADIUS, 0.15);
+
+  // Trunk: frustum from (0,0,0) up to (0, trunkHeight, 0).
   emitFrustum(
     positions, normals, colors, indices,
     { x: 0, y: 0, z: 0 },
-    { x: 0, y: TRUNK_HEIGHT, z: 0 },
-    TRUNK_BASE_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS,
+    { x: 0, y: trunkHeight, z: 0 },
+    trunkBaseR, trunkTipR, color, SEGMENTS,
+    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
   );
 
-  // Two branches: diverging in ±X, each tilted BRANCH_ANGLE from vertical.
+  // Two branches — slightly asymmetric so the Y isn't a mirror.
+  const angleA = branchAngle;
+  const angleB = branchAngle * angleAsymmetry;
   const tipA = {
-    x: Math.sin(BRANCH_ANGLE) * BRANCH_LENGTH,
-    y: TRUNK_HEIGHT + Math.cos(BRANCH_ANGLE) * BRANCH_LENGTH,
+    x: Math.sin(angleA) * branchLength,
+    y: trunkHeight + Math.cos(angleA) * branchLength,
     z: 0,
   };
-  const tipB = { x: -tipA.x, y: tipA.y, z: 0 };
-  const dirA = { x: Math.sin(BRANCH_ANGLE), y: Math.cos(BRANCH_ANGLE), z: 0 };
-  const dirB = { x: -dirA.x, y: dirA.y, z: 0 };
+  const tipB = {
+    x: -Math.sin(angleB) * branchLength,
+    y: trunkHeight + Math.cos(angleB) * branchLength,
+    z: 0,
+  };
+  const dirA = { x: Math.sin(angleA), y: Math.cos(angleA), z: 0 };
+  const dirB = { x: -Math.sin(angleB), y: Math.cos(angleB), z: 0 };
 
   emitFrustum(
     positions, normals, colors, indices,
-    { x: 0, y: TRUNK_HEIGHT, z: 0 }, tipA,
-    BRANCH_BASE_RADIUS, BRANCH_TIP_RADIUS, color, SEGMENTS,
+    { x: 0, y: trunkHeight, z: 0 }, tipA,
+    branchBaseR, branchTipR, color, SEGMENTS,
+    { seed: input.seed * 11 + 2, noiseAmplitude: NOISE_AMP },
   );
   emitFrustum(
     positions, normals, colors, indices,
-    { x: 0, y: TRUNK_HEIGHT, z: 0 }, tipB,
-    BRANCH_BASE_RADIUS, BRANCH_TIP_RADIUS, color, SEGMENTS,
+    { x: 0, y: trunkHeight, z: 0 }, tipB,
+    branchBaseR, branchTipR, color, SEGMENTS,
+    { seed: input.seed * 13 + 3, noiseAmplitude: NOISE_AMP },
   );
 
   return {

--- a/packages/generator/src/tree/variants/starburst.ts
+++ b/packages/generator/src/tree/variants/starburst.ts
@@ -1,15 +1,21 @@
 import type { VariantGenerateInput, VariantOutput } from '../variant.js';
-import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import {
+  tipAttachPoint,
+  emitFrustum,
+  computeAABB,
+  seededRand,
+  jitter,
+} from '../variant.js';
 import { colorVec3 } from '../../species/_common.js';
 
-const HUB_RADIUS = 0.018;                  // dense central mass (~3× a branch radius)
-const HUB_TALL = 0.006;                    // vertical extent of the hub blob
-const TIP_LENGTH = 0.04;                   // how far each tip extends from center
+const HUB_RADIUS = 0.018;
+const HUB_TALL = 0.006;
+const TIP_LENGTH = 0.04;
 const TIP_BASE_RADIUS = 0.006;
 const TIP_TIP_RADIUS = 0.002;
-const TIP_ELEVATION = Math.PI / 4;         // 45° above horizontal
-const TIP_COUNT = 4;
-const SEGMENTS = 8;                         // slightly higher than Trident since hub is prominent
+const TIP_ELEVATION = Math.PI / 4;
+const SEGMENTS = 12; // highest among variants — hub is prominent, close to camera
+const NOISE_AMP = 0.14;
 
 export function generateStarburst(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -18,39 +24,58 @@ export function generateStarburst(input: VariantGenerateInput): VariantOutput {
   const indices: number[] = [];
   const color = colorVec3(input.colorKey);
 
-  // Central spherical mass: approximate with two stacked short frustums for simplicity.
-  // A full UV-sphere would need its own emitter; two fat frustums fused at HUB_TALL/2
-  // read plausibly as a dense blob under the bloom pass.
-  emitFrustum(positions, normals, colors, indices,
+  const rand = seededRand(input.seed);
+  const hubR = jitter(rand, HUB_RADIUS, 0.1);
+  const hubTall = jitter(rand, HUB_TALL, 0.15);
+
+  // Hub: two stacked fat frustums fused at hubTall/2. Each gets its own noise
+  // seed so the blob has irregular surface bumps.
+  emitFrustum(
+    positions, normals, colors, indices,
     { x: 0, y: 0, z: 0 },
-    { x: 0, y: HUB_TALL / 2, z: 0 },
-    HUB_RADIUS * 0.6, HUB_RADIUS, color, SEGMENTS);
-  emitFrustum(positions, normals, colors, indices,
-    { x: 0, y: HUB_TALL / 2, z: 0 },
-    { x: 0, y: HUB_TALL, z: 0 },
-    HUB_RADIUS, HUB_RADIUS * 0.6, color, SEGMENTS);
+    { x: 0, y: hubTall / 2, z: 0 },
+    hubR * 0.6, hubR, color, SEGMENTS,
+    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+  );
+  emitFrustum(
+    positions, normals, colors, indices,
+    { x: 0, y: hubTall / 2, z: 0 },
+    { x: 0, y: hubTall, z: 0 },
+    hubR, hubR * 0.6, color, SEGMENTS,
+    { seed: input.seed * 7 + 2, noiseAmplitude: NOISE_AMP },
+  );
 
-  const hub = { x: 0, y: HUB_TALL / 2, z: 0 };
+  const hub = { x: 0, y: hubTall / 2, z: 0 };
 
-  // 4 tips: +X, +Z, -X, -Z (sweeping counter-clockwise around Y).
+  // 4 tips in cardinal horizontal directions. Each tip gets individual jitter
+  // so the star isn't perfectly symmetric.
   const cardinalAzimuths = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
-  const horizFactor = Math.cos(TIP_ELEVATION); // lateral component
-  const vertFactor = Math.sin(TIP_ELEVATION);  // upward component
-
   const attachPoints = [];
-  for (const az of cardinalAzimuths) {
+  for (let i = 0; i < cardinalAzimuths.length; i++) {
+    const tipLen = jitter(rand, TIP_LENGTH, 0.12);
+    const elevation = jitter(rand, TIP_ELEVATION, 0.1);
+    const tipBaseR = jitter(rand, TIP_BASE_RADIUS, 0.1);
+    const tipTipR = jitter(rand, TIP_TIP_RADIUS, 0.15);
+    const azJitter = (rand() - 0.5) * 0.18; // ±0.09 rad azimuth wander
+
+    const az = cardinalAzimuths[i]! + azJitter;
+    const horizFactor = Math.cos(elevation);
+    const vertFactor = Math.sin(elevation);
     const dir = {
       x: Math.cos(az) * horizFactor,
       y: vertFactor,
       z: Math.sin(az) * horizFactor,
     };
     const tip = {
-      x: hub.x + dir.x * TIP_LENGTH,
-      y: hub.y + dir.y * TIP_LENGTH,
-      z: hub.z + dir.z * TIP_LENGTH,
+      x: hub.x + dir.x * tipLen,
+      y: hub.y + dir.y * tipLen,
+      z: hub.z + dir.z * tipLen,
     };
-    emitFrustum(positions, normals, colors, indices,
-      hub, tip, TIP_BASE_RADIUS, TIP_TIP_RADIUS, color, SEGMENTS);
+    emitFrustum(
+      positions, normals, colors, indices,
+      hub, tip, tipBaseR, tipTipR, color, SEGMENTS,
+      { seed: input.seed * 11 + (i + 1) * 19, noiseAmplitude: NOISE_AMP },
+    );
     attachPoints.push(tipAttachPoint(tip, dir));
   }
 

--- a/packages/generator/src/tree/variants/trident.ts
+++ b/packages/generator/src/tree/variants/trident.ts
@@ -1,5 +1,11 @@
 import type { VariantGenerateInput, VariantOutput } from '../variant.js';
-import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import {
+  tipAttachPoint,
+  emitFrustum,
+  computeAABB,
+  seededRand,
+  jitter,
+} from '../variant.js';
 import { colorVec3 } from '../../species/_common.js';
 
 const TRUNK_BASE_RADIUS = 0.008;
@@ -8,9 +14,10 @@ const TRUNK_HEIGHT = 0.05;
 const SPIKE_LENGTH = 0.05;
 const SPIKE_BASE_RADIUS = 0.0055;
 const SPIKE_TIP_RADIUS = 0.002;
-const SPIKE_TILT_FROM_VERTICAL = Math.PI / 6; // 30° off vertical, toward each spike's azimuth
+const SPIKE_TILT_FROM_VERTICAL = Math.PI / 6;
 const SPIKE_COUNT = 3;
-const SEGMENTS = 6;
+const SEGMENTS = 10;
+const NOISE_AMP = 0.12;
 
 export function generateTrident(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -19,33 +26,47 @@ export function generateTrident(input: VariantGenerateInput): VariantOutput {
   const indices: number[] = [];
   const color = colorVec3(input.colorKey);
 
-  // Short trunk up to the hub.
+  const rand = seededRand(input.seed);
+  const trunkHeight = jitter(rand, TRUNK_HEIGHT, 0.1);
+  const trunkBaseR = jitter(rand, TRUNK_BASE_RADIUS, 0.1);
+  const trunkTipR = jitter(rand, TRUNK_TIP_RADIUS, 0.1);
+
   emitFrustum(
     positions, normals, colors, indices,
     { x: 0, y: 0, z: 0 },
-    { x: 0, y: TRUNK_HEIGHT, z: 0 },
-    TRUNK_BASE_RADIUS, TRUNK_TIP_RADIUS, color, SEGMENTS,
+    { x: 0, y: trunkHeight, z: 0 },
+    trunkBaseR, trunkTipR, color, SEGMENTS,
+    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
   );
 
-  const hub = { x: 0, y: TRUNK_HEIGHT, z: 0 };
+  const hub = { x: 0, y: trunkHeight, z: 0 };
   const attachPoints = [];
   for (let i = 0; i < SPIKE_COUNT; i++) {
-    const az = (i * 2 * Math.PI) / SPIKE_COUNT; // 0°, 120°, 240° (= -120°)
-    const horizFactor = Math.sin(SPIKE_TILT_FROM_VERTICAL);
-    const vertFactor = Math.cos(SPIKE_TILT_FROM_VERTICAL);
+    // Each spike gets its own length/angle jitter so the trident's 3 prongs
+    // have visibly different sizes and tilts.
+    const spikeLength = jitter(rand, SPIKE_LENGTH, 0.12);
+    const spikeTilt = jitter(rand, SPIKE_TILT_FROM_VERTICAL, 0.12);
+    const spikeBaseR = jitter(rand, SPIKE_BASE_RADIUS, 0.1);
+    const spikeTipR = jitter(rand, SPIKE_TIP_RADIUS, 0.15);
+    const azJitter = (rand() - 0.5) * 0.2; // ±0.1 rad azimuth wander
+
+    const az = (i * 2 * Math.PI) / SPIKE_COUNT + azJitter;
+    const horizFactor = Math.sin(spikeTilt);
+    const vertFactor = Math.cos(spikeTilt);
     const dir = {
       x: Math.cos(az) * horizFactor,
       y: vertFactor,
       z: Math.sin(az) * horizFactor,
     };
     const tip = {
-      x: hub.x + dir.x * SPIKE_LENGTH,
-      y: hub.y + dir.y * SPIKE_LENGTH,
-      z: hub.z + dir.z * SPIKE_LENGTH,
+      x: hub.x + dir.x * spikeLength,
+      y: hub.y + dir.y * spikeLength,
+      z: hub.z + dir.z * spikeLength,
     };
     emitFrustum(
       positions, normals, colors, indices,
-      hub, tip, SPIKE_BASE_RADIUS, SPIKE_TIP_RADIUS, color, SEGMENTS,
+      hub, tip, spikeBaseR, spikeTipR, color, SEGMENTS,
+      { seed: input.seed * 11 + (i + 1) * 17, noiseAmplitude: NOISE_AMP },
     );
     attachPoints.push(tipAttachPoint(tip, dir));
   }

--- a/packages/generator/src/tree/variants/wishbone.ts
+++ b/packages/generator/src/tree/variants/wishbone.ts
@@ -1,14 +1,21 @@
 import type { VariantGenerateInput, VariantOutput } from '../variant.js';
-import { tipAttachPoint, emitFrustum, computeAABB } from '../variant.js';
+import {
+  tipAttachPoint,
+  emitFrustum,
+  computeAABB,
+  seededRand,
+  jitter,
+} from '../variant.js';
 import { colorVec3 } from '../../species/_common.js';
 
-const ARM_LENGTH_X = 0.05;      // horizontal distance from center to tip
-const ARM_HEIGHT_Y = 0.035;      // vertical rise of tip above base
-const ARM_CONTROL_Y = 0.05;      // apex of the curve (above the tip)
-const ARM_STEPS = 6;             // segments per arm
+const ARM_LENGTH_X = 0.05;
+const ARM_HEIGHT_Y = 0.035;
+const ARM_CONTROL_Y = 0.05;
+const ARM_STEPS = 6;
 const BASE_RADIUS = 0.0065;
 const TIP_RADIUS = 0.002;
-const SEGMENTS = 6;
+const SEGMENTS = 10;
+const NOISE_AMP = 0.12;
 
 interface Vec3 { x: number; y: number; z: number; }
 
@@ -28,23 +35,33 @@ function emitArm(
   indices: number[],
   color: ReturnType<typeof colorVec3>,
   sign: -1 | 1,
+  armSeed: number,
+  lengthX: number,
+  heightY: number,
+  controlY: number,
+  baseR: number,
+  tipR: number,
 ): { tip: Vec3; tipDir: Vec3 } {
   const p0 = { x: 0, y: 0, z: 0 };
-  const p1 = { x: sign * (ARM_LENGTH_X / 2), y: ARM_CONTROL_Y, z: 0 };
-  const p2 = { x: sign * ARM_LENGTH_X, y: ARM_HEIGHT_Y, z: 0 };
+  const p1 = { x: sign * (lengthX / 2), y: controlY, z: 0 };
+  const p2 = { x: sign * lengthX, y: heightY, z: 0 };
 
   let prev = p0;
   for (let i = 1; i <= ARM_STEPS; i++) {
     const tCurr = i / ARM_STEPS;
     const tPrev = (i - 1) / ARM_STEPS;
     const next = quadBezier(p0, p1, p2, tCurr);
-    const r0 = BASE_RADIUS + (TIP_RADIUS - BASE_RADIUS) * tPrev;
-    const r1 = BASE_RADIUS + (TIP_RADIUS - BASE_RADIUS) * tCurr;
-    emitFrustum(positions, normals, colors, indices, prev, next, r0, r1, color, SEGMENTS);
+    const r0 = baseR + (tipR - baseR) * tPrev;
+    const r1 = baseR + (tipR - baseR) * tCurr;
+    emitFrustum(
+      positions, normals, colors, indices, prev, next, r0, r1, color, SEGMENTS,
+      // Each bezier segment gets its own seed so surface bumps don't align
+      // into stripes along the curve.
+      { seed: armSeed + i * 23, noiseAmplitude: NOISE_AMP },
+    );
     prev = next;
   }
 
-  // Tangent at t=1 is (p2 - p1) * 2; normalize.
   const tipDirRaw = { x: p2.x - p1.x, y: p2.y - p1.y, z: p2.z - p1.z };
   const dLen = Math.hypot(tipDirRaw.x, tipDirRaw.y, tipDirRaw.z) || 1;
   const tipDir = { x: tipDirRaw.x / dLen, y: tipDirRaw.y / dLen, z: tipDirRaw.z / dLen };
@@ -58,8 +75,28 @@ export function generateWishbone(input: VariantGenerateInput): VariantOutput {
   const indices: number[] = [];
   const color = colorVec3(input.colorKey);
 
-  const left = emitArm(positions, normals, colors, indices, color, -1);
-  const right = emitArm(positions, normals, colors, indices, color, +1);
+  const rand = seededRand(input.seed);
+  // Left arm + right arm are independently jittered so the V isn't a mirror.
+  const leftLenX = jitter(rand, ARM_LENGTH_X, 0.12);
+  const leftHeightY = jitter(rand, ARM_HEIGHT_Y, 0.12);
+  const leftControlY = jitter(rand, ARM_CONTROL_Y, 0.15);
+  const leftBaseR = jitter(rand, BASE_RADIUS, 0.1);
+  const leftTipR = jitter(rand, TIP_RADIUS, 0.15);
+
+  const rightLenX = jitter(rand, ARM_LENGTH_X, 0.12);
+  const rightHeightY = jitter(rand, ARM_HEIGHT_Y, 0.12);
+  const rightControlY = jitter(rand, ARM_CONTROL_Y, 0.15);
+  const rightBaseR = jitter(rand, BASE_RADIUS, 0.1);
+  const rightTipR = jitter(rand, TIP_RADIUS, 0.15);
+
+  const left = emitArm(
+    positions, normals, colors, indices, color, -1,
+    input.seed * 7 + 1, leftLenX, leftHeightY, leftControlY, leftBaseR, leftTipR,
+  );
+  const right = emitArm(
+    positions, normals, colors, indices, color, +1,
+    input.seed * 11 + 2, rightLenX, rightHeightY, rightControlY, rightBaseR, rightTipR,
+  );
 
   return {
     mesh: {

--- a/packages/server/src/tree/db.ts
+++ b/packages/server/src/tree/db.ts
@@ -30,6 +30,7 @@ export class TreeDb {
     countLiveChildren: Database.Statement;
     softDelete: Database.Statement;
     hasAny: Database.Statement;
+    softDeleteAll: Database.Statement;
   };
 
   // ReefDb owns the underlying sqlite handle. Share it so migrations run once
@@ -63,7 +64,20 @@ export class TreeDb {
       hasAny: this.db.prepare(
         'SELECT 1 FROM tree_polyps WHERE deleted = 0 LIMIT 1',
       ),
+      softDeleteAll: this.db.prepare(
+        'UPDATE tree_polyps SET deleted = 1 WHERE deleted = 0',
+      ),
     };
+  }
+
+  /**
+   * Soft-delete every live polyp. Used by the reset endpoint so visitors can
+   * wipe the tree and start over. Soft-delete (rather than hard DELETE) keeps
+   * history in the DB; the partial unique index on (parent_id, attach_index)
+   * frees the slots so a fresh root can be inserted immediately after.
+   */
+  deleteAll(): void {
+    this.stmt.softDeleteAll.run();
   }
 
   insertRoot(input: InsertRootInput): PublicTreePolyp {

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -2,12 +2,27 @@ import type { FastifyInstance } from 'fastify';
 import { TreePolypInputSchema } from '@reef/shared';
 import type { Hub } from '../hub.js';
 import type { TreeDb } from './db.js';
+import { seedRootIfEmpty } from './seed.js';
 
 export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub): void {
   app.get('/api/tree', async () => ({
     polyps: tree.listLive(),
     serverTime: Date.now(),
   }));
+
+  // Reset: soft-delete every live polyp, then seed a fresh Starburst root so
+  // the tree never boots into a "no attach point" state. Clients re-fetch
+  // after the call (see packages/client/src/tree/api.ts).
+  app.post('/api/tree/reset', async () => {
+    tree.deleteAll();
+    seedRootIfEmpty(tree);
+    const polyps = tree.listLive();
+    hub.broadcast({ type: 'tree_reset' } as never);
+    if (polyps[0]) {
+      hub.broadcast({ type: 'tree_polyp_added', polyp: polyps[0] } as never);
+    }
+    return { polyps };
+  });
 
   app.post('/api/tree/polyp', async (req, reply) => {
     const parsed = TreePolypInputSchema.safeParse(req.body);

--- a/packages/shared/src/tree/ws.ts
+++ b/packages/shared/src/tree/ws.ts
@@ -3,4 +3,5 @@ import type { PublicTreePolyp } from './types.js';
 export type TreeServerMessage =
   | { type: 'tree_hello'; polypCount: number; serverTime: number }
   | { type: 'tree_polyp_added'; polyp: PublicTreePolyp }
-  | { type: 'tree_polyp_removed'; id: number };
+  | { type: 'tree_polyp_removed'; id: number }
+  | { type: 'tree_reset' };


### PR DESCRIPTION
## Summary

- Replace ad-hoc mutable flag machinery in tree mode with a finite state machine (pure reducer + dep-injected effect runner + thin orchestrator). `tree.ts` goes from 482 → 340 lines. Illegal states become unrepresentable.
- Add 93 reducer tests (Vitest) including an exhaustive 56-cell no-op matrix that verifies every `(state, action)` pair returns identity unless explicitly specified as a transition.
- Carry along visual polish from the prior session: `MeshPhysicalMaterial` (clearcoat + transmission), underwater fog/background/lighting, per-piece dimensional jitter + ridge noise in the generator, sea-life orbit helpers.
- Add support APIs the state machine needs: `TreeReef.clear()`, `TreePlacement.rotateGhost()`, `POST /api/tree/reset`, `tree_reset` WebSocket message.

## Architecture

Three-layer split:

- `packages/client/src/tree/state.ts` — discriminated union `TreeState` (`idle` / `placing` / `submitting` / `resetting`), `TreeAction` union, pure `reduce`. Zero Three.js/DOM imports.
- `packages/client/src/tree/effects.ts` — `createEffects(deps)` factory. Side effects flow: transition → `apply(prev, next, action)` calls `showGhost` / `submitTreePolyp` / `resetTree` / hint updates. Async handlers re-enter the machine via `deps.dispatch`.
- `packages/client/src/tree.ts` — thin orchestrator. Single `state` let, single `dispatch(action)` function, DOM / picker / socket events translate to actions.

Full design rationale: `docs/superpowers/specs/2026-04-22-tree-state-machine-design.md`. Task-by-task plan: `docs/superpowers/plans/2026-04-22-tree-state-machine.md`.

## Commits

Pre-refactor (carried on the branch):
- `d0af025` — initial visual polish pass + sea life scaffolding
- `b956da6` — state-machine design spec
- `fe62240` — 13-task implementation plan

State machine reducer (Tasks 1-7, 93 tests):
- `49fdb99` — state.ts scaffold + no-op reducer (2 tests)
- `b5df5dd` — picker actions (VARIANT_CHOSEN, COLOR_CHOSEN) → 8 tests
- `9d35b5b` — attach selection (ATTACH_CLICKED, REROLL_CLICKED) → 15 tests
- `c23d146` — placement feedback (PLACEMENT_BLOCKED/OK) → 19 tests
- `33d2932` — commit flow (CANCEL, GROW, COMMIT_RESOLVED/REJECTED) → 28 tests
- `e24434d` — reset flow (CLEAR, RESET_*, TREE_RESET_EXTERNAL) → 37 tests
- `71ca0fb` — exhaustive 56-cell no-op matrix → 93 tests

Effect runner (Tasks 8-11):
- `d730549` — createEffects scaffold + EffectsDeps interface
- `834ed63` — placement transitions (showGhost, blocked flip, cancel)
- `6146029` — commit flow (submit POST, resolved, rejected)
- `9c6814d` — reset flow (clear, re-fetch, external reset)

Orchestrator (Task 12) + cleanup:
- `cecfa17` — rewrite tree.ts as thin state-machine orchestrator
- `9bb712a` — drop unused OrbitControls dep from EffectsDeps

Support + visual polish (carried along):
- `992f8f5` — runtime support: `TreeReef.clear()`, `TreePlacement.rotateGhost()`, `/api/tree/reset`, `tree_reset` WS message, toolbar buttons
- `ecbd8d2` — MeshPhysicalMaterial, underwater env, organic variant generation, shark/clownfish orbit params

## Test plan

Automated (all pass on this branch):

- [x] `pnpm -r typecheck` — clean across shared / generator / client / server
- [x] `pnpm -r test` — 422 tests pass total: shared 19, generator 54, client 257 (includes 93 new reducer tests), server 92

Manual browser smoke (to run against a local dev server — `pnpm --filter @reef/server dev` and `pnpm --filter @reef/client dev`, then open `http://localhost:5173/tree.html?api=http://localhost:8787`):

- [ ] Initial load shows seeded root with attach indicators
- [ ] Click attach indicator → ghost appears, Grow/Reroll/Cancel enabled
- [ ] Click Reroll 5× in a row → each produces a new ghost, none disappear
- [ ] Drag on canvas while ghost showing → ghost rotates, camera does not orbit; release → subsequent drags orbit again
- [ ] Click a different indicator → ghost moves to new slot
- [ ] Cancel → ghost disappears
- [ ] Grow → piece committed, indicators refresh
- [ ] Clear → tree wipes, fresh Starburst root re-seeds, indicators refresh
- [ ] Add shark / Add clownfish toolbar → creatures spawn and orbit

## Known trade-offs flagged by cross-cutting review

- Dropped `tree_polyp_added` try/catch race guard. In practice the race is no longer structurally possible (WS echo arrives after HTTP POST resolves, so the state machine is already `idle`). Low risk.
- Dropped `clearBtn.disabled` toggle during `resetting`. Double-click during an in-flight reset is a reducer no-op (`if (state.kind === 'resetting') return state`), so nothing breaks server-side — the button just visually doesn't gray out. Minor UX nit; follow-up if it bothers.
- `VARIANT_CHOSEN` during `submitting` updates the reducer's `picker`/`seed` but fires no effect, so the ghost still shows the old variant until `COMMIT_RESOLVED` (hides it) or `COMMIT_REJECTED` (re-runs `showGhost` with the new variant). Narrow window, but a latent visual inconsistency.

## Deferred follow-ups (intentionally out of scope)

- Multi-branch per attach point (schema migration)
- Persisted drag yaw to server at commit
- Indicator hit-test radius tuning past current bump
- Rejection UI as toast/banner instead of hint text
- Effects-layer unit tests (reset flow's nested try/catch inside `.then` is the hardest branch to reason about)
