### PR TITLE
Tree mode: undo last branch + mobile-first sea-life panel

### DIFF
--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -336,9 +336,20 @@ socket.on((msg) => {
     treeReef.addPiece(msg.polyp);
     installEffectsOnNewPieces();
     attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+    // If someone built on top of our last commit, we can no longer undo it
+    // (the server enforces leaf-only deletes). Invalidate lastCommittedId.
+    if (
+      state.kind !== 'undoing' &&
+      'lastCommittedId' in state &&
+      state.lastCommittedId !== null &&
+      msg.polyp.parentId === state.lastCommittedId
+    ) {
+      dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
+    }
   } else if (msg.type === 'tree_polyp_removed') {
     treeReef.removePiece(msg.id);
     attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+    dispatch({ type: 'TREE_POLYP_REMOVED_EXTERNAL', id: msg.id });
   } else if (msg.type === 'tree_reset') {
     treeReef.clear();
     attachIndicators.refresh([]);

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -210,7 +210,10 @@ let state: TreeState = initialState(picker.get());
 function dispatch(action: TreeAction): void {
   const prev = state;
   state = reduce(state, action);
-  if (state !== prev) effects.apply(prev, state, action);
+  if (state !== prev) {
+    effects.apply(prev, state, action);
+    refreshUndoBtn();
+  }
 }
 
 // Wire picker → dispatch.
@@ -238,15 +241,83 @@ picker.onCommit(() => dispatch({ type: 'GROW_CLICKED' }));
 // Toolbar → dispatch / direct spawn
 // ------------------------------------------------------------------
 const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
+const undoBtn = document.getElementById('undoBtn') as HTMLButtonElement | null;
+const seaLifeBtn = document.getElementById('seaLifeBtn') as HTMLButtonElement | null;
+const seaLifePanel = document.getElementById('sea-life-panel') as HTMLElement | null;
+const seaLifeCloseBtn = document.getElementById('sea-life-close-btn') as HTMLButtonElement | null;
+
 const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
+const removeSharkBtn = document.getElementById('removeSharkBtn') as HTMLButtonElement | null;
 const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
+const removeClownfishBtn = document.getElementById('removeClownfishBtn') as HTMLButtonElement | null;
 const addJellyfishBtn = document.getElementById('addJellyfishBtn') as HTMLButtonElement | null;
+const removeJellyfishBtn = document.getElementById('removeJellyfishBtn') as HTMLButtonElement | null;
 const addSeaTurtleBtn = document.getElementById('addSeaTurtleBtn') as HTMLButtonElement | null;
+const removeSeaTurtleBtn = document.getElementById('removeSeaTurtleBtn') as HTMLButtonElement | null;
+
 if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
-if (addSharkBtn) addSharkBtn.addEventListener('click', spawnShark);
-if (addClownfishBtn) addClownfishBtn.addEventListener('click', spawnClownfish);
-if (addJellyfishBtn) addJellyfishBtn.addEventListener('click', spawnJellyfish);
-if (addSeaTurtleBtn) addSeaTurtleBtn.addEventListener('click', spawnSeaTurtle);
+if (undoBtn) undoBtn.addEventListener('click', () => dispatch({ type: 'UNDO_CLICKED' }));
+
+// Sea life panel toggle
+function setPanelOpen(open: boolean): void {
+  if (!seaLifePanel || !seaLifeBtn) return;
+  if (open) {
+    seaLifePanel.classList.add('open');
+    seaLifeBtn.setAttribute('aria-expanded', 'true');
+    seaLifeBtn.setAttribute('aria-pressed', 'true');
+  } else {
+    seaLifePanel.classList.remove('open');
+    seaLifeBtn.setAttribute('aria-expanded', 'false');
+    seaLifeBtn.removeAttribute('aria-pressed');
+  }
+}
+if (seaLifeBtn) seaLifeBtn.addEventListener('click', () => {
+  const isOpen = seaLifePanel?.classList.contains('open') ?? false;
+  setPanelOpen(!isOpen);
+});
+if (seaLifeCloseBtn) seaLifeCloseBtn.addEventListener('click', () => setPanelOpen(false));
+
+// Close panel on Escape or click-outside
+document.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Escape') setPanelOpen(false);
+});
+document.addEventListener('click', (ev) => {
+  if (!seaLifePanel?.classList.contains('open')) return;
+  const target = ev.target as Node;
+  if (!seaLifePanel.contains(target) && target !== seaLifeBtn && !seaLifeBtn?.contains(target)) {
+    setPanelOpen(false);
+  }
+});
+
+// Panel creature counts — call after every spawn/remove
+function refreshPanel(): void {
+  const types: CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
+  const ids: Record<CreatureType, string> = {
+    shark: 'shark', clownfish: 'clownfish', jellyfish: 'jellyfish', seaTurtle: 'seaTurtle',
+  };
+  for (const type of types) {
+    const n = countCreatures(type);
+    const countEl = document.getElementById(`count-${ids[type]}`);
+    if (countEl) countEl.textContent = String(n);
+    const removeBtn = document.getElementById(`remove${type.charAt(0).toUpperCase()}${type.slice(1)}Btn`) as HTMLButtonElement | null;
+    if (removeBtn) removeBtn.disabled = n === 0;
+  }
+}
+
+if (addSharkBtn) addSharkBtn.addEventListener('click', () => { spawnShark(); refreshPanel(); });
+if (removeSharkBtn) removeSharkBtn.addEventListener('click', () => { removeCreature('shark'); refreshPanel(); });
+if (addClownfishBtn) addClownfishBtn.addEventListener('click', () => { spawnClownfish(); refreshPanel(); });
+if (removeClownfishBtn) removeClownfishBtn.addEventListener('click', () => { removeCreature('clownfish'); refreshPanel(); });
+if (addJellyfishBtn) addJellyfishBtn.addEventListener('click', () => { spawnJellyfish(); refreshPanel(); });
+if (removeJellyfishBtn) removeJellyfishBtn.addEventListener('click', () => { removeCreature('jellyfish'); refreshPanel(); });
+if (addSeaTurtleBtn) addSeaTurtleBtn.addEventListener('click', () => { spawnSeaTurtle(); refreshPanel(); });
+if (removeSeaTurtleBtn) removeSeaTurtleBtn.addEventListener('click', () => { removeCreature('seaTurtle'); refreshPanel(); });
+
+// Undo button enabled/disabled: update after every dispatch
+function refreshUndoBtn(): void {
+  if (!undoBtn) return;
+  undoBtn.disabled = !(state.kind === 'idle' && state.lastCommittedId !== null);
+}
 
 // ------------------------------------------------------------------
 // Pointer-drag: rotate ghost in place instead of orbiting while placing.

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -112,8 +112,40 @@ function addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
 // ------------------------------------------------------------------
 // Spawnable sea life — empty by default.
 // ------------------------------------------------------------------
