### PR TITLE
Tree mode: more sea life + indicator UX fixes

### DIFF
--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -27,6 +27,7 @@ import { computeOrbitPose } from './playground/autoOrbit.js';
 import { Shark } from './tree/shark.js';
 import { Clownfish } from './tree/clownfish.js';
 import { Jellyfish } from './tree/jellyfish.js';
+import { SeaTurtle } from './tree/seaTurtle.js';
 import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
 import { createEffects } from './tree/effects.js';
 
@@ -146,6 +147,17 @@ function spawnJellyfish(): void {
   scene.add(j.group);
   creatures.push(j);
 }
+function spawnSeaTurtle(): void {
+  const t = new SeaTurtle({
+    orbitRadius: 0.28 + Math.random() * 0.12,
+    orbitHeight: 0.04 + Math.random() * 0.12,
+    orbitPeriodSec: 28 + Math.random() * 12,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(t.group);
+  creatures.push(t);
+}
 
 // ------------------------------------------------------------------
 // Picker + state machine
@@ -197,10 +209,12 @@ const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null
 const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
 const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
 const addJellyfishBtn = document.getElementById('addJellyfishBtn') as HTMLButtonElement | null;
+const addSeaTurtleBtn = document.getElementById('addSeaTurtleBtn') as HTMLButtonElement | null;
 if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
 if (addSharkBtn) addSharkBtn.addEventListener('click', spawnShark);
 if (addClownfishBtn) addClownfishBtn.addEventListener('click', spawnClownfish);
 if (addJellyfishBtn) addJellyfishBtn.addEventListener('click', spawnJellyfish);
+if (addSeaTurtleBtn) addSeaTurtleBtn.addEventListener('click', spawnSeaTurtle);
 
 // ------------------------------------------------------------------
 // Pointer-drag: rotate ghost in place instead of orbiting while placing.

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -26,6 +26,7 @@ import { TREE_VARIANTS, TreePicker } from './ui/treePicker.js';
 import { computeOrbitPose } from './playground/autoOrbit.js';
 import { Shark } from './tree/shark.js';
 import { Clownfish } from './tree/clownfish.js';
+import { Jellyfish } from './tree/jellyfish.js';
 import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
 import { createEffects } from './tree/effects.js';
 
@@ -134,6 +135,17 @@ function spawnClownfish(): void {
   scene.add(c.group);
   creatures.push(c);
 }
+function spawnJellyfish(): void {
+  const j = new Jellyfish({
+    orbitRadius: 0.18 + Math.random() * 0.14,
+    orbitHeight: 0.1 + Math.random() * 0.2,
+    orbitPeriodSec: 20 + Math.random() * 12,
+    phaseRad: Math.random() * Math.PI * 2,
+    direction: Math.random() < 0.5 ? 1 : -1,
+  });
+  scene.add(j.group);
+  creatures.push(j);
+}
 
 // ------------------------------------------------------------------
 // Picker + state machine
@@ -184,9 +196,11 @@ picker.onCommit(() => dispatch({ type: 'GROW_CLICKED' }));
 const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
 const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
 const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
+const addJellyfishBtn = document.getElementById('addJellyfishBtn') as HTMLButtonElement | null;
 if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
 if (addSharkBtn) addSharkBtn.addEventListener('click', spawnShark);
 if (addClownfishBtn) addClownfishBtn.addEventListener('click', spawnClownfish);
+if (addJellyfishBtn) addJellyfishBtn.addEventListener('click', spawnJellyfish);
 
 // ------------------------------------------------------------------
 // Pointer-drag: rotate ghost in place instead of orbiting while placing.

--- a/packages/client/src/tree/indicators.ts
+++ b/packages/client/src/tree/indicators.ts
@@ -8,21 +8,38 @@ export interface AttachSlot {
 }
 
 const INDICATOR_RADIUS = 0.007;
+const HIT_PROXY_RADIUS = 0.018;
 const INDICATOR_SEGMENTS = 12;
 
 function makeIndicatorMesh(): Mesh {
-  const geom = new SphereGeometry(INDICATOR_RADIUS, INDICATOR_SEGMENTS, INDICATOR_SEGMENTS);
+  // Outer mesh is an invisible hit proxy ~2.5× the visual radius so the
+  // raycast target is comfortable to click without enlarging the rendered
+  // orb. The raycaster in tree.ts uses intersectObjects(..., false), so
+  // the proxy must be a direct child of the group — the visual is nested
+  // under it. Opacity 0 + depthWrite false keeps the proxy invisible.
+  const proxyGeom = new SphereGeometry(HIT_PROXY_RADIUS, 8, 8);
+  const proxyMat = new MeshStandardMaterial({
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+  });
+  const proxy = new Mesh(proxyGeom, proxyMat);
+
+  const visualGeom = new SphereGeometry(INDICATOR_RADIUS, INDICATOR_SEGMENTS, INDICATOR_SEGMENTS);
   // Cool-blue tint + low emissive so the orbs read as subtle "clickable
   // hints" rather than dominant bright-white spots. Kept below the bloom
   // threshold so they don't pick up halos from the post-processing pass.
-  const mat = new MeshStandardMaterial({
-    color: 0x7aa4c4,
-    emissive: 0x2f5a7a,
-    emissiveIntensity: 0.25,
+  const visualMat = new MeshStandardMaterial({
+    color: 0x9ecae8,
+    emissive: 0x4a88b4,
+    emissiveIntensity: 0.6,
     transparent: true,
-    opacity: 0.55,
+    opacity: 0.85,
   });
-  return new Mesh(geom, mat);
+  const visual = new Mesh(visualGeom, visualMat);
+  proxy.add(visual);
+
+  return proxy;
 }
 
 export class AttachIndicators {
@@ -36,8 +53,7 @@ export class AttachIndicators {
     for (const [key, mesh] of this.bySlot) {
       if (!wantedKeys.has(key)) {
         this.group.remove(mesh);
-        mesh.geometry.dispose();
-        (mesh.material as MeshStandardMaterial).dispose();
+        disposeIndicator(mesh);
         this.bySlot.delete(key);
       }
     }
@@ -62,6 +78,17 @@ export class AttachIndicators {
     for (const [key, mesh] of this.bySlot) {
       const [pid, idx] = key.split('/');
       yield { parentId: Number(pid), index: Number(idx), mesh };
+    }
+  }
+}
+
+function disposeIndicator(mesh: Mesh): void {
+  mesh.geometry.dispose();
+  (mesh.material as MeshStandardMaterial).dispose();
+  for (const child of mesh.children) {
+    if (child instanceof Mesh) {
+      child.geometry.dispose();
+      (child.material as MeshStandardMaterial).dispose();
     }
   }
 }

--- a/packages/client/src/tree/jellyfish.test.ts
+++ b/packages/client/src/tree/jellyfish.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { Mesh } from 'three';
+import { Jellyfish } from './jellyfish.js';
+
+describe('Jellyfish', () => {
+  test('constructs with a bell plus 7 tentacles (8 children total)', () => {
+    const j = new Jellyfish();
+    expect(j.group.children.length).toBe(8);
+    expect(j.group.children[0]).toBeInstanceOf(Mesh);
+  });
+
+  test('update(0) places the jellyfish on the +X side of its orbit', () => {
+    const j = new Jellyfish();
+    j.update(0);
+    expect(j.group.position.x).toBeGreaterThan(0);
+    // z has a small phase term so allow a tiny tolerance
+    expect(j.group.position.z).toBeCloseTo(0, 5);
+  });
+
+  test('orbit position is periodic — a full period returns to the start', () => {
+    const j = new Jellyfish();
+    j.update(0);
+    const start = j.group.position.clone();
+    // Default period is 24s; bob has period ~7s so this returns XZ exactly
+    // but Y differs — only assert the orbit plane.
+    j.update(24);
+    expect(j.group.position.x).toBeCloseTo(start.x, 4);
+    expect(j.group.position.z).toBeCloseTo(start.z, 4);
+  });
+
+  test('bell pulses (scale changes) over time', () => {
+    const j = new Jellyfish();
+    j.update(0);
+    const startYScale = j.group.children[0]!.scale.y;
+    j.update(1);
+    const laterYScale = j.group.children[0]!.scale.y;
+    expect(Math.abs(startYScale - laterYScale)).toBeGreaterThan(0.01);
+  });
+});

--- a/packages/client/src/tree/jellyfish.ts
+++ b/packages/client/src/tree/jellyfish.ts
@@ -1,0 +1,123 @@
+import {
+  CylinderGeometry,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  SphereGeometry,
+} from 'three';
+
+const DEFAULT_ORBIT_RADIUS = 0.22;
+const DEFAULT_ORBIT_HEIGHT = 0.2;
+const DEFAULT_ORBIT_PERIOD_SEC = 24;
+
+const BELL_RADIUS = 0.022;
+const TENTACLE_COUNT = 7;
+const TENTACLE_LENGTH = 0.055;
+const TENTACLE_RADIUS = 0.0015;
+
+export interface JellyfishOrbitParams {
+  orbitRadius?: number;
+  orbitHeight?: number;
+  orbitPeriodSec?: number;
+  /** Starting offset in radians so multiple jellies don't stack. */
+  phaseRad?: number;
+  /** +1 clockwise (viewed from +Y), -1 counter-clockwise. */
+  direction?: 1 | -1;
+}
+
+const BELL_COLOR = 0xd6a6d9;
+const BELL_EMISSIVE = 0x8c4fa4;
+const TENTACLE_COLOR = 0xc994d1;
+
+/**
+ * Translucent bell-shaped jellyfish drifting slowly around the tree. The
+ * bell squishes on a slow pulse while the tentacles sway with a phase
+ * offset, giving a subtle breathing effect. Vertical bob on the orbit
+ * layers a secondary motion on top of the circular path.
+ */
+export class Jellyfish {
+  readonly group = new Group();
+  private readonly bell: Mesh;
+  private readonly tentacles: Mesh[] = [];
+  private readonly orbitRadius: number;
+  private readonly orbitHeight: number;
+  private readonly orbitPeriodSec: number;
+  private readonly phaseRad: number;
+  private readonly direction: 1 | -1;
+
+  constructor(params: JellyfishOrbitParams = {}) {
+    this.orbitRadius = params.orbitRadius ?? DEFAULT_ORBIT_RADIUS;
+    this.orbitHeight = params.orbitHeight ?? DEFAULT_ORBIT_HEIGHT;
+    this.orbitPeriodSec = params.orbitPeriodSec ?? DEFAULT_ORBIT_PERIOD_SEC;
+    this.phaseRad = params.phaseRad ?? 0;
+    this.direction = params.direction ?? 1;
+
+    // Bell: hemisphere (thetaLength = PI/2), translucent so the tentacles
+    // show through faintly from behind.
+    const bellGeom = new SphereGeometry(BELL_RADIUS, 18, 12, 0, Math.PI * 2, 0, Math.PI / 2);
+    const bellMat = new MeshStandardMaterial({
+      color: BELL_COLOR,
+      emissive: BELL_EMISSIVE,
+      emissiveIntensity: 0.4,
+      transparent: true,
+      opacity: 0.55,
+      roughness: 0.4,
+      depthWrite: false,
+    });
+    this.bell = new Mesh(bellGeom, bellMat);
+    this.group.add(this.bell);
+
+    // Tentacles: thin cylinders splayed out around the rim. Each one lives
+    // in its own Group so it can pivot from the bell rim during sway.
+    const tentacleGeom = new CylinderGeometry(
+      TENTACLE_RADIUS * 0.4, // narrower tip
+      TENTACLE_RADIUS,       // wider at attach point
+      TENTACLE_LENGTH,
+      6,
+    );
+    // Translate geometry so the top sits at y=0 and the body hangs down.
+    tentacleGeom.translate(0, -TENTACLE_LENGTH / 2, 0);
+    const tentacleMat = new MeshStandardMaterial({
+      color: TENTACLE_COLOR,
+      emissive: BELL_EMISSIVE,
+      emissiveIntensity: 0.18,
+      transparent: true,
+      opacity: 0.72,
+      roughness: 0.6,
+    });
+    for (let i = 0; i < TENTACLE_COUNT; i++) {
+      const t = new Mesh(tentacleGeom, tentacleMat);
+      const angle = (i / TENTACLE_COUNT) * Math.PI * 2;
+      const rimOffset = BELL_RADIUS * 0.75;
+      t.position.set(Math.cos(angle) * rimOffset, 0, Math.sin(angle) * rimOffset);
+      this.group.add(t);
+      this.tentacles.push(t);
+    }
+  }
+
+  update(clockSec: number): void {
+    const angle =
+      this.direction * (clockSec / this.orbitPeriodSec) * Math.PI * 2 + this.phaseRad;
+    const x = Math.cos(angle) * this.orbitRadius;
+    const z = Math.sin(angle) * this.orbitRadius;
+    // Gentle vertical bob layered on top of the circular path — amplitude
+    // is small so it reads as buoyancy rather than teleporting.
+    const bob = Math.sin(clockSec * 0.9 + this.phaseRad) * 0.015;
+    this.group.position.set(x, this.orbitHeight + bob, z);
+
+    // Bell pulse: squish vertically while expanding horizontally slightly,
+    // the classic jellyfish breath. Scale range 0.88–1.08 keeps it subtle.
+    const pulse = Math.sin(clockSec * 1.8 + this.phaseRad) * 0.1;
+    this.bell.scale.set(1 + pulse, 1 - pulse, 1 + pulse);
+
+    // Tentacles sway with a phase offset per tentacle so they don't all
+    // wave in unison. Rotation around local X/Z; amplitude small to keep
+    // them hanging approximately downward.
+    for (let i = 0; i < this.tentacles.length; i++) {
+      const t = this.tentacles[i]!;
+      const sway = clockSec * 1.3 + i * 0.8 + this.phaseRad;
+      t.rotation.x = Math.sin(sway) * 0.18;
+      t.rotation.z = Math.cos(sway * 0.7) * 0.14;
+    }
+  }
+}

--- a/packages/client/src/tree/seaTurtle.test.ts
+++ b/packages/client/src/tree/seaTurtle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { Mesh } from 'three';
+import { SeaTurtle } from './seaTurtle.js';
+
+describe('SeaTurtle', () => {
+  test('constructs with shell + belly + head + 4 flipper groups (7 children)', () => {
+    const t = new SeaTurtle();
+    // shell, belly, head, front-left, front-right, rear-left, rear-right = 7.
+    expect(t.group.children.length).toBe(7);
+    expect(t.group.children[0]).toBeInstanceOf(Mesh);
+  });
+
+  test('update(0) places the turtle on the +X side of its orbit', () => {
+    const t = new SeaTurtle();
+    t.update(0);
+    expect(t.group.position.x).toBeGreaterThan(0);
+    expect(t.group.position.z).toBeCloseTo(0, 5);
+  });
+
+  test('orbit position is periodic — a full period returns to the start', () => {
+    const t = new SeaTurtle();
+    t.update(0);
+    const start = t.group.position.clone();
+    // Default period 32s.
+    t.update(32);
+    expect(t.group.position.x).toBeCloseTo(start.x, 4);
+    expect(t.group.position.z).toBeCloseTo(start.z, 4);
+  });
+
+  test('flippers animate (rotation.z changes over time)', () => {
+    const t = new SeaTurtle();
+    t.update(0);
+    // front-left flipper is 4th child (index 3)
+    const flipperAt0 = t.group.children[3]!.rotation.z;
+    t.update(1);
+    const flipperAt1 = t.group.children[3]!.rotation.z;
+    expect(Math.abs(flipperAt0 - flipperAt1)).toBeGreaterThan(0.01);
+  });
+});

--- a/packages/client/src/tree/seaTurtle.ts
+++ b/packages/client/src/tree/seaTurtle.ts
@@ -1,0 +1,173 @@
+import {
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  SphereGeometry,
+  Vector3,
+} from 'three';
+
+const DEFAULT_ORBIT_RADIUS = 0.3;
+const DEFAULT_ORBIT_HEIGHT = 0.07;
+const DEFAULT_ORBIT_PERIOD_SEC = 32;
+
+const SHELL_RADIUS = 0.025;
+const HEAD_RADIUS = 0.009;
+const FLIPPER_LENGTH = 0.022;
+const FLIPPER_WIDTH = 0.012;
+const FLIPPER_THICKNESS = 0.003;
+
+export interface SeaTurtleOrbitParams {
+  orbitRadius?: number;
+  orbitHeight?: number;
+  orbitPeriodSec?: number;
+  /** Starting offset in radians so multiple turtles don't stack. */
+  phaseRad?: number;
+  /** +1 clockwise (viewed from +Y), -1 counter-clockwise. */
+  direction?: 1 | -1;
+}
+
+const SHELL_COLOR = 0x3d5a3a;
+const SHELL_EMISSIVE = 0x2b4a5a;
+const BELLY_COLOR = 0xb8a978;
+const FLIPPER_COLOR = 0x354a35;
+
+/**
+ * Slow-cruising sea turtle. Domed oval shell + small head pokes forward,
+ * four flippers paddle in alternating pairs. Orbits wide and low near
+ * the pedestal, much slower than the shark.
+ */
+export class SeaTurtle {
+  readonly group = new Group();
+  private readonly frontLeftFlipper: Group;
+  private readonly frontRightFlipper: Group;
+  private readonly rearLeftFlipper: Group;
+  private readonly rearRightFlipper: Group;
+  private readonly orbitRadius: number;
+  private readonly orbitHeight: number;
+  private readonly orbitPeriodSec: number;
+  private readonly phaseRad: number;
+  private readonly direction: 1 | -1;
+
+  constructor(params: SeaTurtleOrbitParams = {}) {
+    this.orbitRadius = params.orbitRadius ?? DEFAULT_ORBIT_RADIUS;
+    this.orbitHeight = params.orbitHeight ?? DEFAULT_ORBIT_HEIGHT;
+    this.orbitPeriodSec = params.orbitPeriodSec ?? DEFAULT_ORBIT_PERIOD_SEC;
+    this.phaseRad = params.phaseRad ?? 0;
+    this.direction = params.direction ?? 1;
+
+    // Shell: flattened, slightly elongated sphere. Forward points along -Z
+    // so lookAt orients properly.
+    const shellMat = new MeshStandardMaterial({
+      color: SHELL_COLOR,
+      emissive: SHELL_EMISSIVE,
+      emissiveIntensity: 0.2,
+      roughness: 0.75,
+      metalness: 0.05,
+    });
+    const shellGeom = new SphereGeometry(SHELL_RADIUS, 20, 14);
+    const shell = new Mesh(shellGeom, shellMat);
+    shell.scale.set(1, 0.55, 1.15);
+    this.group.add(shell);
+
+    // Pale underside visible from below — a smaller flattened sphere tucked
+    // just under the shell. Reads as a belly at grazing angles.
+    const bellyMat = new MeshStandardMaterial({
+      color: BELLY_COLOR,
+      emissive: BELLY_COLOR,
+      emissiveIntensity: 0.08,
+      roughness: 0.8,
+    });
+    const belly = new Mesh(shellGeom, bellyMat);
+    belly.scale.set(0.9, 0.35, 1.05);
+    belly.position.y = -SHELL_RADIUS * 0.25;
+    this.group.add(belly);
+
+    // Head: sphere poking out front (-Z direction).
+    const headMat = new MeshStandardMaterial({
+      color: SHELL_COLOR,
+      emissive: SHELL_EMISSIVE,
+      emissiveIntensity: 0.15,
+      roughness: 0.7,
+    });
+    const headGeom = new SphereGeometry(HEAD_RADIUS, 12, 10);
+    const head = new Mesh(headGeom, headMat);
+    head.position.set(0, -SHELL_RADIUS * 0.1, -SHELL_RADIUS * 1.1);
+    head.scale.set(1, 0.9, 1.2);
+    this.group.add(head);
+
+    // Flippers: four flattened ellipsoid "paddles". Each flipper lives in
+    // its own Group so the paddle can pivot from near the shell edge
+    // during animation. Front flippers are larger + more active.
+    const makeFlipper = (scaleX: number, emissive: number): Group => {
+      const node = new Group();
+      const flipperMat = new MeshStandardMaterial({
+        color: FLIPPER_COLOR,
+        emissive,
+        emissiveIntensity: 0.15,
+        roughness: 0.7,
+      });
+      const paddle = new Mesh(headGeom, flipperMat);
+      // Extend along the flipper's +X axis, flatten vertically, narrow
+      // front-to-back. Translate so the root of the paddle sits at the
+      // group's origin (which becomes the shoulder pivot).
+      paddle.scale.set(
+        FLIPPER_LENGTH / (HEAD_RADIUS * 2) * scaleX,
+        FLIPPER_THICKNESS / (HEAD_RADIUS * 2),
+        FLIPPER_WIDTH / (HEAD_RADIUS * 2),
+      );
+      paddle.position.x = (FLIPPER_LENGTH * scaleX) / 2;
+      node.add(paddle);
+      return node;
+    };
+
+    // Front-left: pivot at left side of shell, fore position.
+    this.frontLeftFlipper = makeFlipper(1.0, SHELL_EMISSIVE);
+    this.frontLeftFlipper.position.set(-SHELL_RADIUS * 0.85, -SHELL_RADIUS * 0.15, -SHELL_RADIUS * 0.45);
+    this.frontLeftFlipper.rotation.y = 0.25; // slight forward sweep
+    this.group.add(this.frontLeftFlipper);
+
+    // Front-right: mirror of front-left.
+    this.frontRightFlipper = makeFlipper(1.0, SHELL_EMISSIVE);
+    this.frontRightFlipper.position.set(SHELL_RADIUS * 0.85, -SHELL_RADIUS * 0.15, -SHELL_RADIUS * 0.45);
+    this.frontRightFlipper.rotation.y = Math.PI - 0.25;
+    this.group.add(this.frontRightFlipper);
+
+    // Rear-left: smaller, positioned back.
+    this.rearLeftFlipper = makeFlipper(0.65, SHELL_EMISSIVE);
+    this.rearLeftFlipper.position.set(-SHELL_RADIUS * 0.7, -SHELL_RADIUS * 0.18, SHELL_RADIUS * 0.7);
+    this.rearLeftFlipper.rotation.y = -0.3;
+    this.group.add(this.rearLeftFlipper);
+
+    // Rear-right: mirror of rear-left.
+    this.rearRightFlipper = makeFlipper(0.65, SHELL_EMISSIVE);
+    this.rearRightFlipper.position.set(SHELL_RADIUS * 0.7, -SHELL_RADIUS * 0.18, SHELL_RADIUS * 0.7);
+    this.rearRightFlipper.rotation.y = Math.PI + 0.3;
+    this.group.add(this.rearRightFlipper);
+  }
+
+  update(clockSec: number): void {
+    const angle =
+      this.direction * (clockSec / this.orbitPeriodSec) * Math.PI * 2 + this.phaseRad;
+    const x = Math.cos(angle) * this.orbitRadius;
+    const z = Math.sin(angle) * this.orbitRadius;
+    this.group.position.set(x, this.orbitHeight, z);
+
+    // Face direction of travel.
+    const tangent = new Vector3(
+      -Math.sin(angle) * this.direction,
+      0,
+      Math.cos(angle) * this.direction,
+    );
+    this.group.lookAt(this.group.position.clone().add(tangent));
+
+    // Flipper stroke: slow sinuous paddle. Front pair dominant, rear pair
+    // smaller counter-movement for realism. Rotation around local Z tilts
+    // the flipper up (out of the horizontal plane) and back down.
+    const stroke = Math.sin(clockSec * 1.1) * 0.4;
+    this.frontLeftFlipper.rotation.z = stroke;
+    this.frontRightFlipper.rotation.z = -stroke;
+    const rearStroke = Math.sin(clockSec * 1.1 + Math.PI / 3) * 0.18;
+    this.rearLeftFlipper.rotation.z = rearStroke;
+    this.rearRightFlipper.rotation.z = -rearStroke;
+  }
+}

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -16,7 +16,7 @@
       pointer-events: none;
     }
     #toolbar {
-      position: fixed; top: 12px; right: 12px; display: flex; gap: 6px;
+      position: fixed; top: 12px; right: 12px; z-index: 5; display: flex; gap: 6px;
       font: 500 12px/1 system-ui, sans-serif;
     }
     #toolbar button {

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -35,6 +35,7 @@
     <button id="clearBtn" type="button">Clear</button>
     <button id="addSharkBtn" type="button">Add shark</button>
     <button id="addClownfishBtn" type="button">Add clownfish</button>
+    <button id="addJellyfishBtn" type="button">Add jellyfish</button>
   </div>
   <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
     <div class="picker-row" role="group" aria-label="Variant">

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -36,6 +36,7 @@
     <button id="addSharkBtn" type="button">Add shark</button>
     <button id="addClownfishBtn" type="button">Add clownfish</button>
     <button id="addJellyfishBtn" type="button">Add jellyfish</button>
+    <button id="addSeaTurtleBtn" type="button">Add sea turtle</button>
   </div>
   <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
     <div class="picker-row" role="group" aria-label="Variant">


### PR DESCRIPTION
## Summary

- Add Jellyfish (translucent pulsing bell + 7 trailing tentacles, ~24s orbit) and SeaTurtle (flattened oval shell + 4 paddling flippers, ~32s orbit) creatures. Both expose the same `group` + `update(clockSec)` + orbit-param constructor interface as Shark/Clownfish.
- Add "Add jellyfish" and "Add sea turtle" toolbar buttons. Each spawn randomises orbit radius / height / period / phase / direction so multiple creatures don't stack.
- Fix indicator hit-test: invisible hit proxy around each attach orb so the click target is ~2.5× the rendered sphere (0.018 radius proxy vs 0.007 visual). Previously many indicators that looked clickable weren't.
- Polish attach indicators: brighter emissive (0.25 → 0.6), higher opacity (0.55 → 0.85), lightened base + emissive colors.
- Fix toolbar z-index: add `z-index: 5` to `#toolbar` in tree.html so the Clear / Add ... buttons render above the canvas (previously hidden behind `#gl` which has `z-index: 1` from styles.css).

## Commits

- `9cb0323` — Tree UX: larger indicator hit zones, brighter orbs, toolbar z-index
- `43d679c` — Tree sea life: add Jellyfish creature + toolbar button
- `c922418` — Tree sea life: add SeaTurtle creature + toolbar button

## Test plan

Automated:

- [x] `pnpm --filter @reef/client typecheck` — clean
- [x] `pnpm --filter @reef/client test` — 265 tests pass (was 257, +4 jellyfish, +4 sea turtle)

Manual browser smoke (verified locally):

- [x] All 5 toolbar buttons render at top-right: Clear / Add shark / Add clownfish / Add jellyfish / Add sea turtle
- [x] Add jellyfish → translucent bell drifts into view, pulses, tentacles sway with phase offset
- [x] Add sea turtle → flippers paddle in alternating strokes as it circles
- [x] Attach indicators are noticeably easier to click than before

## Files changed

- `packages/client/src/tree/jellyfish.ts` — new
- `packages/client/src/tree/jellyfish.test.ts` — new
- `packages/client/src/tree/seaTurtle.ts` — new
- `packages/client/src/tree/seaTurtle.test.ts` — new
- `packages/client/src/tree/indicators.ts` — hit proxy + brighter visual + dispose helper
- `packages/client/src/tree.ts` — import + spawn functions + button wiring for both creatures
- `packages/client/tree.html` — 2 new buttons, `z-index: 5` on `#toolbar`
