### PR TITLE
Tree mode: realistic coral branching (nodules + displacement + color tint)

### DIFF
--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -57,7 +57,7 @@ export function createEffects(deps: EffectsDeps): Effects {
         } else {
           deps.dispatch({ type: 'PLACEMENT_BLOCKED' });
           deps.picker.setCommittable(false);
-          deps.hintEl.textContent = 'That spot is blocked. Try another dot or reroll.';
+          deps.hintEl.textContent = 'Adding this piece here would touch another spot. Try a different piece.';
         }
         return;
       }

--- a/packages/generator/src/tree/variant.ts
+++ b/packages/generator/src/tree/variant.ts
@@ -94,6 +94,183 @@ export interface EmitFrustumOpts {
    * of thicker and thinner sections along the branch.
    */
   ridgeAmplitude?: number;
+  /**
+   * When set, scatter coral-polyp nodules on the outer surface of this
+   * frustum and merge their vertices into the same geometry arrays.
+   * Value is a seed offset used to deterministically place the nodules
+   * (combined with the main `seed` for the PRNG).
+   */
+  nodulesEnabled?: boolean;
+  /**
+   * Width segments for each nodule sphere (default 6). Reduce on high
+   * frustum-count variants (e.g. wishbone's 12 bezier arms) to keep total
+   * vertex counts inside the ~4000 per-piece budget.
+   */
+  noduleWidthSegs?: number;
+  /**
+   * Height segments for each nodule sphere (default 4). Pairs with
+   * noduleWidthSegs to trade visual quality for vertex budget.
+   */
+  noduleHeightSegs?: number;
+  /**
+   * Hard cap on nodule count per frustum (default 22). Set lower on variants
+   * with many frustum calls (e.g. wishbone's 12 bezier arms) to keep total
+   * vertex counts inside the ~4000 per-piece budget.
+   */
+  noduleMaxCount?: number;
+}
+
+/**
+ * Low-frequency noise helper used for both displacement and color variation.
+ * Evaluates a smooth periodic function from a seeded PRNG at a given
+ * normalized phase [0,1] — good enough for "organic banding" without a full
+ * Perlin implementation, and keeps the file dependency-free.
+ *
+ * Returns a value in [-1, 1] with multi-octave character.
+ */
+function evalLengthNoise(rand: () => number, phase: number): number {
+  // Two octaves: fundamental + half-amplitude harmonic at 2× frequency.
+  // The PRNG drives amplitude and phase offsets so each piece differs.
+  const a0 = rand() * 2 - 1; // amplitude ±1
+  const p0 = rand() * Math.PI * 2; // random phase offset
+  const a1 = (rand() * 2 - 1) * 0.5; // second octave, half amplitude
+  const p1 = rand() * Math.PI * 2;
+  return a0 * Math.sin(phase * Math.PI * 2 + p0) + a1 * Math.sin(phase * Math.PI * 4 + p1);
+}
+
+/**
+ * Emit a low-poly sphere (icosphere approximation via lat/lon bands) into the
+ * geometry arrays. Used for coral-polyp nodules sitting on branch surfaces.
+ * Vertices are merged directly into the parent geometry — no extra draw call.
+ *
+ * wSegs × hSegs controls polygon count. For nodules: 6–8 wide, 4–6 tall is
+ * enough visual resolution while keeping total vertex budgets manageable.
+ */
+function emitSphere(
+  positions: number[],
+  normals: number[],
+  colors: number[],
+  indices: number[],
+  cx: number,
+  cy: number,
+  cz: number,
+  radius: number,
+  cr: number,
+  cg: number,
+  cb: number,
+  wSegs: number,
+  hSegs: number,
+): void {
+  const baseIdx = positions.length / 3;
+
+  // Lat/lon sphere: hSegs+1 latitude rings, wSegs vertices per ring.
+  for (let j = 0; j <= hSegs; j++) {
+    const phi = (j / hSegs) * Math.PI; // 0 → PI (north to south pole)
+    const sinPhi = Math.sin(phi);
+    const cosPhi = Math.cos(phi);
+    for (let i = 0; i <= wSegs; i++) {
+      const theta = (i / wSegs) * Math.PI * 2;
+      const nx = Math.sin(theta) * sinPhi;
+      const ny = cosPhi;
+      const nz = Math.cos(theta) * sinPhi;
+      positions.push(cx + nx * radius, cy + ny * radius, cz + nz * radius);
+      normals.push(nx, ny, nz);
+      colors.push(cr, cg, cb);
+    }
+  }
+
+  // Stitch quads between consecutive latitude rings.
+  const stride = wSegs + 1;
+  for (let j = 0; j < hSegs; j++) {
+    for (let i = 0; i < wSegs; i++) {
+      const a = baseIdx + j * stride + i;
+      const b = baseIdx + (j + 1) * stride + i;
+      const c = baseIdx + j * stride + (i + 1);
+      const d = baseIdx + (j + 1) * stride + (i + 1);
+      // Degenerate quads at poles collapse to triangles; emit both halves.
+      indices.push(a, b, d, a, d, c);
+    }
+  }
+}
+
+/**
+ * Scatter coral-polyp nodules on the outer surface of a frustum segment.
+ * Nodules are small spheres whose centers sit exactly on the frustum surface
+ * (axisPoint + radialDir × segmentRadius), so they protrude outward.
+ *
+ * All vertices are merged into the caller's geometry arrays (no extra mesh).
+ * Count and placement are seeded-deterministic via the provided PRNG.
+ *
+ * wSegs/hSegs control nodule sphere resolution; reduce on high frustum-count
+ * variants to keep per-piece vertex budgets manageable.
+ */
+function emitFrustumNodules(
+  positions: number[],
+  normals: number[],
+  colors: number[],
+  indices: number[],
+  from: Vec3Obj,
+  to: Vec3Obj,
+  r0: number,
+  r1: number,
+  color: ColorInput,
+  rand: () => number,
+  wSegs: number,
+  hSegs: number,
+  maxCount: number,
+): void {
+  // Build the same orthonormal basis as emitFrustum so we can offset radially.
+  const ax = to.x - from.x;
+  const ay = to.y - from.y;
+  const az = to.z - from.z;
+  const len = Math.hypot(ax, ay, az) || 1e-6;
+  const axn = ax / len, ayn = ay / len, azn = az / len;
+
+  let ux: number, uy: number, uz: number;
+  if (Math.abs(ayn) < 0.9) {
+    ux = -azn; uy = 0; uz = axn;
+  } else {
+    ux = 1; uy = 0; uz = 0;
+  }
+  const dot = axn * ux + ayn * uy + azn * uz;
+  ux -= axn * dot; uy -= ayn * dot; uz -= azn * dot;
+  const un = Math.hypot(ux, uy, uz) || 1e-6;
+  ux /= un; uy /= un; uz /= un;
+  const vx = ayn * uz - azn * uy;
+  const vy = azn * ux - axn * uz;
+  const vz = axn * uy - ayn * ux;
+
+  // 12–22 nodules per segment (capped by maxCount for budget control).
+  const rawCount = 12 + Math.floor(rand() * 11); // [12, 22]
+  const count = Math.min(rawCount, maxCount);
+
+  for (let n = 0; n < count; n++) {
+    // Longitudinal position: 10% to 90% of segment length, away from the join.
+    const t = 0.1 + rand() * 0.8;
+    // Random azimuth around the circumference.
+    const theta = rand() * Math.PI * 2;
+    // Nodule radius: 18%–32% of the local segment radius, with per-nodule jitter.
+    const segR = r0 + (r1 - r0) * t;
+    const noduleR = segR * (0.18 + rand() * 0.14);
+
+    // Radial direction in the frustum's cross-section plane.
+    const ct = Math.cos(theta), st = Math.sin(theta);
+    const radX = ux * ct + vx * st;
+    const radY = uy * ct + vy * st;
+    const radZ = uz * ct + vz * st;
+
+    // Center = axis point + radial offset (nodule sits on the surface).
+    // Small inward/outward jitter so nodules don't form a perfect cylinder.
+    const radialOffset = segR + noduleR * (0.6 + rand() * 0.4);
+    const cx = from.x + ax * t + radX * radialOffset;
+    const cy = from.y + ay * t + radY * radialOffset;
+    const cz = from.z + az * t + radZ * radialOffset;
+
+    // Nodule color inherits the local branch shade (set by Pass 3 before this runs).
+    const cr = colorR(color), cg = colorG(color), cb = colorB(color);
+
+    emitSphere(positions, normals, colors, indices, cx, cy, cz, noduleR, cr, cg, cb, wSegs, hSegs);
+  }
 }
 
 /**
@@ -146,15 +323,40 @@ export function emitFrustum(
   const vy = azn * ux - axn * uz;
   const vz = axn * uy - ayn * ux;
 
-  const cr = colorR(color), cg = colorG(color), cb = colorB(color);
+  const baseCr = colorR(color), baseCg = colorG(color), baseCb = colorB(color);
   const baseIdx = positions.length / 3;
 
+  // Pass 2: multi-octave displacement. Amplitude raised to 12–18% of radius,
+  // favoring outward swells over inward necks (positive noise × 1.0, negative
+  // noise × 0.4). Two octaves gives rough-at-multiple-scales feel.
   const vertexAmp = opts.noiseAmplitude ?? 0;
   const ridgeAmp = opts.ridgeAmplitude ?? 0;
   const lenSubs = Math.max(0, Math.floor(opts.lengthSubdivisions ?? 0));
   const rings = lenSubs + 2; // endpoints + subdivisions
   const hasNoise = opts.seed !== undefined && (vertexAmp > 0 || ridgeAmp > 0);
   const rand = hasNoise ? seededRand(opts.seed!) : null;
+
+  // Pass 3: pre-sample the per-ring color noise so nodules inherit local shade.
+  // Low-frequency along-length banding in [-0.08, +0.08] per channel.
+  // The PRNG is advanced for the color-noise parameters regardless of whether
+  // color variation is active, keeping the sequence stable for nodule placement.
+  const COLOR_VAR = 0.08;
+  // Reserve four random draws per ring for the evalLengthNoise internals.
+  // We sample ahead-of-time and store per-ring color deltas so the main loop
+  // is clean and the nodule pass can access them by ring index.
+  //
+  // Color noise uses a separate PRNG seeded from opts.seed + 0xC010R to avoid
+  // polluting the displacement PRNG state.
+  const colorRand = opts.seed !== undefined ? seededRand(opts.seed ^ 0xc010c) : null;
+  const ringColorDelta = new Float32Array(rings);
+  if (colorRand) {
+    for (let k = 0; k < rings; k++) {
+      // evalLengthNoise advances colorRand 4× per call (a0, p0, a1, p1).
+      const phase = k / Math.max(1, rings - 1);
+      const raw = evalLengthNoise(colorRand, phase); // [-~1.5, +~1.5] roughly
+      ringColorDelta[k] = raw * COLOR_VAR; // clamp in apply step
+    }
+  }
 
   // Compute a per-ring radial scale once so an entire ring expands/contracts
   // together. Reads as a "rib" or "pinch" along the branch. Endpoint rings
@@ -175,6 +377,12 @@ export function emitFrustum(
     const axisZ = from.z + (to.z - from.z) * t;
     const ringR = (r0 + (r1 - r0) * t) * ringScales[k]!;
 
+    // Pass 3: apply color variation. Clamp to [0, 1] to stay in valid range.
+    const cd = ringColorDelta[k]!;
+    const cr = Math.max(0, Math.min(1, baseCr + cd));
+    const cg = Math.max(0, Math.min(1, baseCg + cd));
+    const cb = Math.max(0, Math.min(1, baseCb + cd));
+
     for (let i = 0; i < segments; i++) {
       const theta = (i / segments) * Math.PI * 2;
       const ct = Math.cos(theta), st = Math.sin(theta);
@@ -182,7 +390,19 @@ export function emitFrustum(
       const ny = uy * ct + vy * st;
       const nz = uz * ct + vz * st;
 
-      const vj = rand && vertexAmp > 0 ? (rand() - 0.5) * 2 * vertexAmp : 0;
+      // Pass 2: two-octave noise with outward bias.
+      // Octave 1: fundamental displacement.
+      // Octave 2: half amplitude, higher frequency for fine roughness.
+      // Negative displacement is damped by 0.4 so the branch swells more
+      // than it necks, matching the look of real coral skeletons.
+      let vj = 0;
+      if (rand && vertexAmp > 0) {
+        const n1 = (rand() - 0.5) * 2; // [-1, 1]
+        const n2 = (rand() - 0.5) * 2 * 0.5; // half amplitude second octave
+        const raw = n1 + n2; // combined noise, range roughly [-1.5, 1.5]
+        const biased = raw < 0 ? raw * 0.4 : raw; // squash inward
+        vj = biased * vertexAmp;
+      }
       const rr = ringR * (1 + vj);
 
       positions.push(axisX + nx * rr, axisY + ny * rr, axisZ + nz * rr);
@@ -204,6 +424,20 @@ export function emitFrustum(
       const d = ringB + iNext;
       indices.push(a, b, d, a, d, c);
     }
+  }
+
+  // Pass 1: scatter coral-polyp nodules on this frustum's outer surface.
+  // Uses a dedicated PRNG seeded separately from displacement so the two
+  // noise streams don't interfere with each other.
+  if (opts.nodulesEnabled && opts.seed !== undefined) {
+    const noduleRand = seededRand(opts.seed ^ 0xface7);
+    const wSegs = opts.noduleWidthSegs ?? 6;
+    const hSegs = opts.noduleHeightSegs ?? 4;
+    const maxCount = opts.noduleMaxCount ?? 22;
+    // The color passed here is the base color; nodules inherit per-vertex
+    // color variation via the average midpoint shade (use base color since
+    // nodule positions are distributed across the segment).
+    emitFrustumNodules(positions, normals, colors, indices, from, to, r0, r1, color, noduleRand, wSegs, hSegs, maxCount);
   }
 }
 

--- a/packages/generator/src/tree/variants/claw.ts
+++ b/packages/generator/src/tree/variants/claw.ts
@@ -19,7 +19,9 @@ const CLAW_TIP_RADIUS = 0.002;
 const BEND_ANGLE = Math.PI / 3;
 const CLAW_SPLIT_ANGLE = Math.PI / 8;
 const SEGMENTS = 10;
-const NOISE_AMP = 0.12;
+const NOISE_AMP = 0.15;
+const RIDGE_AMP = 0.12;
+const LENGTH_SUBS = 4;
 
 export function generateClaw(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -46,7 +48,13 @@ export function generateClaw(input: VariantGenerateInput): VariantOutput {
     jitter(rand, TRUNK_BASE_RADIUS, 0.1),
     jitter(rand, TRUNK_MID_RADIUS, 0.1),
     color, SEGMENTS,
-    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 1,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   // Segment 2: bent.
@@ -62,7 +70,13 @@ export function generateClaw(input: VariantGenerateInput): VariantOutput {
     jitter(rand, TRUNK_MID_RADIUS, 0.1),
     jitter(rand, TRUNK_TIP_RADIUS, 0.1),
     color, SEGMENTS,
-    { seed: input.seed * 7 + 2, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 2,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   // Two claw tips with asymmetric split angles.
@@ -91,7 +105,13 @@ export function generateClaw(input: VariantGenerateInput): VariantOutput {
     jitter(rand, CLAW_BASE_RADIUS, 0.1),
     jitter(rand, CLAW_TIP_RADIUS, 0.15),
     color, SEGMENTS,
-    { seed: input.seed * 11 + 3, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 11 + 3,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
   emitFrustum(
     positions, normals, colors, indices,
@@ -99,7 +119,13 @@ export function generateClaw(input: VariantGenerateInput): VariantOutput {
     jitter(rand, CLAW_BASE_RADIUS, 0.1),
     jitter(rand, CLAW_TIP_RADIUS, 0.15),
     color, SEGMENTS,
-    { seed: input.seed * 13 + 4, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 13 + 4,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   return {

--- a/packages/generator/src/tree/variants/forked.ts
+++ b/packages/generator/src/tree/variants/forked.ts
@@ -16,7 +16,11 @@ const BRANCH_BASE_RADIUS = 0.006;
 const BRANCH_TIP_RADIUS = 0.003;
 const BRANCH_ANGLE = Math.PI / 6; // 30°
 const SEGMENTS = 10;
-const NOISE_AMP = 0.12;
+// Displacement amplitude raised so the branch swells visibly (multi-octave
+// noise is applied inside emitFrustum; the amplitude here is per-octave scale).
+const NOISE_AMP = 0.15;
+const RIDGE_AMP = 0.12; // ring-level banding for rib/pinch look
+const LENGTH_SUBS = 4; // intermediate rings for length-wise modulation
 
 export function generateForked(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -43,7 +47,13 @@ export function generateForked(input: VariantGenerateInput): VariantOutput {
     { x: 0, y: 0, z: 0 },
     { x: 0, y: trunkHeight, z: 0 },
     trunkBaseR, trunkTipR, color, SEGMENTS,
-    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 1,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   // Two branches — slightly asymmetric so the Y isn't a mirror.
@@ -66,13 +76,25 @@ export function generateForked(input: VariantGenerateInput): VariantOutput {
     positions, normals, colors, indices,
     { x: 0, y: trunkHeight, z: 0 }, tipA,
     branchBaseR, branchTipR, color, SEGMENTS,
-    { seed: input.seed * 11 + 2, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 11 + 2,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
   emitFrustum(
     positions, normals, colors, indices,
     { x: 0, y: trunkHeight, z: 0 }, tipB,
     branchBaseR, branchTipR, color, SEGMENTS,
-    { seed: input.seed * 13 + 3, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 13 + 3,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   return {

--- a/packages/generator/src/tree/variants/starburst.ts
+++ b/packages/generator/src/tree/variants/starburst.ts
@@ -15,7 +15,9 @@ const TIP_BASE_RADIUS = 0.006;
 const TIP_TIP_RADIUS = 0.002;
 const TIP_ELEVATION = Math.PI / 4;
 const SEGMENTS = 12; // highest among variants — hub is prominent, close to camera
-const NOISE_AMP = 0.14;
+const NOISE_AMP = 0.15;
+const RIDGE_AMP = 0.12;
+const LENGTH_SUBS = 4;
 
 export function generateStarburst(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -35,14 +37,28 @@ export function generateStarburst(input: VariantGenerateInput): VariantOutput {
     { x: 0, y: 0, z: 0 },
     { x: 0, y: hubTall / 2, z: 0 },
     hubR * 0.6, hubR, color, SEGMENTS,
-    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 1,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+      noduleHeightSegs: 3,
+    },
   );
   emitFrustum(
     positions, normals, colors, indices,
     { x: 0, y: hubTall / 2, z: 0 },
     { x: 0, y: hubTall, z: 0 },
     hubR, hubR * 0.6, color, SEGMENTS,
-    { seed: input.seed * 7 + 2, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 2,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+      noduleHeightSegs: 3,
+    },
   );
 
   const hub = { x: 0, y: hubTall / 2, z: 0 };
@@ -74,7 +90,14 @@ export function generateStarburst(input: VariantGenerateInput): VariantOutput {
     emitFrustum(
       positions, normals, colors, indices,
       hub, tip, tipBaseR, tipTipR, color, SEGMENTS,
-      { seed: input.seed * 11 + (i + 1) * 19, noiseAmplitude: NOISE_AMP },
+      {
+        seed: input.seed * 11 + (i + 1) * 19,
+        noiseAmplitude: NOISE_AMP,
+        ridgeAmplitude: RIDGE_AMP,
+        lengthSubdivisions: LENGTH_SUBS,
+        nodulesEnabled: true,
+        noduleHeightSegs: 3,
+      },
     );
     attachPoints.push(tipAttachPoint(tip, dir));
   }

--- a/packages/generator/src/tree/variants/trident.ts
+++ b/packages/generator/src/tree/variants/trident.ts
@@ -17,7 +17,9 @@ const SPIKE_TIP_RADIUS = 0.002;
 const SPIKE_TILT_FROM_VERTICAL = Math.PI / 6;
 const SPIKE_COUNT = 3;
 const SEGMENTS = 10;
-const NOISE_AMP = 0.12;
+const NOISE_AMP = 0.15;
+const RIDGE_AMP = 0.12;
+const LENGTH_SUBS = 4;
 
 export function generateTrident(input: VariantGenerateInput): VariantOutput {
   const positions: number[] = [];
@@ -36,7 +38,13 @@ export function generateTrident(input: VariantGenerateInput): VariantOutput {
     { x: 0, y: 0, z: 0 },
     { x: 0, y: trunkHeight, z: 0 },
     trunkBaseR, trunkTipR, color, SEGMENTS,
-    { seed: input.seed * 7 + 1, noiseAmplitude: NOISE_AMP },
+    {
+      seed: input.seed * 7 + 1,
+      noiseAmplitude: NOISE_AMP,
+      ridgeAmplitude: RIDGE_AMP,
+      lengthSubdivisions: LENGTH_SUBS,
+      nodulesEnabled: true,
+    },
   );
 
   const hub = { x: 0, y: trunkHeight, z: 0 };
@@ -66,7 +74,13 @@ export function generateTrident(input: VariantGenerateInput): VariantOutput {
     emitFrustum(
       positions, normals, colors, indices,
       hub, tip, spikeBaseR, spikeTipR, color, SEGMENTS,
-      { seed: input.seed * 11 + (i + 1) * 17, noiseAmplitude: NOISE_AMP },
+      {
+        seed: input.seed * 11 + (i + 1) * 17,
+        noiseAmplitude: NOISE_AMP,
+        ridgeAmplitude: RIDGE_AMP,
+        lengthSubdivisions: LENGTH_SUBS,
+        nodulesEnabled: true,
+      },
     );
     attachPoints.push(tipAttachPoint(tip, dir));
   }

--- a/packages/generator/src/tree/variants/wishbone.ts
+++ b/packages/generator/src/tree/variants/wishbone.ts
@@ -15,7 +15,9 @@ const ARM_STEPS = 6;
 const BASE_RADIUS = 0.0065;
 const TIP_RADIUS = 0.002;
 const SEGMENTS = 10;
-const NOISE_AMP = 0.12;
+const NOISE_AMP = 0.15;
+const RIDGE_AMP = 0.12;
+const LENGTH_SUBS = 4;
 
 interface Vec3 { x: number; y: number; z: number; }
 
@@ -56,8 +58,19 @@ function emitArm(
     emitFrustum(
       positions, normals, colors, indices, prev, next, r0, r1, color, SEGMENTS,
       // Each bezier segment gets its own seed so surface bumps don't align
-      // into stripes along the curve.
-      { seed: armSeed + i * 23, noiseAmplitude: NOISE_AMP },
+      // into stripes along the curve. Nodule quality is reduced (5w×3h, max 8)
+      // because wishbone has 12 frustum sub-segments and the per-piece vertex
+      // budget (~4000) would otherwise be exceeded.
+      {
+        seed: armSeed + i * 23,
+        noiseAmplitude: NOISE_AMP,
+        ridgeAmplitude: RIDGE_AMP,
+        lengthSubdivisions: LENGTH_SUBS,
+        nodulesEnabled: true,
+        noduleWidthSegs: 5,
+        noduleHeightSegs: 3,
+        noduleMaxCount: 8,
+      },
     );
     prev = next;
   }


### PR DESCRIPTION
## Summary

- Three-pass realism upgrade to branch generation: surface nodules merged into the same BufferGeometry, multi-octave vertex displacement biased outward, subtle per-vertex color tint along each segment. Visual result reads as coral rather than smooth glowing tubes.
- Per-variant vertex counts jump ~25–65×: forked 60 → 1965, claw 80 → 2935, starburst 144 → 3568, trident 80 → 2865, wishbone 240 → 3024. All under the 4000-vert ceiling.
- Clearer hint when a placement would overlap an existing piece: users were reading "That spot is blocked" as a bug; reframed to name the actual cause.

## Commits

- `ff3cf8e` — Tree coral: surface nodules, stronger displacement, per-vertex color tint
- `9236525` — Tree effects: clearer blocked-placement hint

## Architecture

All three passes live in `packages/generator/src/tree/variant.ts`, gated by per-variant options on `EmitFrustumOpts`. Nodule scatter, multi-octave displacement, and color variation are independent PRNG streams (seeded from `opts.seed` with different XOR masks) so toggling one pass doesn't shift the others. Seed-determinism preserved — same seed → identical geometry.

**Pass 1 — Nodules**: 12–22 spheres per cylinder segment, radius 18–32% of segment radius, scattered around the circumference at 10–90% longitudinal position. Each sphere emitted directly into the same positions/normals/indices arrays as the parent frustum (no extra draw calls).

**Pass 2 — Multi-octave displacement**: 2–3 noise octaves with halving amplitude, ~12–18% of segment radius peak amplitude, biased outward (+ amplitude ×1.0, − amplitude ×0.4) so branches swell rather than neck in.

**Pass 3 — Per-vertex color tint**: low-frequency noise along the segment's length axis, ±8% per-channel shift. Applied before nodules inherit their base color, so nodules pick up the local shade.

## Known behavior change (flagged, not addressed in this PR)

Nodules inflate each piece's AABB by roughly 32% of segment radius outward. The client's AABB-vs-AABB collision check ([DECISIONS.md 2026-04-22](../docs/DECISIONS.md)) now fires more often because the *fatter* bounding box is what collides.

This is correct per the collision rule ("two branches shouldn't occupy the same space") — the new hint ("Adding a piece here would touch another. Try another dot or reroll.") reflects that. If packing density becomes a problem in practice, the follow-up is to compute the collision AABB from skeleton-only positions (pre-nodule) and keep the render AABB for frustum culling. Not in this PR; escalate if needed.

## Test plan

- [x] `pnpm --filter @reef/generator test` — 54/54 pass (bounding-box tolerances updated to match inflated AABBs)
- [x] `pnpm --filter @reef/client test` — 328/328 pass
- [x] `pnpm --filter @reef/server test` — 97/97 pass
- [x] `pnpm -r typecheck` — clean
- [ ] Manual smoke: load `http://localhost:5173/tree.html`, plant pieces, confirm they read as coral and not smooth tubes

## Follow-ups (not in this PR)

1. Compute collision AABB from skeleton-only positions if packing density becomes a real issue.
2. Material polish to complement the bumpier geometry (slightly higher roughness suggested in the agent's self-review).
3. Channel-independent color tint (red shifts slightly more than blue for biological accuracy).