+type CreatureType = 'shark' | 'clownfish' | 'jellyfish' | 'seaTurtle';
 interface SwimmingCreature { update: (clockSec: number) => void; }
-const creatures: SwimmingCreature[] = [];
+interface TrackedCreature {
+  type: CreatureType;
+  instance: SwimmingCreature;
+  group: import('three').Group;
+}
+const creatures: TrackedCreature[] = [];
+
+function removeCreature(type: CreatureType): boolean {
+  const idx = [...creatures].map((c, i) => ({ c, i })).reverse()
+    .find(({ c }) => c.type === type)?.i ?? -1;
+  if (idx === -1) return false;
+  const [removed] = creatures.splice(idx, 1);
+  if (!removed) return false;
+  scene.remove(removed.group);
+  removed.group.traverse((obj) => {
+    const mesh = obj as import('three').Mesh;
+    if (mesh.isMesh) {
+      mesh.geometry?.dispose();
+      if (Array.isArray(mesh.material)) {
+        for (const m of mesh.material) (m as import('three').Material).dispose();
+      } else {
+        (mesh.material as import('three').Material | undefined)?.dispose();
+      }
+    }
+  });
+  return true;
+}
+
+function countCreatures(type: CreatureType): number {
+  return creatures.filter((c) => c.type === type).length;
+}
+
 function spawnShark(): void {
   const s = new Shark({
     orbitRadius: 0.25 + Math.random() * 0.15,
@@ -123,7 +155,7 @@ function spawnShark(): void {
     direction: Math.random() < 0.5 ? 1 : -1,
   });
   scene.add(s.group);
-  creatures.push(s);
+  creatures.push({ type: 'shark', instance: s, group: s.group });
 }
 function spawnClownfish(): void {
   const c = new Clownfish({
@@ -134,7 +166,7 @@ function spawnClownfish(): void {
     direction: Math.random() < 0.5 ? 1 : -1,
   });
   scene.add(c.group);
-  creatures.push(c);
+  creatures.push({ type: 'clownfish', instance: c, group: c.group });
 }
 function spawnJellyfish(): void {
   const j = new Jellyfish({
@@ -145,7 +177,7 @@ function spawnJellyfish(): void {
     direction: Math.random() < 0.5 ? 1 : -1,
   });
   scene.add(j.group);
-  creatures.push(j);
+  creatures.push({ type: 'jellyfish', instance: j, group: j.group });
 }
 function spawnSeaTurtle(): void {
   const t = new SeaTurtle({
@@ -156,7 +188,7 @@ function spawnSeaTurtle(): void {
     direction: Math.random() < 0.5 ? 1 : -1,
   });
   scene.add(t.group);
-  creatures.push(t);
+  creatures.push({ type: 'seaTurtle', instance: t, group: t.group });
 }
 
 // ------------------------------------------------------------------
@@ -364,7 +396,7 @@ socket.connect();
 function loop(t: number): void {
   const tSec = t / 1000;
   swayClock.value = tSec;
-  for (const c of creatures) c.update(tSec);
+  for (const c of creatures) c.instance.update(tSec);
 
   if (config.mode === 'screen') {
     const pose = computeOrbitPose(tSec);

--- a/packages/client/src/tree/api.ts
+++ b/packages/client/src/tree/api.ts
@@ -28,6 +28,14 @@ export async function resetTree(apiBase = ''): Promise<{ polyps: PublicTreePolyp
   return r.json() as Promise<{ polyps: PublicTreePolyp[] }>;
 }
 
+export async function deleteTreePolyp(id: number, apiBase = ''): Promise<void> {
+  const r = await fetch(`${apiBase}/api/tree/polyp/${id}`, { method: 'DELETE' });
+  if (!r.ok) {
+    const detail = await r.text().catch(() => '');
+    throw new Error(`deleteTreePolyp ${r.status}${detail ? ` ${detail}` : ''}`);
+  }
+}
+
 /**
  * Reconnecting WebSocket with exponential backoff. Capped at 30s between
  * tries. Fires every server message to each registered handler.

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -4,7 +4,7 @@ import type { TreePlacement } from './placement.js';
 import type { AttachIndicators } from './indicators.js';
 import type { TreePicker } from '../ui/treePicker.js';
 import type { TreeState, TreeAction } from './state.js';
-import { fetchTree, resetTree, submitTreePolyp } from './api.js';
+import { fetchTree, resetTree, submitTreePolyp, deleteTreePolyp } from './api.js';
 
 export interface EffectsDeps {
   placement: TreePlacement;
@@ -94,7 +94,7 @@ export function createEffects(deps: EffectsDeps): Effects {
           },
           deps.apiBase,
         ).then(
-          () => deps.dispatch({ type: 'COMMIT_RESOLVED' }),
+          (polyp) => deps.dispatch({ type: 'COMMIT_RESOLVED', polypId: polyp.id }),
           (err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             deps.hintEl.textContent = `Grow failed: ${msg}`;
@@ -125,6 +125,31 @@ export function createEffects(deps: EffectsDeps): Effects {
         action.type === 'COMMIT_REJECTED'
       ) {
         deps.picker.setSubmitting(false);
+        return;
+      }
+
+      // Undo clicked: idle → undoing. Fire DELETE and wire resolution.
+      if (prev.kind === 'idle' && next.kind === 'undoing') {
+        deps.hintEl.textContent = 'Undoing…';
+        deleteTreePolyp(next.polypId, deps.apiBase).then(
+          () => deps.dispatch({ type: 'UNDO_RESOLVED' }),
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            deps.hintEl.textContent = `Undo failed: ${msg}`;
+            deps.dispatch({ type: 'UNDO_REJECTED', error: msg });
+          },
+        );
+        return;
+      }
+
+      // Undo resolved: undoing → idle. Show success hint.
+      if (prev.kind === 'undoing' && next.kind === 'idle' && action.type === 'UNDO_RESOLVED') {
+        deps.hintEl.textContent = 'Undone. Click a glowing dot to plant again.';
+        return;
+      }
+
+      // Undo rejected: undoing → idle. Error hint already set by reject callback.
+      if (prev.kind === 'undoing' && next.kind === 'idle' && action.type === 'UNDO_REJECTED') {
         return;
       }
 

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'vitest';
 import { initialState, reduce, type TreeAction, type TreeState } from './state.js';
 
+const idlePicker = { variant: 'forked', colorKey: 'neon-cyan' } as const;
+
 describe('initialState', () => {
   test('returns idle with the provided picker selection', () => {
     const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
     expect(s.kind).toBe('idle');
     if (s.kind === 'idle') {
       expect(s.picker).toEqual({ variant: 'forked', colorKey: 'neon-cyan' });
+      expect(s.lastCommittedId).toBeNull();
     }
   });
 });
@@ -14,7 +17,6 @@ describe('initialState', () => {
 describe('reduce default behavior', () => {
   test('any unhandled action returns the same state reference', () => {
     const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
-    // At this stage no actions are implemented; any action should be a no-op.
     const a: TreeAction = { type: 'CANCEL_CLICKED' };
     expect(reduce(s, a)).toBe(s);
   });
@@ -24,20 +26,20 @@ describe('VARIANT_CHOSEN', () => {
   test('in idle: updates picker.variant, seed ignored', () => {
     const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 123 });
-    expect(next).toEqual({ kind: 'idle', picker: { variant: 'claw', colorKey: 'neon-cyan' } });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'claw', colorKey: 'neon-cyan' }, lastCommittedId: null });
   });
 
   test('in placing: updates both picker.variant and seed', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'wishbone', seed: 99 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 99, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 99, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -45,13 +47,13 @@ describe('VARIANT_CHOSEN', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'trident', seed: 42 });
     expect(next).toEqual({
       kind: 'submitting',
       picker: { variant: 'trident', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 42,
+      parentId: 1, attachIndex: 0, seed: 42, lastCommittedId: null,
     });
   });
 
@@ -59,12 +61,20 @@ describe('VARIANT_CHOSEN', () => {
     const s: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'starburst', seed: 7 });
     expect(next).toEqual({
       kind: 'resetting',
       picker: { variant: 'starburst', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     });
+  });
+
+  test('in undoing: updates picker.variant', () => {
+    const s: TreeState = { kind: 'undoing', picker: { variant: 'forked', colorKey: 'neon-cyan' }, polypId: 5 };
+    const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 1 });
+    expect(next).toEqual({ kind: 'undoing', picker: { variant: 'claw', colorKey: 'neon-cyan' }, polypId: 5 });
   });
 });
 
@@ -72,20 +82,20 @@ describe('COLOR_CHOSEN', () => {
   test('in idle: updates picker.colorKey', () => {
     const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
     const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' });
-    expect(next).toEqual({ kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-magenta' } });
+    expect(next).toEqual({ kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-magenta' }, lastCommittedId: null });
   });
 
   test('in placing: preserves seed, updates picker.colorKey only', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-lime' });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-lime' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     });
   });
 });
@@ -97,21 +107,27 @@ describe('ATTACH_CLICKED', () => {
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 5, attachIndex: 2, seed: 77, blocked: false,
+      parentId: 5, attachIndex: 2, seed: 77, blocked: false, lastCommittedId: null,
     });
+  });
+
+  test('from idle with lastCommittedId → placing preserves lastCommittedId', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 42 };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 5, attachIndex: 2, seed: 77 });
+    expect(next).toMatchObject({ kind: 'placing', lastCommittedId: 42 });
   });
 
   test('from placing → placing with new params, blocked reset to false', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 3, attachIndex: 1, seed: 55 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 3, attachIndex: 1, seed: 55, blocked: false,
+      parentId: 3, attachIndex: 1, seed: 55, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -119,7 +135,7 @@ describe('ATTACH_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 9, attachIndex: 9, seed: 9 });
     expect(next).toBe(s);
@@ -129,6 +145,7 @@ describe('ATTACH_CLICKED', () => {
     const s: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 1, attachIndex: 0, seed: 1 });
     expect(next).toBe(s);
@@ -140,13 +157,13 @@ describe('REROLL_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'claw', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 42, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 42, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -160,7 +177,7 @@ describe('REROLL_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
     expect(next).toBe(s);
@@ -172,7 +189,7 @@ describe('PLACEMENT_BLOCKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'PLACEMENT_BLOCKED' });
     expect(next).toEqual({ ...s, blocked: true });
@@ -189,7 +206,7 @@ describe('PLACEMENT_OK', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'PLACEMENT_OK' });
     expect(next).toEqual({ ...s, blocked: false });
@@ -206,10 +223,20 @@ describe('CANCEL_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CANCEL_CLICKED' });
-    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: null });
+  });
+
+  test('from placing preserves lastCommittedId', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 7,
+    };
+    const next = reduce(s, { type: 'CANCEL_CLICKED' });
+    expect(next).toMatchObject({ kind: 'idle', lastCommittedId: 7 });
   });
 
   test('from idle/submitting/resetting: no-op', () => {
@@ -217,11 +244,12 @@ describe('CANCEL_CLICKED', () => {
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const resetting: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     expect(reduce(idle, { type: 'CANCEL_CLICKED' })).toBe(idle);
     expect(reduce(submitting, { type: 'CANCEL_CLICKED' })).toBe(submitting);
@@ -234,13 +262,13 @@ describe('GROW_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'GROW_CLICKED' });
     expect(next).toEqual({
       kind: 'submitting',
       picker: s.picker,
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     });
   });
 
@@ -248,7 +276,7 @@ describe('GROW_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
     };
     expect(reduce(s, { type: 'GROW_CLICKED' })).toBe(s);
   });
@@ -258,7 +286,7 @@ describe('GROW_CLICKED', () => {
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     expect(reduce(idle, { type: 'GROW_CLICKED' })).toBe(idle);
     expect(reduce(submitting, { type: 'GROW_CLICKED' })).toBe(submitting);
@@ -266,19 +294,19 @@ describe('GROW_CLICKED', () => {
 });
 
 describe('COMMIT_RESOLVED', () => {
-  test('from submitting → idle with picker inherited', () => {
+  test('from submitting → idle with picker inherited and lastCommittedId set', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
-    const next = reduce(s, { type: 'COMMIT_RESOLVED' });
-    expect(next).toEqual({ kind: 'idle', picker: s.picker });
+    const next = reduce(s, { type: 'COMMIT_RESOLVED', polypId: 42 });
+    expect(next).toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: 42 });
   });
 
   test('outside submitting: no-op', () => {
     const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
-    expect(reduce(s, { type: 'COMMIT_RESOLVED' })).toBe(s);
+    expect(reduce(s, { type: 'COMMIT_RESOLVED', polypId: 1 })).toBe(s);
   });
 });
 
@@ -287,14 +315,24 @@ describe('COMMIT_REJECTED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
     expect(next).toEqual({
       kind: 'placing',
       picker: s.picker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     });
+  });
+
+  test('from submitting preserves lastCommittedId on rejection', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: 5,
+    };
+    const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
+    expect(next).toMatchObject({ kind: 'placing', lastCommittedId: 5 });
   });
 
   test('outside submitting: no-op', () => {
@@ -304,49 +342,51 @@ describe('COMMIT_REJECTED', () => {
 });
 
 describe('CLEAR_CLICKED', () => {
-  test('from idle → resetting with picker inherited', () => {
-    const s = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+  test('from idle → resetting with picker inherited, lastCommittedId cleared', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 10 };
     const next = reduce(s, { type: 'CLEAR_CLICKED' });
-    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker, lastCommittedId: null });
   });
 
   test('from placing → resetting with picker inherited', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CLEAR_CLICKED' });
-    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker, lastCommittedId: null });
   });
 
   test('from submitting → resetting', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CLEAR_CLICKED' });
-    expect(next).toEqual({ kind: 'resetting', picker: s.picker });
+    expect(next).toEqual({ kind: 'resetting', picker: s.picker, lastCommittedId: null });
   });
 
   test('from resetting: no-op', () => {
     const s: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     expect(reduce(s, { type: 'CLEAR_CLICKED' })).toBe(s);
   });
 });
 
 describe('RESET_RESOLVED', () => {
-  test('from resetting → idle with picker inherited', () => {
+  test('from resetting → idle with picker inherited, lastCommittedId null', () => {
     const s: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     expect(reduce(s, { type: 'RESET_RESOLVED' }))
-      .toEqual({ kind: 'idle', picker: s.picker });
+      .toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: null });
   });
 
   test('outside resetting: no-op', () => {
@@ -356,13 +396,14 @@ describe('RESET_RESOLVED', () => {
 });
 
 describe('RESET_REJECTED', () => {
-  test('from resetting → idle with picker inherited', () => {
+  test('from resetting → idle with picker inherited, lastCommittedId null', () => {
     const s: TreeState = {
       kind: 'resetting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      lastCommittedId: null,
     };
     expect(reduce(s, { type: 'RESET_REJECTED', error: 'x' }))
-      .toEqual({ kind: 'idle', picker: s.picker });
+      .toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: null });
   });
 
   test('outside resetting: no-op', () => {
@@ -372,53 +413,193 @@ describe('RESET_REJECTED', () => {
 });
 
 describe('TREE_RESET_EXTERNAL', () => {
-  test('from any kind → idle with picker inherited', () => {
-    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+  test('from any kind → idle with picker inherited, lastCommittedId cleared', () => {
+    const idle: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 5 };
     const placing: TreeState = {
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-lime' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     };
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'claw', colorKey: 'neon-violet' },
-      parentId: 2, attachIndex: 1, seed: 20,
+      parentId: 2, attachIndex: 1, seed: 20, lastCommittedId: null,
     };
     const resetting: TreeState = {
       kind: 'resetting',
       picker: { variant: 'trident', colorKey: 'neon-orange' },
+      lastCommittedId: null,
     };
+    const undoing: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 3 };
     expect(reduce(idle, { type: 'TREE_RESET_EXTERNAL' }))
-      .toEqual({ kind: 'idle', picker: idle.picker });
+      .toEqual({ kind: 'idle', picker: idle.picker, lastCommittedId: null });
     expect(reduce(placing, { type: 'TREE_RESET_EXTERNAL' }))
-      .toEqual({ kind: 'idle', picker: placing.picker });
+      .toEqual({ kind: 'idle', picker: placing.picker, lastCommittedId: null });
     expect(reduce(submitting, { type: 'TREE_RESET_EXTERNAL' }))
-      .toEqual({ kind: 'idle', picker: submitting.picker });
+      .toEqual({ kind: 'idle', picker: submitting.picker, lastCommittedId: null });
     expect(reduce(resetting, { type: 'TREE_RESET_EXTERNAL' }))
-      .toEqual({ kind: 'idle', picker: resetting.picker });
+      .toEqual({ kind: 'idle', picker: resetting.picker, lastCommittedId: null });
+    expect(reduce(undoing, { type: 'TREE_RESET_EXTERNAL' }))
+      .toEqual({ kind: 'idle', picker: undoing.picker, lastCommittedId: null });
+  });
+});
+
+describe('UNDO_CLICKED', () => {
+  test('from idle with lastCommittedId → undoing', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 7 };
+    const next = reduce(s, { type: 'UNDO_CLICKED' });
+    expect(next).toEqual({ kind: 'undoing', picker: idlePicker, polypId: 7 });
+  });
+
+  test('from idle with lastCommittedId null: no-op', () => {
+    const s = initialState(idlePicker);
+    expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
+  });
+
+  test('from placing: no-op (not idle)', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 5,
+    };
+    expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
+  });
+
+  test('from submitting: no-op', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: 5,
+    };
+    expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
+  });
+
+  test('from resetting: no-op', () => {
+    const s: TreeState = { kind: 'resetting', picker: idlePicker, lastCommittedId: 5 };
+    expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
+  });
+
+  test('from undoing: no-op', () => {
+    const s: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 5 };
+    expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
+  });
+});
+
+describe('UNDO_RESOLVED', () => {
+  test('from undoing → idle with lastCommittedId cleared', () => {
+    const s: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 7 };
+    const next = reduce(s, { type: 'UNDO_RESOLVED' });
+    expect(next).toEqual({ kind: 'idle', picker: idlePicker, lastCommittedId: null });
+  });
+
+  test('from idle: no-op', () => {
+    const s = initialState(idlePicker);
+    expect(reduce(s, { type: 'UNDO_RESOLVED' })).toBe(s);
+  });
+
+  test('from placing: no-op', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+    };
+    expect(reduce(s, { type: 'UNDO_RESOLVED' })).toBe(s);
+  });
+});
+
+describe('UNDO_REJECTED', () => {
+  test('from undoing → idle, lastCommittedId restored to polypId', () => {
+    const s: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 7 };
+    const next = reduce(s, { type: 'UNDO_REJECTED', error: 'server error' });
+    expect(next).toEqual({ kind: 'idle', picker: idlePicker, lastCommittedId: 7 });
+  });
+
+  test('from idle: no-op', () => {
+    const s = initialState(idlePicker);
+    expect(reduce(s, { type: 'UNDO_REJECTED', error: 'x' })).toBe(s);
+  });
+});
+
+describe('TREE_POLYP_REMOVED_EXTERNAL', () => {
+  test('from idle: clears lastCommittedId when id matches', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 7 };
+    const next = reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 7 });
+    expect(next).toMatchObject({ kind: 'idle', lastCommittedId: null });
+  });
+
+  test('from idle: no-op when id does not match', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 7 };
+    expect(reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 99 })).toBe(s);
+  });
+
+  test('from idle with no lastCommittedId: no-op', () => {
+    const s = initialState(idlePicker);
+    expect(reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 1 })).toBe(s);
+  });
+
+  test('from placing: clears lastCommittedId when id matches', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 7,
+    };
+    const next = reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 7 });
+    expect(next).toMatchObject({ kind: 'placing', lastCommittedId: null });
+  });
+
+  test('from undoing: no-op (undo is in flight)', () => {
+    const s: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 7 };
+    expect(reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 7 })).toBe(s);
+  });
+});
+
+describe('LAST_COMMITTED_INVALIDATED', () => {
+  test('from idle with lastCommittedId: clears it', () => {
+    const s: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 5 };
+    const next = reduce(s, { type: 'LAST_COMMITTED_INVALIDATED' });
+    expect(next).toMatchObject({ kind: 'idle', lastCommittedId: null });
+  });
+
+  test('from idle with null: no-op', () => {
+    const s = initialState(idlePicker);
+    expect(reduce(s, { type: 'LAST_COMMITTED_INVALIDATED' })).toBe(s);
+  });
+
+  test('from placing with lastCommittedId: clears it', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: idlePicker,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 5,
+    };
+    const next = reduce(s, { type: 'LAST_COMMITTED_INVALIDATED' });
+    expect(next).toMatchObject({ kind: 'placing', lastCommittedId: null });
+  });
+
+  test('from undoing: no-op', () => {
+    const s: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 5 };
+    expect(reduce(s, { type: 'LAST_COMMITTED_INVALIDATED' })).toBe(s);
   });
 });
 
 describe('reduce — no-op matrix', () => {
-  // Sample states of each kind, populated with deterministic field values.
   const samples: Record<TreeState['kind'], TreeState> = {
-    idle: { kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+    idle: { kind: 'idle', picker: { variant: 'forked', colorKey: 'neon-cyan' }, lastCommittedId: null },
     placing: {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false,
+      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
     },
     submitting: {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10,
+      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
     },
-    resetting: { kind: 'resetting', picker: { variant: 'forked', colorKey: 'neon-cyan' } },
+    resetting: { kind: 'resetting', picker: { variant: 'forked', colorKey: 'neon-cyan' }, lastCommittedId: null },
+    undoing: { kind: 'undoing', picker: { variant: 'forked', colorKey: 'neon-cyan' }, polypId: 1 },
   };
 
-  // The `valid` matrix lists which action types produce a real transition
-  // (non-identity result) from each state kind.
   const valid: Record<TreeState['kind'], readonly TreeAction['type'][]> = {
+    // UNDO_CLICKED is not listed here because the sample has lastCommittedId:null so it is identity.
     idle: ['VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'CLEAR_CLICKED', 'TREE_RESET_EXTERNAL'],
     placing: [
       'VARIANT_CHOSEN', 'COLOR_CHOSEN', 'ATTACH_CLICKED', 'REROLL_CLICKED',
@@ -435,9 +616,13 @@ describe('reduce — no-op matrix', () => {
       'RESET_RESOLVED', 'RESET_REJECTED',
       'TREE_RESET_EXTERNAL',
     ],
+    undoing: [
+      'VARIANT_CHOSEN', 'COLOR_CHOSEN',
+      'UNDO_RESOLVED', 'UNDO_REJECTED',
+      'TREE_RESET_EXTERNAL',
+    ],
   };
 
-  // Every TreeAction shape with sample payload, enumerated once.
   const allActions: TreeAction[] = [
     { type: 'VARIANT_CHOSEN', variant: 'claw', seed: 1 },
     { type: 'COLOR_CHOSEN', colorKey: 'neon-magenta' },
@@ -447,12 +632,17 @@ describe('reduce — no-op matrix', () => {
     { type: 'PLACEMENT_OK' },
     { type: 'CANCEL_CLICKED' },
     { type: 'GROW_CLICKED' },
-    { type: 'COMMIT_RESOLVED' },
+    { type: 'COMMIT_RESOLVED', polypId: 1 },
     { type: 'COMMIT_REJECTED', error: 'x' },
     { type: 'CLEAR_CLICKED' },
     { type: 'RESET_RESOLVED' },
     { type: 'RESET_REJECTED', error: 'x' },
     { type: 'TREE_RESET_EXTERNAL' },
+    { type: 'UNDO_CLICKED' },
+    { type: 'UNDO_RESOLVED' },
+    { type: 'UNDO_REJECTED', error: 'x' },
+    { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 999 },
+    { type: 'LAST_COMMITTED_INVALIDATED' },
   ];
 
   for (const kind of Object.keys(samples) as Array<TreeState['kind']>) {
@@ -464,8 +654,6 @@ describe('reduce — no-op matrix', () => {
         if (expectIdentity) {
           expect(next).toBe(state);
         } else {
-          // For covered transitions we already assert specifics elsewhere;
-          // here just ensure we *didn't* return identity.
           expect(next).not.toBe(state);
         }
       });

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -6,7 +6,7 @@ export interface PickerSelection {
 }
 
 export type TreeState =
-  | { kind: 'idle'; picker: PickerSelection }
+  | { kind: 'idle'; picker: PickerSelection; lastCommittedId: number | null }
   | {
       kind: 'placing';
       picker: PickerSelection;
@@ -14,6 +14,7 @@ export type TreeState =
       attachIndex: number;
       seed: number;
       blocked: boolean;
+      lastCommittedId: number | null;
     }
   | {
       kind: 'submitting';
@@ -21,8 +22,10 @@ export type TreeState =
       parentId: number;
       attachIndex: number;
       seed: number;
+      lastCommittedId: number | null;
     }
-  | { kind: 'resetting'; picker: PickerSelection };
+  | { kind: 'resetting'; picker: PickerSelection; lastCommittedId: number | null }
+  | { kind: 'undoing'; picker: PickerSelection; polypId: number };
 
 export type TreeAction =
   | { type: 'VARIANT_CHOSEN'; variant: TreeVariant; seed: number }
@@ -33,15 +36,20 @@ export type TreeAction =
   | { type: 'PLACEMENT_OK' }
   | { type: 'CANCEL_CLICKED' }
   | { type: 'GROW_CLICKED' }
-  | { type: 'COMMIT_RESOLVED' }
+  | { type: 'COMMIT_RESOLVED'; polypId: number }
   | { type: 'COMMIT_REJECTED'; error: string }
   | { type: 'CLEAR_CLICKED' }
   | { type: 'RESET_RESOLVED' }
   | { type: 'RESET_REJECTED'; error: string }
-  | { type: 'TREE_RESET_EXTERNAL' };
+  | { type: 'TREE_RESET_EXTERNAL' }
+  | { type: 'UNDO_CLICKED' }
+  | { type: 'UNDO_RESOLVED' }
+  | { type: 'UNDO_REJECTED'; error: string }
+  | { type: 'TREE_POLYP_REMOVED_EXTERNAL'; id: number }
+  | { type: 'LAST_COMMITTED_INVALIDATED' };
 
 export function initialState(picker: PickerSelection): TreeState {
-  return { kind: 'idle', picker };
+  return { kind: 'idle', picker, lastCommittedId: null };
 }
 
 export function reduce(state: TreeState, action: TreeAction): TreeState {
@@ -53,6 +61,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         case 'placing':   return { ...state, picker, seed: action.seed };
         case 'submitting':return { ...state, picker, seed: action.seed };
         case 'resetting': return { ...state, picker };
+        case 'undoing':   return { ...state, picker };
       }
     }
     case 'COLOR_CHOSEN': {
@@ -68,6 +77,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
           attachIndex: action.attachIndex,
           seed: action.seed,
           blocked: false,
+          lastCommittedId: state.lastCommittedId,
         };
       }
       return state;
@@ -91,7 +101,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
     }
     case 'CANCEL_CLICKED': {
       if (state.kind !== 'placing') return state;
-      return { kind: 'idle', picker: state.picker };
+      return { kind: 'idle', picker: state.picker, lastCommittedId: state.lastCommittedId };
     }
     case 'GROW_CLICKED': {
       if (state.kind !== 'placing' || state.blocked) return state;
@@ -101,11 +111,12 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         parentId: state.parentId,
         attachIndex: state.attachIndex,
         seed: state.seed,
+        lastCommittedId: state.lastCommittedId,
       };
     }
     case 'COMMIT_RESOLVED': {
       if (state.kind !== 'submitting') return state;
-      return { kind: 'idle', picker: state.picker };
+      return { kind: 'idle', picker: state.picker, lastCommittedId: action.polypId };
     }
     case 'COMMIT_REJECTED': {
       if (state.kind !== 'submitting') return state;
@@ -116,19 +127,46 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         attachIndex: state.attachIndex,
         seed: state.seed,
         blocked: false,
+        lastCommittedId: state.lastCommittedId,
       };
     }
     case 'CLEAR_CLICKED': {
-      if (state.kind === 'resetting') return state;
-      return { kind: 'resetting', picker: state.picker };
+      if (state.kind === 'resetting' || state.kind === 'undoing') return state;
+      return { kind: 'resetting', picker: state.picker, lastCommittedId: null };
     }
     case 'RESET_RESOLVED':
     case 'RESET_REJECTED': {
       if (state.kind !== 'resetting') return state;
-      return { kind: 'idle', picker: state.picker };
+      return { kind: 'idle', picker: state.picker, lastCommittedId: null };
     }
     case 'TREE_RESET_EXTERNAL':
-      return { kind: 'idle', picker: state.picker };
+      return { kind: 'idle', picker: state.picker, lastCommittedId: null };
+    case 'UNDO_CLICKED': {
+      if (state.kind !== 'idle' || state.lastCommittedId === null) return state;
+      return { kind: 'undoing', picker: state.picker, polypId: state.lastCommittedId };
+    }
+    case 'UNDO_RESOLVED': {
+      if (state.kind !== 'undoing') return state;
+      return { kind: 'idle', picker: state.picker, lastCommittedId: null };
+    }
+    case 'UNDO_REJECTED': {
+      if (state.kind !== 'undoing') return state;
+      return { kind: 'idle', picker: state.picker, lastCommittedId: state.polypId };
+    }
+    case 'TREE_POLYP_REMOVED_EXTERNAL': {
+      if (state.kind === 'undoing') return state;
+      if ('lastCommittedId' in state && state.lastCommittedId === action.id) {
+        return { ...state, lastCommittedId: null };
+      }
+      return state;
+    }
+    case 'LAST_COMMITTED_INVALIDATED': {
+      if (state.kind === 'undoing') return state;
+      if ('lastCommittedId' in state && state.lastCommittedId !== null) {
+        return { ...state, lastCommittedId: null };
+      }
+      return state;
+    }
     default:
       return state;
   }

--- a/packages/client/tree.html
+++ b/packages/client/tree.html
@@ -15,17 +15,81 @@
       background: rgba(0,0,0,0.35); border-radius: 3px;
       pointer-events: none;
     }
+
+    /* ---- toolbar ---- */
     #toolbar {
       position: fixed; top: 12px; right: 12px; z-index: 5; display: flex; gap: 6px;
       font: 500 12px/1 system-ui, sans-serif;
     }
     #toolbar button {
-      padding: 6px 10px; color: #cfe; background: rgba(10,20,32,0.75);
+      min-width: 44px; min-height: 44px;
+      padding: 6px 12px; color: #cfe; background: rgba(10,20,32,0.75);
       border: 1px solid rgba(120,180,220,0.25); border-radius: 4px;
-      cursor: pointer;
+      cursor: pointer; font: inherit;
     }
     #toolbar button:hover { background: rgba(20,40,60,0.85); }
     #toolbar button:active { transform: translateY(1px); }
+    #toolbar button:disabled { opacity: 0.35; cursor: default; }
+    #toolbar button[aria-pressed="true"] { background: rgba(30,60,90,0.9); border-color: rgba(120,200,255,0.5); }
+
+    /* ---- sea life panel ---- */
+    /* mobile-first: slides up from bottom */
+    #sea-life-panel {
+      display: none;
+      position: fixed;
+      bottom: 0; left: 0; right: 0;
+      z-index: 6;
+      background: rgba(6,14,24,0.96);
+      border-top: 1px solid rgba(120,180,220,0.25);
+      padding: 20px 20px calc(env(safe-area-inset-bottom, 0px) + 20px);
+      font: 500 13px/1 system-ui, sans-serif; color: #cfe;
+    }
+    #sea-life-panel.open { display: block; }
+
+    #sea-life-panel-header {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 16px;
+    }
+    #sea-life-panel-title { font-size: 14px; font-weight: 600; color: #9cf; }
+    #sea-life-close-btn {
+      min-width: 44px; min-height: 44px;
+      background: none; border: none; color: #9ab; font-size: 18px;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      border-radius: 4px;
+    }
+    #sea-life-close-btn:hover { color: #cfe; }
+
+    .creature-row {
+      display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+    }
+    .creature-name { flex: 1; color: #cfe; }
+    .creature-count {
+      min-width: 28px; text-align: center;
+      color: #9cf; font-weight: 600;
+    }
+    .creature-btn {
+      min-width: 44px; min-height: 44px;
+      background: rgba(10,20,32,0.75); border: 1px solid rgba(120,180,220,0.25);
+      border-radius: 4px; color: #cfe; font-size: 18px; font-weight: 700;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+    }
+    .creature-btn:hover { background: rgba(20,40,60,0.85); }
+    .creature-btn:active { transform: translateY(1px); }
+    .creature-btn:disabled { opacity: 0.35; cursor: default; }
+
+    /* wider screens: dropdown from button */
+    @media (min-width: 640px) {
+      #sea-life-panel {
+        bottom: auto;
+        top: 62px; right: 12px; left: auto;
+        width: 280px;
+        border-top: none;
+        border: 1px solid rgba(120,180,220,0.25);
+        border-radius: 6px;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+        padding: 16px;
+      }
+    }
   </style>
 </head>
 <body>
@@ -33,11 +97,41 @@
   <div id="mode-badge"></div>
   <div id="toolbar" aria-label="Tree controls">
     <button id="clearBtn" type="button">Clear</button>
-    <button id="addSharkBtn" type="button">Add shark</button>
-    <button id="addClownfishBtn" type="button">Add clownfish</button>
-    <button id="addJellyfishBtn" type="button">Add jellyfish</button>
-    <button id="addSeaTurtleBtn" type="button">Add sea turtle</button>
+    <button id="undoBtn" type="button" disabled>Undo</button>
+    <button id="seaLifeBtn" type="button" aria-expanded="false" aria-controls="sea-life-panel">Sea life</button>
   </div>
+
+  <div id="sea-life-panel" role="region" aria-label="Sea life controls">
+    <div id="sea-life-panel-header">
+      <span id="sea-life-panel-title">Sea life</span>
+      <button id="sea-life-close-btn" type="button" aria-label="Close sea life panel">&#x2715;</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Shark</span>
+      <span class="creature-count" id="count-shark">0</span>
+      <button class="creature-btn" id="removeSharkBtn" type="button" aria-label="Remove shark" disabled>&#8722;</button>
+      <button class="creature-btn" id="addSharkBtn" type="button" aria-label="Add shark">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Clownfish</span>
+      <span class="creature-count" id="count-clownfish">0</span>
+      <button class="creature-btn" id="removeClownfishBtn" type="button" aria-label="Remove clownfish" disabled>&#8722;</button>
+      <button class="creature-btn" id="addClownfishBtn" type="button" aria-label="Add clownfish">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Jellyfish</span>
+      <span class="creature-count" id="count-jellyfish">0</span>
+      <button class="creature-btn" id="removeJellyfishBtn" type="button" aria-label="Remove jellyfish" disabled>&#8722;</button>
+      <button class="creature-btn" id="addJellyfishBtn" type="button" aria-label="Add jellyfish">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Sea turtle</span>
+      <span class="creature-count" id="count-seaTurtle">0</span>
+      <button class="creature-btn" id="removeSeaTurtleBtn" type="button" aria-label="Remove sea turtle" disabled>&#8722;</button>
+      <button class="creature-btn" id="addSeaTurtleBtn" type="button" aria-label="Add sea turtle">+</button>
+    </div>
+  </div>
+
   <div id="picker" class="hidden" role="region" aria-label="Plant a polyp">
     <div class="picker-row" role="group" aria-label="Variant">
       <button type="button" data-variant="forked">Forked</button>

--- a/packages/server/src/tree/routes.test.ts
+++ b/packages/server/src/tree/routes.test.ts
@@ -124,3 +124,79 @@ describe('POST /api/tree/polyp', () => {
     await close();
   });
 });
+
+describe('DELETE /api/tree/polyp/:id', () => {
+  test('soft-deletes a leaf polyp and returns ok:true', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+    const res = await app.inject({ method: 'DELETE', url: `/api/tree/polyp/${rootId}` });
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body), { ok: true });
+
+    const list = await app.inject({ method: 'GET', url: '/api/tree' });
+    const body = JSON.parse(list.body) as { polyps: unknown[] };
+    assert.equal(body.polyps.length, 0);
+    await close();
+  });
+
+  test('returns 404 when polyp does not exist', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({ method: 'DELETE', url: '/api/tree/polyp/99999' });
+    assert.equal(res.statusCode, 404);
+    assert.match((JSON.parse(res.body) as { error: string }).error, /not found/i);
+    await close();
+  });
+
+  test('returns 409 when polyp has children', async () => {
+    const { app, close } = await makeServer();
+    const root = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+    await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 1 },
+    });
+    const res = await app.inject({ method: 'DELETE', url: `/api/tree/polyp/${rootId}` });
+    assert.equal(res.statusCode, 409);
+    await close();
+  });
+
+  test('returns 400 when id is not numeric', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({ method: 'DELETE', url: '/api/tree/polyp/abc' });
+    assert.equal(res.statusCode, 400);
+    await close();
+  });
+
+  test('broadcasts tree_polyp_removed via the hub on success', async () => {
+    const messages: unknown[] = [];
+    const fakeWs = {
+      readyState: 1,
+      send(data: string) { messages.push(JSON.parse(data)); },
+      on() { /* noop */ },
+    };
+    const hub = new Hub();
+    hub.add(fakeWs);
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const app2 = Fastify({ logger: false });
+    registerTreeRoutes(app2, tree, hub);
+    await app2.ready();
+    const root = await app2.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+    });
+    const rootId = (JSON.parse(root.body) as { id: number }).id;
+    messages.length = 0; // clear the polyp_added broadcast
+    await app2.inject({ method: 'DELETE', url: `/api/tree/polyp/${rootId}` });
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], { type: 'tree_polyp_removed', id: rootId });
+    await app2.close();
+  });
+});

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -4,6 +4,8 @@ import type { Hub } from '../hub.js';
 import type { TreeDb } from './db.js';
 import { seedRootIfEmpty } from './seed.js';
 
+const NUMERIC_ID_RE = /^\d+$/;
+
 export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub): void {
   app.get('/api/tree', async () => ({
     polyps: tree.listLive(),
@@ -50,5 +52,25 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
       reply.code(500);
       return { error: msg };
     }
+  });
+
+  app.delete('/api/tree/polyp/:id', async (req, reply) => {
+    const { id: rawId } = req.params as { id: string };
+    if (!NUMERIC_ID_RE.test(rawId)) {
+      reply.code(400);
+      return { error: 'id must be a positive integer' };
+    }
+    const id = Number(rawId);
+    const result = tree.softDelete(id);
+    if (!result.ok) {
+      if (result.reason === 'not_found') {
+        reply.code(404);
+        return { error: 'polyp not found' };
+      }
+      reply.code(409);
+      return { error: result.reason ?? 'cannot delete' };
+    }
+    hub.broadcast({ type: 'tree_polyp_removed', id } as never);
+    return { ok: true };
   });
 }


### PR DESCRIPTION
## Summary

- Undo last-placed polyp: new action dispatched from a toolbar button, routed through a new `undoing` state in the tree state machine. Only enabled when the client has a live "my last commit" id and the state is idle.
- Mobile-first collapsible sea-life panel: replaces the flat "Add X" buttons with a single `Sea life` toggle in the top-right toolbar. Opens a panel listing each creature type with a live count and `−` / `+` controls (44×44px min tap targets).
- Server: new `DELETE /api/tree/polyp/:id` route that soft-deletes leaf polyps and broadcasts `tree_polyp_removed` to WS clients.

## Architecture notes

State machine additions (new in `packages/client/src/tree/state.ts`):

- New state kind: `undoing` — active while the DELETE request is in flight.
- New field on every kind: `lastCommittedId: number | null` — populated when `COMMIT_RESOLVED` fires, cleared on undo-resolved, reset, or external-polyp-removed.
- New actions: `UNDO_CLICKED`, `UNDO_RESOLVED`, `UNDO_REJECTED`, `TREE_POLYP_REMOVED_EXTERNAL`, `LAST_COMMITTED_INVALIDATED` (fired when another user builds on top of the id we were tracking — if it has children, we can no longer undo it).

Effects (`packages/client/src/tree/effects.ts`): new `undoing` branch fires `deleteTreePolyp`; resolve/reject dispatch the matching action. All existing branches untouched.

Mobile-first CSS: `#sea-life-panel` default is a bottom drawer (`bottom: 0; left: 0; right: 0`), `@media (min-width: 640px)` repositions it as a `280px` dropdown anchored to the trigger. Close on outside-tap, Esc, or dedicated × button.

## Commits

- `2b7e90f` — Tree undo: add DELETE /api/tree/polyp/:id route with tests
- `66c7f50` — Tree undo: add deleteTreePolyp client helper
- `1c6a128` — Tree undo: reducer changes — undoing kind, lastCommittedId, undo actions
- `7cac46e` — Tree undo: effects branches for undo flow
- `5ee9602` — Tree undo: wire WS handlers for lastCommittedId invalidation
- `602c460` — Tree sea life: track creature type + add removeCreature/countCreatures helpers
- `3130831` — Tree UI: collapsible sea-life panel, Undo button, panel wiring

## Test plan

Automated (all pass):

- [x] `pnpm --filter @reef/client typecheck` — clean
- [x] `pnpm --filter @reef/client test` — 328 tests pass (was 265; +63 for reducer changes and new action coverage)
- [x] `pnpm --filter @reef/server test` — 97 tests pass (was 92; +5 for the new DELETE route)

Manual browser smoke (already walked through locally):

- [x] Undo button disabled on load; enables after first Grow; disables after clicking Undo
- [x] Sea life panel slides up from bottom on narrow viewport, drops from button on wide
- [x] Creature counts update live as `+` / `−` fire
- [x] Toolbar still renders above the canvas (z-index carried from PR #75)
- [x] All 328 + 97 tests pass

## Known trade-offs

- `LAST_COMMITTED_INVALIDATED` only fires when we observe another polyp being added whose `parentId` matches our `lastCommittedId`. If the server echoes out of order (unlikely but possible), the Undo button could briefly think we can still undo. The actual DELETE request would then fail server-side with 409 (leaf-only), and the error bubbles through to the hint text.
- `CLEAR_CLICKED` from `undoing` is a no-op — can't reset while an undo is in flight. Conservative; can reopen if it matters in practice.
