### PR TITLE
Tree mode: persisted yaw + AR Phase 2 + collision polish

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,14 +15,20 @@ Related docs:
 
 ## Current state
 
-- **Main branch CI**: green. 313 tests pass across 4 packages (shared 19 /
-  generator 54 / server 92 / client 148).
+- **Main branch CI**: green. 434 tests pass across 4 packages (shared 21 /
+  generator 54 / server 99 / client 334 as of tree-overnight tip; +121
+  from the mid-April baseline as the tree surface has grown).
 - **Deployed version**: v0.4.0 live on the Beelink LXC at
-  `https://reef.home.local/`. Three surfaces available:
-  `index.html` (AR, phone), `playground.html` (orbit camera, desktop),
-  `playground.html?mode=screen` (auto-orbit, museum display).
-- **Latest**: tree mode (third surface) — fully implemented. Phase 2
-  (AR client migration) ahead.
+  `https://reef.home.local/`. Three surfaces available on main:
+  `index.html` (AR landscape, phone), `playground.html` (orbit camera,
+  desktop), `playground.html?mode=screen` (auto-orbit, museum display),
+  `tree.html` (desktop tree sandbox — PRs #73-#77).
+- **In flight on `tree-overnight`**: Phase A (persisted drag yaw,
+  committed) + Phase B (AR client reads tree data — in progress via
+  background agent). Not yet a PR. See
+  `docs/superpowers/specs/2026-04-24-ar-phase-2-migration.md` for design
+  rationale and `docs/superpowers/plans/2026-04-24-ar-phase-2-migration.md`
+  for task breakdown.
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
   @fastify/cors 9 (pinned — issue #54 tracks Fastify 5 migration) ·
   node:25-alpine · happy-dom 19 · Oxlint.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -10,6 +10,157 @@ history see [`CHANGELOG.md`](../CHANGELOG.md).
 
 ---
 
+## 2026-04-24 — Persisted drag yaw lives in the state machine, applied around the attach-point normal
+
+**Context:** Visitors could drag to rotate the ghost of a pending coral
+piece, but the rotation was visual-only. On commit, the POST payload
+didn't include yaw and the server had no column for it, so the committed
+piece rendered at the canonical attach-normal orientation and "snapped
+back" from the user's drag. User-reported.
+
+Separately, `TreePlacement.rotateGhost` used `mesh.rotateY(delta)` after
+`mesh.applyMatrix4(worldMatrix)` had baked the alignment transform
+into vertex positions. With an identity transform post-bake, `rotateY`
+rotated around world +Y — which was only the attach normal for the tree
+root, not side branches.
+
+**Options considered:**
+1. Add `attachYaw` as a transient client-only field on `TreeReef.addPiece`
+   so the committed piece gets the rotation applied at render time
+2. Persist `attachYaw` through the full stack (schema → server → wire →
+   client state → render) — matches `attachIndex` pattern
+3. Store the combined orientation as a quaternion rather than a scalar
+   yaw, to support arbitrary free rotation later
+
+**Decision:** Option 2 — `attachYaw: number` (radians) persisted end-to-end.
+SQLite column added via imperative pragma-guarded ALTER in `ReefDb.migrate`
+(ALTER TABLE ADD COLUMN has no IF NOT EXISTS form). Yaw is tracked on
+`placing` + `submitting` state kinds as `yawRad`, accumulated via new
+`GHOST_ROTATED` action. Effects layer calls `placement.rotateGhost` only
+via state dispatch — no direct mutation path.
+
+Separately, `TreePlacement.showGhost` no longer bakes the world matrix
+into vertex positions. The mesh keeps a live `position`/`quaternion`
+transform, and `rotateGhost` uses `rotateOnWorldAxis(attachNormal, delta)`
+so the pivot axis matches what `TreeReef.addPiece` applies at commit.
+
+**Rationale:**
+- Scalar yaw matches the UX: drag rotates in one plane around the
+  attach normal. A full quaternion is unnecessary complexity for now.
+- Single source of truth in state machine; the reducer tests already
+  cover carry-across transitions (GROW_CLICKED, COMMIT_REJECTED).
+- Pivoting via `rotateOnWorldAxis` through a live transform avoids
+  accumulating rounding error from repeated vertex-matrix applications.
+
+**Trade-offs accepted:**
+- Migration is imperative in `db.ts`, breaking the otherwise
+  all-SQL-file migration pattern. Contained to one `ensureColumn` helper.
+- Client + server need a coordinated deploy: a client that sends
+  `attachYaw` to a server without the column will 500 on insert. Safe
+  because the deploy pipeline updates both together.
+
+**Artifacts:** commits `a10004e` (server), `c761e2c` (client), on the
+`tree-overnight` branch.
+
+---
+
+## 2026-04-24 — AR Phase 2 migration is a new surface (`treeAr.html`), not a query-param fork of `index.html`
+
+**Context:** `DECISIONS.md 2026-04-22` ("Tree mode Phase 1 → Phase 2
+staging") committed to migrating the AR client to read tree data once
+tree-mode visuals felt right. The original spec (first pass) proposed a
+`?reef=tree` query param inside `index.html` to swap between landscape
+and tree without a new HTML file.
+
+Verification showed each existing surface has its own hand-crafted HTML
+with surface-specific picker markup: `index.html` hardcodes landscape
+species (branching/bulbous/fan/tube/encrusting), `tree.html` hardcodes
+tree variants (forked/trident/starburst/claw/wishbone). A query-param
+fork would have to inject markup at runtime for the non-default surface,
+or keep both pickers in one DOM and hide one.
+
+**Decision:** Add `treeAr.html` + `packages/client/src/treeAr.ts` +
+`packages/client/src/treeApp.ts` as a fourth surface. Composition pattern
+for `TreeApp`: import the same `TreeReef`, `TreePlacement`,
+`AttachIndicators`, `TreePicker`, state machine, effects, socket the
+desktop `tree.html` uses. Drops desktop-only pieces: no `OrbitControls`,
+no `createUnderwaterBackground`, no `createUnderwaterFog`, no
+`createBloomComposer`. Keeps `installUnderwaterLighting`.
+
+`Reef.applyAnchorPose` lifted from a static method on the landscape
+`Reef` class to `packages/client/src/tracking/anchor.ts` as a shared
+helper. Takes an optional `scaleMultiplier` (default 1) so `TreeApp`
+can request room-scale rendering by passing e.g. 5.
+
+**Rationale:**
+- Matches existing project pattern (one HTML per surface).
+- `TreeApp` imports existing modules instead of forking them; zero
+  duplication of the state machine or the effects runner.
+- Landscape surface stays fully intact; `?reef=landscape` continues to
+  work. Retirement of the landscape client is a follow-up PR after
+  field validation.
+- `scaleMultiplier` is a single knob at the anchor level, not a
+  pervasive change to generator units or collision constants.
+
+**Trade-offs accepted:**
+- Two AR surfaces deployed side-by-side during transition period. Visitors
+  get different experiences depending on URL until retirement happens.
+- Bloom is off for the first AR migration; the palette will look duller
+  on phones than on desktop. Accepted per earlier decision on bloom cost
+  on mobile GPUs; revisit with a Kawase-style cheap preset if needed.
+
+**Artifacts:** spec at `docs/superpowers/specs/2026-04-24-ar-phase-2-migration.md`,
+plan at `docs/superpowers/plans/2026-04-24-ar-phase-2-migration.md`,
+commits `8f5c2cf`, `6b93e84`, `282b8ed`, `f986fcb`, `bc077aa`, `daded10`
+on `tree-overnight`.
+
+---
+
+## 2026-04-24 — Collision AABBs shrink by 15% before intersection test
+
+**Context:** The coral-realism pass (PR #77) added surface nodules that
+extend roughly 20–30% of segment radius outward from the skeleton
+cylinder. Nodule vertices are included in `computeAABB(positions)`, so
+each piece's world AABB is noticeably wider than its skeleton cylinder.
+Users started hitting "That spot is blocked" on attach slots that
+visually had clear space between skeleton cylinders. User-reported.
+
+**Options considered:**
+1. Compute a skeleton-only AABB in the generator (separate positions
+   tracker before nodule emit), expose as a second output field,
+   `TreePlacement` uses it for collision
+2. Shrink both boxes by a constant factor around their centers before
+   the intersection test in `wouldCollide`
+3. Keep behavior; just update the hint wording to explain the "touching"
+   behavior as intentional (the already-landed hint fix)
+
+**Decision:** Both (3) — the hint clarifies intent — AND (2), the shrink
+factor, for the user's practical complaint. Skipped (1) for now because
+it requires restructuring `emitFrustum` to surface skeleton vs full
+positions, and the shrink approximation is close enough (0.85 ≈
+skeleton/full ratio across the five variants).
+
+**Rationale:**
+- Shrinking each box by 15% around the center permits the shrunk boxes
+  to pass through each other exactly when the skeleton cylinders would
+  clear — the nodule envelopes can graze without the placement check
+  seeing it as overlap.
+- Low-risk one-file change in `collision.ts`, no generator work needed,
+  no cross-package coordination.
+- User can revert or tighten by adjusting a single constant.
+
+**Trade-offs accepted:**
+- The shrink is a uniform approximation; variants whose nodule/skeleton
+  ratio is higher than 0.85 might still hit false blocks, and variants
+  with lower ratios might permit slightly-overlapping skeletons.
+- Not a principled physical-collision model; escalating to capsule-vs-
+  capsule or skeleton-only AABB remains the future path if the
+  approximation proves too loose in practice.
+
+**Artifacts:** commit `8f51810` on `tree-overnight`.
+
+---
+
 ## 2026-04-19 — Migrate from retired hosted 8th Wall to self-hosted engine binary
 
 **Context:** 8th Wall's hosted platform (`apps.8thwall.com/xrweb?appKey=…`)

--- a/docs/superpowers/plans/2026-04-24-ar-phase-2-migration.md
+++ b/docs/superpowers/plans/2026-04-24-ar-phase-2-migration.md
@@ -1,0 +1,251 @@
+# AR Phase 2 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `treeAr.html` — a new AR surface that renders the tree reef through the 8th Wall tracker, reusing tree-mode's existing state machine, effects runner, TreeReef, TreePlacement, TreePicker, and socket. Landscape surface untouched.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-ar-phase-2-migration.md`. Read before starting.
+
+**Branch:** stacked on current development (tree-coral-realism → tree-ui-undo → main). Target `main`; rebase as needed before the PR.
+
+**Defaults locked (not knobs to ask about):**
+
+- `SCALE = 5` (reef anchor scale multiplier; tune in the field via follow-up)
+- Creatures live under `treeReef.anchor` (inherit scale)
+- Landscape surface stays indefinitely — retirement is a follow-up PR
+
+## File structure
+
+**New:**
+
+- `packages/client/src/tracking/anchor.ts` — `applyAnchorPose(anchor: Group, poseMatrixElements: ArrayLike<number>, scaleMultiplier?: number): void`
+- `packages/client/src/tracking/anchor.test.ts` — unit tests for the helper
+- `packages/client/src/treeApp.ts` — `TreeApp` class (AR orchestrator using tree data)
+- `packages/client/src/treeAr.ts` — bootstrap (≈25 lines, parallel to `main.ts`)
+- `packages/client/treeAr.html` — HTML entry, tree picker markup, 8th Wall script tag
+
+**Modified:**
+
+- `packages/client/src/scene/reef.ts` — delete the static `Reef.applyAnchorPose` method; replace its usage in `app.ts` with the shared helper import. Behavior preserved.
+- `packages/client/src/app.ts` — import + call `applyAnchorPose` from the new shared module (1-line change at line 89).
+- `packages/client/src/tree.ts` — add creatures under `treeReef.anchor` instead of `scene`. Four lines change (the four spawn helpers). Preserves tree.html visuals.
+
+**Unchanged (verified before starting):**
+
+- `packages/client/src/tree/{state,effects,reef,placement,indicators,variants,material,scene,config,api,shark,clownfish,jellyfish,seaTurtle,pulse}.ts`
+- `packages/client/src/tracking/{eightwall,noop,index}.ts`
+- `packages/client/src/ui/treePicker.ts`
+- `packages/generator/**/*`, `packages/server/**/*`, `packages/shared/**/*`
+
+---
+
+## Task 1: Shared `applyAnchorPose` helper
+
+Extract the static method from `Reef` into a pose-agnostic module so both `App` (landscape) and `TreeApp` (AR tree) can use it. Add an optional `scaleMultiplier` argument.
+
+**Files:**
+- Create: `packages/client/src/tracking/anchor.ts`
+- Create: `packages/client/src/tracking/anchor.test.ts`
+- Modify: `packages/client/src/scene/reef.ts` (remove static method)
+- Modify: `packages/client/src/app.ts` (swap call site)
+
+- [ ] **Step 1: Write failing tests** in `anchor.test.ts`:
+  - Identity pose with `scaleMultiplier` undefined → anchor position `(0,0,0)`, quaternion identity, scale `(1,1,1)`.
+  - Identity pose with `scaleMultiplier = 5` → scale `(5,5,5)`.
+  - Non-identity pose (translation `(1,2,3)`) → position applied, `scaleMultiplier = 2` multiplies decomposed scale.
+  - Empty or non-16-length array input → no-op (behavior from existing static method).
+
+- [ ] **Step 2: Verify failure.** `pnpm --filter @reef/client test src/tracking/anchor.test.ts`
+
+- [ ] **Step 3: Implement** `anchor.ts`:
+
+  ```ts
+  import { Group, Matrix4, Quaternion, Vector3 } from 'three';
+
+  export function applyAnchorPose(
+    anchor: Group,
+    poseMatrixElements: ArrayLike<number>,
+    scaleMultiplier = 1,
+  ): void {
+    if (poseMatrixElements.length !== 16) return;
+    const m = new Matrix4();
+    const te = m.elements;
+    for (let i = 0; i < 16; i++) te[i] = poseMatrixElements[i] ?? 0;
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const scl = new Vector3();
+    m.decompose(pos, quat, scl);
+    anchor.position.copy(pos);
+    anchor.quaternion.copy(quat);
+    anchor.scale.copy(scl.multiplyScalar(scaleMultiplier));
+    anchor.matrix.copy(m);
+  }
+  ```
+
+- [ ] **Step 4: Remove `Reef.applyAnchorPose` static method** from `scene/reef.ts` and replace the call at `app.ts:89` with `applyAnchorPose(this.reef.anchor, pose.elements)` imported from `./tracking/anchor.js`.
+
+- [ ] **Step 5: Verify.** `pnpm --filter @reef/client typecheck && pnpm --filter @reef/client test`. All tests pass.
+
+- [ ] **Step 6: Commit.**
+
+  ```
+  Tracking: extract applyAnchorPose to shared helper + scaleMultiplier
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 2: Reparent creatures under tree anchor
+
+Creatures currently attach to `scene` in `tree.ts`. Reparenting them to `treeReef.anchor` means they move with the SLAM pose in AR and inherit the anchor scale. Tree.html's desktop view is unaffected because the anchor's transform is identity there.
+
+**Files:**
+- Modify: `packages/client/src/tree.ts` (four spawn helpers)
+
+- [ ] **Step 1: Change the four `spawnX()` functions** in `tree.ts` — replace `scene.add(X.group)` with `treeReef.anchor.add(X.group)` in each of `spawnShark`, `spawnClownfish`, `spawnJellyfish`, `spawnSeaTurtle`.
+
+- [ ] **Step 2: Verify.** `pnpm --filter @reef/client typecheck && pnpm --filter @reef/client test`. All tests pass; existing creature tests don't assert scene graph parentage.
+
+- [ ] **Step 3: Manual sanity** — reload `http://localhost:5173/tree.html`, spawn each creature, confirm they still orbit the tree visually (they should; the anchor is at origin in tree.html).
+
+- [ ] **Step 4: Commit.**
+
+  ```
+  Tree: add creatures under treeReef.anchor for AR anchor inheritance
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 3: `treeAr.html` + `treeAr.ts` bootstrap skeleton
+
+The landing page + 8th Wall script tag + picker markup + start button, and a minimal bootstrap that instantiates `TreeApp` (which doesn't exist yet — stub it).
+
+**Files:**
+- Create: `packages/client/treeAr.html`
+- Create: `packages/client/src/treeAr.ts`
+- Create: `packages/client/src/treeApp.ts` (skeleton: empty `TreeApp` class with `start()` / `stop()` no-ops)
+
+- [ ] **Step 1: Write `treeAr.html`** — copy structure from `index.html` (landing, `#cam`, `#gl`, `#status`) but use the tree picker markup from `tree.html` (forked/trident/starburst/claw/wishbone, reroll/cancel/grow/hint). Keep the 8th Wall script tag. Include mode-badge and the sea-life toolbar+panel markup from `tree.html` so users get the same controls. `<script type="module" src="/src/treeAr.ts"></script>`.
+
+- [ ] **Step 2: Write `treeAr.ts`** — copy structure from `main.ts`. Read config via `readTreeConfig()`. Instantiate `TreeApp` with the canvas/video/picker/status elements. On Start-button click, call `treeApp.start()`.
+
+- [ ] **Step 3: Write skeleton `treeApp.ts`** — export `TreeApp` class with constructor params matching `AppOptions` (canvas, video, pickerRoot, statusEl), plus `start(): Promise<void>` and `stop(): void` methods that are no-ops.
+
+- [ ] **Step 4: Verify.** `pnpm --filter @reef/client typecheck`. Opening `http://localhost:5173/treeAr.html` should show the landing page with the Start button.
+
+- [ ] **Step 5: Commit.**
+
+  ```
+  Tree AR: scaffold treeAr.html + treeAr.ts bootstrap + empty TreeApp class
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 4: `TreeApp` — scene, camera, tracker, render loop
+
+Fill in the scaffold. Renderer is transparent (alpha) for camera passthrough. No underwater background, no fog, no bloom. Underwater lighting retained. No `OrbitControls`.
+
+**Files:**
+- Modify: `packages/client/src/treeApp.ts`
+
+- [ ] **Step 1: Implement** the renderer + scene + camera + tracker lifecycle, mirroring `app.ts:47–114` but swapping:
+  - `Reef` → `TreeReef` (create `this.treeReef = new TreeReef()`; add `this.treeReef.anchor` to the scene).
+  - `installLighting` → `installUnderwaterLighting` (from `./tree/scene.js`).
+  - No `createUnderwaterBackground`, no `createUnderwaterFog`, no `createBloomComposer`.
+  - In `onAnchorFound`: call `applyAnchorPose(this.treeReef.anchor, pose.elements, SCALE)` with `SCALE = 5` module-level constant.
+  - Render loop: `this.renderer.render(this.scene, this.camera)` directly (no bloom composer).
+
+- [ ] **Step 2: Verify typecheck.** Browser: open `treeAr.html`, tap Start, point at the 8th Wall marker. Anchor should find + scene should render (empty tree, no polyps yet — that's Task 5).
+
+- [ ] **Step 3: Commit.**
+
+  ```
+  Tree AR: TreeApp scene + camera + tracker lifecycle
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 5: `TreeApp` — state machine, picker, tap-to-attach
+
+Wire the existing state machine (same `reduce`, same `createEffects`) into `TreeApp`. Wire the picker. Implement tap-to-attach that raycasts against `attachIndicators.group.children` and dispatches `ATTACH_CLICKED`.
+
+**Files:**
+- Modify: `packages/client/src/treeApp.ts`
+
+- [ ] **Step 1: Compose modules** — instantiate `TreePlacement`, `AttachIndicators`, `TreePicker` inside `TreeApp`. Add their groups/anchors under `treeReef.anchor` (not scene) so they inherit the SLAM pose + scale.
+
+- [ ] **Step 2: Wire state machine** — `let state = initialState(picker.get())`; implement `dispatch(action)` that calls `reduce` then `effects.apply(prev, next, action)`. `createEffects` gets `{ placement, treeReef, indicators, picker, hintEl, apiBase, dispatch, addPiecesAndRefresh }` exactly like `tree.ts`.
+
+- [ ] **Step 3: Wire picker** — `picker.onChange`, `onReroll`, `onCancel`, `onCommit` → dispatch. Identical to `tree.ts`.
+
+- [ ] **Step 4: Wire tap-to-attach** — in `handleTap(x, y)` raycast against `attachIndicators.group.children` (not against a reef ground plane like landscape). On hit, dispatch `ATTACH_CLICKED` with the indicator's `userData.parentId` / `userData.attachIndex`.
+
+- [ ] **Step 5: Wire initial fetch** — `fetchTree(apiBase).then(...)` → `addPiecesAndRefresh(polyps)`. Same pattern as tree.ts.
+
+- [ ] **Step 6: Wire socket** — `TreeSocket` on the appropriate WS URL, dispatch tree messages.
+
+- [ ] **Step 7: Verify.** Browser smoke test on desktop via `?tracker=noop` query (uses `NoopProvider`, which pins the anchor in front of the camera — lets us iterate without the physical marker). Tree should render, tap an indicator, ghost appears, Grow commits.
+
+- [ ] **Step 8: Commit.**
+
+  ```
+  Tree AR: TreeApp state machine + picker + tap-to-attach + socket
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 6: `TreeApp` — toolbar (Clear, Undo, creatures)
+
+Wire the existing toolbar buttons in `treeAr.html` to dispatches / spawn helpers. Creature spawn helpers add to `treeReef.anchor` (not `scene`), reusing the same pattern from tree.ts (post-Task-2).
+
+**Files:**
+- Modify: `packages/client/src/treeApp.ts`
+
+- [ ] **Step 1: Wire Clear, Undo** to `dispatch({ type: 'CLEAR_CLICKED' })` and `dispatch({ type: 'UNDO_CLICKED' })`.
+
+- [ ] **Step 2: Wire the sea-life panel** toggle + `+`/`−` buttons to the creature spawn/remove helpers.
+
+- [ ] **Step 3: Wire creature count refresh** matching tree.ts's `refreshPanel` pattern.
+
+- [ ] **Step 4: Verify.** `pnpm --filter @reef/client typecheck && pnpm --filter @reef/client test`. Browser smoke: Clear, Undo, add/remove each creature type.
+
+- [ ] **Step 5: Commit.**
+
+  ```
+  Tree AR: TreeApp toolbar + sea-life panel wiring
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Task 7: Field smoke test + PR
+
+Full workspace verification, then real-device AR smoke test.
+
+- [ ] **Step 1: Workspace check.** `pnpm -r typecheck && pnpm -r test`. All green.
+
+- [ ] **Step 2: Local dev smoke** — `pnpm --filter @reef/client dev` + `pnpm --filter @reef/server dev`. Load `http://localhost:5173/tree.html` (desktop tree — should be unchanged) and `http://localhost:5173/treeAr.html?tracker=noop` (AR tree via noop — should render with pinned anchor).
+
+- [ ] **Step 3: Physical marker smoke** — deploy to the LXC (or serve over local HTTPS so 8th Wall will run), open `treeAr.html` on a phone, point at the printed marker. Verify: anchor finds, tree renders at SCALE=5 (~2.5m tall), tap-to-attach works, indicators are reachable at arm's length.
+
+- [ ] **Step 4: PR** — target `main`. Body: spec link + per-task commit list + test plan (desktop smoke, marker smoke, both landscape + tree AR surfaces still load). Drafted via `draft-review-post` skill; wait for explicit approval.
+
+---
+
+## Follow-ups (not in this plan)
+
+1. Retire landscape surface — delete `app.ts`, `scene/reef.ts`, `placement.ts`, landscape `Picker`, `FishSchool`. Own PR after field validation.
+2. Mobile-safe bloom preset for AR tree.
+3. Two-finger gesture for ghost rotation in AR.
+4. Persisted drag yaw.
+5. Dynamic SCALE control (pinch-to-resize or picker slider).

--- a/docs/superpowers/specs/2026-04-24-ar-phase-2-migration.md
+++ b/docs/superpowers/specs/2026-04-24-ar-phase-2-migration.md
@@ -1,0 +1,94 @@
+# AR Phase 2 — Tree Data in the AR Client
+
+## Context
+
+[DECISIONS.md 2026-04-22](../../DECISIONS.md) ("Tree mode Phase 1 → Phase 2 staging") promises that once tree-mode visuals feel right, the AR client migrates to read tree data. The pedestal on `tree.html` becomes a portal into the same fractal reef the AR client renders.
+
+Current state (verified):
+
+- `packages/client/src/app.ts` is the AR entry. It composes `Reef` (`packages/client/src/scene/reef.ts`), `Placement` (`packages/client/src/placement.ts`), `Picker` (`packages/client/src/ui/picker.ts`), `fetchReef`/`submitPolyp`, and `ReefSocket` (`polyp_added` / `polyp_removed` / `sim_update` / `hello`).
+- The 8th Wall `TrackingProvider` (`packages/client/src/tracking/eightwall.ts`) emits `onAnchorFound({ pose })`; the app passes `pose.elements` into `Reef.applyAnchorPose(this.reef.anchor, pose.elements)` at `app.ts:89`. This static helper decomposes the 16-element matrix into `position/quaternion/scale` on the anchor `Group`. Everything else lives under that anchor and moves with it.
+- Tree mode's `TreeReef` (`packages/client/src/tree/reef.ts`) owns its own `anchor: Group`, already bakes piece transforms into vertex positions under it, and exposes `allPieces()` / `getAvailableAttachPoints()` / `clear()`. It has no `applyAnchorPose` method — `Reef.applyAnchorPose` is pose-agnostic though (just decomposes a matrix onto any `Group`), so the same static helper works for a `TreeReef.anchor`.
+- Sea-life creatures (`Shark`, `Clownfish`, `Jellyfish`, `SeaTurtle`) are currently added to `scene` directly in `tree.ts`, not under `treeReef.anchor`. In AR that means they'd orbit the world origin instead of the marker. They need to move under the tree anchor during migration.
+- `DECISIONS.md 2026-04-22` ("Avatar-bioluminescent aesthetic for tree mode") explicitly notes: "Bloom costs 2-4ms/frame on modern GPUs — trivial for desktop screen view, potentially rough for phone AR (which is why this aesthetic is scoped to tree mode, not the existing AR client)." Bloom will need a mobile-AR preset or to be off entirely in the first migration.
+
+## Goals
+
+1. AR client renders the tree reef, not the landscape reef. Marker-found → tree anchored to marker, visitors can add/remove branches through the same state machine tree mode already uses.
+2. Preserve the 8th Wall tracking lifecycle (`onAnchorFound` / `onAnchorLost` / anchor visibility) with no regressions. Tracking isn't touched.
+3. Creatures live under the tree anchor so they move with the marker, not the world.
+4. Introduce a single scale factor at the anchor level so "room-filling" is one config knob (default set once, tunable per deployment or via query param for site-testing).
+5. Coexist with the landscape surface during migration — don't delete anything landscape-related until Phase 2 is proven in the field.
+
+## Non-goals
+
+- Any changes to the tree-mode state machine (`state.ts` / `effects.ts`) or generator. The AR client hosts the same state machine; it's just a different orchestrator calling `reduce` / `effects.apply`.
+- WebXR. 8th Wall stays. This doc is about data/source swap, not tracker swap.
+- Landscape retirement. Landscape reef, `Reef`, landscape `Placement`, `FishSchool`, `ReefSocket`'s `sim_update` path remain intact and reachable via an opt-out path until a follow-up PR deletes them.
+- New interaction patterns. Tap-an-attach-indicator is the interaction; same as tree mode.
+- 2+ branches per attach point, persisted drag yaw, rejection toasts — same deferrals DECISIONS.md and the state-machine spec already list.
+
+## Architecture
+
+Three decisions shape the migration:
+
+### D1 — New surface alongside existing, not destructive rewrite
+
+The project already follows a "one HTML file per surface" pattern: `index.html` (AR landscape), `tree.html` (desktop tree), `playground.html` (desktop orbit). `index.html` hardcodes the landscape picker species in markup; `tree.html` hardcodes the tree variants. A query-param fork inside `index.html` would mix the two picker markups.
+
+Phase 2 introduces a fourth surface: `treeAr.html` (AR tree data), bootstrapped by `packages/client/src/treeAr.ts`, which instantiates a new `TreeApp` class. It imports the same `TreeReef` / `TreePlacement` / `TreePicker` / state machine the desktop `tree.html` uses, plus the 8th Wall `TrackingProvider` the existing `app.ts` uses.
+
+`index.html` + `app.ts` + landscape `Reef` keep working unchanged. `treeAr.html` lingers as the AR tree testbed until field-validated, at which point a follow-up PR either retires the landscape surface (rename `treeAr.html` → `index.html`) or keeps both as separate deployed entry points.
+
+### D2 — TreeApp composes existing tree-mode modules, not parallel copies
+
+`TreeApp` (`packages/client/src/treeApp.ts`) imports the same `TreeReef`, `TreePlacement`, `AttachIndicators`, `TreePicker`, `initialState` + `reduce`, `createEffects` that `tree.ts` uses. No forks. The differences from `tree.ts` are:
+
+- No `OrbitControls`. Camera is driven by the tracker, not user input.
+- No `createUnderwaterBackground`, no `createUnderwaterFog`. In AR the background is the camera feed (`clearColor` stays transparent on `WebGLRenderer(alpha:true)`, as in current `app.ts`). Fog would interfere with passthrough.
+- `installUnderwaterLighting` is kept (tree mode relies on it for the bioluminescent palette), but `createBloomComposer` is replaced by a direct `renderer.render(scene, camera)` for the first migration. A mobile-safe bloom preset can land as a follow-up.
+- No pointer-drag rotation of the ghost for the first cut. Keep placement dead-simple: tap an attach indicator, preview the ghost, commit via the Grow button. Drag rotation can reappear as a two-finger gesture in a follow-up if needed.
+- `Reef.applyAnchorPose` is lifted to a shared helper `applyAnchorPose` in `packages/client/src/tracking/anchor.ts` (pose-agnostic; both landscape and tree anchors call it). No behavior change.
+- Tap-to-attach raycasts against `attachIndicators.group.children` (same as current `tree.ts`), but takes the screen coords from `touchend`/`click` the same way `app.ts` does. The two-finger gesture path from `app.ts` is not brought over (no ghost rotation in v1).
+
+The state machine is identical to tree-mode's. Picker, collision, reset flow, WebSocket message handling — all reused verbatim by importing the same modules.
+
+### D3 — Scale at the anchor, not at the generator
+
+`TreeApp` sets `treeReef.anchor.scale.setScalar(SCALE)` before the first pose arrives. The anchor's transform is what `applyAnchorPose` writes to on every anchor-found. Since the static helper decomposes the pose matrix and writes `position/quaternion/scale` directly, it will *overwrite* any pre-set scale on the next `onAnchorFound` call.
+
+The fix: `applyAnchorPose` takes an optional third argument `scaleMultiplier` that multiplies the decomposed scale before it's applied. Default 1 preserves current behavior. `TreeApp` passes e.g. 5 to target a ~2–3m tall reef anchored to the marker.
+
+Open tuning knobs (first cut values, iterate in the field):
+
+- `SCALE = 5` — visual size of the full reef. 1 would match tree.html desktop scale (~50cm); 5 makes pieces ~75cm tall → full reef up to 2.5m.
+- No change to piece-internal dimensions (generator output stays). Collision AABBs, attach-point distances, indicator radii all scale uniformly with the anchor.
+- Scale also modifies the tap-raycast hit radius on indicators — no special handling needed, the proxy sphere geometry (`packages/client/src/tree/indicators.ts`) scales with its parent.
+
+## Risks and open questions
+
+**Creature orbit centers.** Sharks/clownfish/jellyfish/turtles compute positions from world-origin in the current tree mode. Under the anchor, world-origin lives at the marker after transform. But the orbit radius itself is scene-units; with `SCALE = 5`, a 0.3-unit shark orbit becomes a 1.5m radius swim loop around the reef — probably too big for a marker-tabletop setup, probably right for a room-scale install. **Decision needed**: apply the anchor scale to creature group too (creatures stay proportional to reef), or keep creature radii in absolute scene units and add scale-aware spawn params. First cut: add them under `treeReef.anchor` so they inherit the scale; tune orbit radii in spawn functions if they end up too wide.
+
+**SLAM drift at distance.** 8th Wall's accuracy degrades with distance from the printed marker. A room-filling reef implies the visitor walks around it — they'll be 2–4m from the marker for long stretches. We don't have field data on drift at those distances. Mitigation options (not part of this spec; resurface if observed): larger marker, multi-marker anchor, or scale down if wobble is unacceptable.
+
+**Mobile GPU budget without bloom.** Tree mode's palette depends on bloom for the glow look. Without bloom in AR, the material's `emissive` still brightens surfaces but doesn't produce halos. Visitors on the AR client will see a duller version of the desktop tree look. Option to revisit: a cheap "kawase blur + additive" cut of bloom tuned for mobile — ~1ms/frame instead of 2–4. Ship without bloom first, add back on measurement.
+
+**Anchor scale + gestures.** `TreePlacement`'s collision and attach-point math all run in world space post-anchor-transform. Read through to confirm no assumptions about unit magnitude (e.g., minimum spacing constants hard-coded in meters-or-whatever). If any exist, multiply them by `SCALE` or factor the scale into the collision check.
+
+## Out of scope follow-ups
+
+1. Retire landscape client entirely — delete `app.ts`, `scene/reef.ts`, `placement.ts`, `FishSchool`, landscape `Picker`, landscape API/socket. Own PR after field validation.
+2. Pointer/two-finger drag to rotate the ghost in AR.
+3. Bloom preset for mobile AR.
+4. Persisted drag yaw (same follow-up as tree mode).
+5. Multi-marker or device-world-mesh anchoring for larger spaces.
+6. Dynamic scale adjustment (slider in picker UI, or pinch-to-resize via two-finger gesture).
+
+## Success criteria
+
+1. Open `https://reef.home.local/?reef=tree` on a supported phone (8th Wall's required Safari/Chrome versions).
+2. Point at the printed marker → tree anchor appears, any existing tree polyps render.
+3. Tap an attach indicator → ghost previews, Grow button activates.
+4. Tap Grow → piece commits, WebSocket echo updates the picker hint.
+5. Walk around the reef → tracking holds, pieces stay where they were placed.
+6. `?reef=landscape` still works (landscape reef still renders as before).

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -11,6 +11,7 @@ import { fetchReef, submitPolyp, RateLimitError } from './net/api.js';
 import { ReefSocket, defaultWsUrl } from './net/ws.js';
 import { readTrackerFromUrl, selectProvider } from './tracking/index.js';
 import { EightWallProvider } from './tracking/eightwall.js';
+import { applyAnchorPose } from './tracking/anchor.js';
 import type { TrackingProvider } from '@reef/shared';
 
 export interface AppOptions {
@@ -86,7 +87,7 @@ export class App {
       canvasElement: this.opts.canvas,
     });
     this.tracker.onAnchorFound(({ pose }) => {
-      Reef.applyAnchorPose(this.reef.anchor, pose.elements);
+      applyAnchorPose(this.reef.anchor, pose.elements);
       this.reef.anchor.visible = true;
       this.setStatus('Tap a spot to place your polyp.');
       this.picker.show();

--- a/packages/client/src/scene/reef.ts
+++ b/packages/client/src/scene/reef.ts
@@ -1,4 +1,4 @@
-import { Group, Object3D, Quaternion, Vector3 } from 'three';
+import { Group, Object3D, Vector3 } from 'three';
 import type { PublicPolyp, SimDelta } from '@reef/shared';
 import { generatePolyp } from '@reef/generator';
 import { polypMesh } from './meshAdapter.js';
@@ -102,16 +102,4 @@ export class Reef {
     return result;
   }
 
-  static applyAnchorPose(anchor: Group, poseMatrixElements: ArrayLike<number>): void {
-    if (poseMatrixElements.length !== 16) return;
-    const te = anchor.matrix.elements;
-    for (let i = 0; i < 16; i++) te[i] = poseMatrixElements[i] ?? 0;
-    const pos = new Vector3();
-    const quat = new Quaternion();
-    const scl = new Vector3();
-    anchor.matrix.decompose(pos, quat, scl);
-    anchor.position.copy(pos);
-    anchor.quaternion.copy(quat);
-    anchor.scale.copy(scl);
-  }
 }

--- a/packages/client/src/tracking/anchor.test.ts
+++ b/packages/client/src/tracking/anchor.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'vitest';
+import { Group, Matrix4, Quaternion, Vector3 } from 'three';
+import { applyAnchorPose } from './anchor.js';
+
+function identityElements(): number[] {
+  return new Matrix4().identity().elements.slice();
+}
+
+function translationElements(x: number, y: number, z: number): number[] {
+  return new Matrix4().makeTranslation(x, y, z).elements.slice();
+}
+
+describe('applyAnchorPose', () => {
+  test('identity pose, no scaleMultiplier → position (0,0,0), quaternion identity, scale (1,1,1)', () => {
+    const anchor = new Group();
+    applyAnchorPose(anchor, identityElements());
+    expect(anchor.position.x).toBeCloseTo(0);
+    expect(anchor.position.y).toBeCloseTo(0);
+    expect(anchor.position.z).toBeCloseTo(0);
+    const q = new Quaternion();
+    expect(anchor.quaternion.angleTo(q)).toBeCloseTo(0);
+    expect(anchor.scale.x).toBeCloseTo(1);
+    expect(anchor.scale.y).toBeCloseTo(1);
+    expect(anchor.scale.z).toBeCloseTo(1);
+  });
+
+  test('identity pose with scaleMultiplier=5 → scale (5,5,5)', () => {
+    const anchor = new Group();
+    applyAnchorPose(anchor, identityElements(), 5);
+    expect(anchor.scale.x).toBeCloseTo(5);
+    expect(anchor.scale.y).toBeCloseTo(5);
+    expect(anchor.scale.z).toBeCloseTo(5);
+  });
+
+  test('translation (1,2,3) pose → position applied, scaleMultiplier=2 multiplies decomposed scale', () => {
+    const anchor = new Group();
+    applyAnchorPose(anchor, translationElements(1, 2, 3), 2);
+    expect(anchor.position.x).toBeCloseTo(1);
+    expect(anchor.position.y).toBeCloseTo(2);
+    expect(anchor.position.z).toBeCloseTo(3);
+    expect(anchor.scale.x).toBeCloseTo(2);
+    expect(anchor.scale.y).toBeCloseTo(2);
+    expect(anchor.scale.z).toBeCloseTo(2);
+  });
+
+  test('empty array input → no-op (anchor unchanged)', () => {
+    const anchor = new Group();
+    anchor.position.set(9, 9, 9);
+    applyAnchorPose(anchor, []);
+    expect(anchor.position.x).toBeCloseTo(9);
+  });
+
+  test('non-16-length array input → no-op (anchor unchanged)', () => {
+    const anchor = new Group();
+    anchor.position.set(7, 7, 7);
+    applyAnchorPose(anchor, [1, 2, 3, 4, 5]);
+    expect(anchor.position.x).toBeCloseTo(7);
+  });
+
+  test('scale (1,1,1) in matrix with scaleMultiplier=1 → Vector3 magnitude consistent', () => {
+    const anchor = new Group();
+    const elements = new Matrix4()
+      .compose(new Vector3(0.1, 0.2, 0.3), new Quaternion(), new Vector3(1, 1, 1))
+      .elements.slice();
+    applyAnchorPose(anchor, elements, 1);
+    expect(anchor.scale.x).toBeCloseTo(1);
+    expect(anchor.scale.y).toBeCloseTo(1);
+    expect(anchor.scale.z).toBeCloseTo(1);
+  });
+});

--- a/packages/client/src/tracking/anchor.ts
+++ b/packages/client/src/tracking/anchor.ts
@@ -1,0 +1,20 @@
+import { Group, Matrix4, Quaternion, Vector3 } from 'three';
+
+export function applyAnchorPose(
+  anchor: Group,
+  poseMatrixElements: ArrayLike<number>,
+  scaleMultiplier = 1,
+): void {
+  if (poseMatrixElements.length !== 16) return;
+  const m = new Matrix4();
+  const te = m.elements;
+  for (let i = 0; i < 16; i++) te[i] = poseMatrixElements[i] ?? 0;
+  const pos = new Vector3();
+  const quat = new Quaternion();
+  const scl = new Vector3();
+  m.decompose(pos, quat, scl);
+  anchor.position.copy(pos);
+  anchor.quaternion.copy(quat);
+  anchor.scale.copy(scl.multiplyScalar(scaleMultiplier));
+  anchor.matrix.copy(m);
+}

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -342,7 +342,7 @@ canvas.addEventListener('pointermove', (ev) => {
   const dx = ev.clientX - dragState.lastX;
   if (!dragState.moved && Math.abs(dx) > DRAG_THRESHOLD_PX) dragState.moved = true;
   if (dragState.moved) {
-    placement.rotateGhost(dx * ROT_SENSITIVITY);
+    dispatch({ type: 'GHOST_ROTATED', deltaRad: dx * ROT_SENSITIVITY });
     dragState.lastX = ev.clientX;
   }
 });

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -330,7 +330,11 @@ const ROT_SENSITIVITY = 0.0055;
 canvas.addEventListener(
   'pointerdown',
   (ev) => {
-    if (state.kind !== 'placing') return;
+    // Drag-to-rotate only engages when a ghost is actually pending. When
+    // placing is blocked there's no ghost on-screen, so drags should fall
+    // through to OrbitControls (camera orbit) rather than being captured
+    // for a no-op GHOST_ROTATED dispatch.
+    if (state.kind !== 'placing' || state.blocked) return;
     if (config.mode !== 'screen') controls.enabled = false;
     dragState = { lastX: ev.clientX, moved: false };
     canvas.setPointerCapture(ev.pointerId);

--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -127,7 +127,7 @@ function removeCreature(type: CreatureType): boolean {
   if (idx === -1) return false;
   const [removed] = creatures.splice(idx, 1);
   if (!removed) return false;
-  scene.remove(removed.group);
+  treeReef.anchor.remove(removed.group);
   removed.group.traverse((obj) => {
     const mesh = obj as import('three').Mesh;
     if (mesh.isMesh) {
@@ -154,7 +154,7 @@ function spawnShark(): void {
     phaseRad: Math.random() * Math.PI * 2,
     direction: Math.random() < 0.5 ? 1 : -1,
   });
-  scene.add(s.group);
+  treeReef.anchor.add(s.group);
   creatures.push({ type: 'shark', instance: s, group: s.group });
 }
 function spawnClownfish(): void {
@@ -165,7 +165,7 @@ function spawnClownfish(): void {
     phaseRad: Math.random() * Math.PI * 2,
     direction: Math.random() < 0.5 ? 1 : -1,
   });
-  scene.add(c.group);
+  treeReef.anchor.add(c.group);
   creatures.push({ type: 'clownfish', instance: c, group: c.group });
 }
 function spawnJellyfish(): void {
@@ -176,7 +176,7 @@ function spawnJellyfish(): void {
     phaseRad: Math.random() * Math.PI * 2,
     direction: Math.random() < 0.5 ? 1 : -1,
   });
-  scene.add(j.group);
+  treeReef.anchor.add(j.group);
   creatures.push({ type: 'jellyfish', instance: j, group: j.group });
 }
 function spawnSeaTurtle(): void {
@@ -187,7 +187,7 @@ function spawnSeaTurtle(): void {
     phaseRad: Math.random() * Math.PI * 2,
     direction: Math.random() < 0.5 ? 1 : -1,
   });
-  scene.add(t.group);
+  treeReef.anchor.add(t.group);
   creatures.push({ type: 'seaTurtle', instance: t, group: t.group });
 }
 

--- a/packages/client/src/tree/collision.test.ts
+++ b/packages/client/src/tree/collision.test.ts
@@ -13,15 +13,27 @@ describe('wouldCollide', () => {
     expect(wouldCollide(proposed, others)).toBe(false);
   });
 
-  test('returns true when the proposal overlaps any existing box', () => {
+  test('returns true when a proposal deeply overlaps an existing box', () => {
     const proposed = box(0, 0, 0, 1, 1, 1);
-    const others = [box(2, 0, 0, 3, 1, 1), box(0.5, 0.5, 0.5, 1.5, 1.5, 1.5)];
+    // Overlap is >15% per side, well past the shrink tolerance.
+    const others = [box(2, 0, 0, 3, 1, 1), box(0.3, 0.3, 0.3, 1.3, 1.3, 1.3)];
     expect(wouldCollide(proposed, others)).toBe(true);
   });
 
-  test('touching boxes at a shared face count as intersecting (Three.js behavior)', () => {
+  test('boxes touching at a shared face do NOT collide (shrink tolerance)', () => {
+    // Shrink factor intentionally permits coral-nodule grazing on the
+    // AABB surface. Two unit boxes sharing x=1 have shrunk extents
+    // [0.075, 0.925] and [1.075, 1.925] — clear of each other.
     const proposed = box(0, 0, 0, 1, 1, 1);
-    const others = [box(1, 0, 0, 2, 1, 1)];  // shares the x=1 face
+    const others = [box(1, 0, 0, 2, 1, 1)];
+    expect(wouldCollide(proposed, others)).toBe(false);
+  });
+
+  test('boxes that overlap past the shrink tolerance still collide', () => {
+    // Centers 0.8 apart on X, shrunk half-extent 0.425: shrunk boxes
+    // cover [0.075, 0.925] and [0.875, 1.725] — overlap 0.05 on X.
+    const proposed = box(0, 0, 0, 1, 1, 1);
+    const others = [box(0.8, 0, 0, 1.8, 1, 1)];
     expect(wouldCollide(proposed, others)).toBe(true);
   });
 

--- a/packages/client/src/tree/collision.ts
+++ b/packages/client/src/tree/collision.ts
@@ -1,11 +1,33 @@
-import type { Box3 } from 'three';
+import { Box3, Vector3 } from 'three';
+
+/**
+ * Coral mesh bounding boxes include surface nodules that extend ~20–30%
+ * of segment radius outward from the skeleton cylinder. Nodules are
+ * visual polish, not a physical collision surface — without compensation
+ * the placement check falsely rejects many slot choices that look like
+ * clear space to the viewer.
+ *
+ * Shrinking both boxes around their centers before the intersection
+ * test permits adjacent branches to graze their outer polyp surfaces.
+ * 0.85 matches the approximate ratio of skeleton-only AABB to
+ * nodule-inclusive AABB across the five variants; a generator-side
+ * skeleton AABB would be more principled, deferred.
+ */
+const COLLISION_SHRINK_FACTOR = 0.85;
+
+function shrink(box: Box3): Box3 {
+  const center = box.getCenter(new Vector3());
+  const size = box.getSize(new Vector3()).multiplyScalar(COLLISION_SHRINK_FACTOR);
+  return new Box3().setFromCenterAndSize(center, size);
+}
 
 export function wouldCollide(
   proposedBox: Box3,
   existingBoxes: Iterable<Box3>,
 ): boolean {
+  const a = shrink(proposedBox);
   for (const other of existingBoxes) {
-    if (proposedBox.intersectsBox(other)) return true;
+    if (a.intersectsBox(shrink(other))) return true;
   }
   return false;
 }

--- a/packages/client/src/tree/effects.ts
+++ b/packages/client/src/tree/effects.ts
@@ -49,6 +49,7 @@ export function createEffects(deps: EffectsDeps): Effects {
           colorKey,
           next.parentId,
           next.attachIndex,
+          next.yawRad,
         );
         if (ghost) {
           deps.dispatch({ type: 'PLACEMENT_OK' });
@@ -73,6 +74,17 @@ export function createEffects(deps: EffectsDeps): Effects {
         return;
       }
 
+      // Drag-yaw within placing (GHOST_ROTATED): apply the delta to the
+      // ghost mesh so the visual preview tracks the accumulated state yaw.
+      if (
+        next.kind === 'placing' && prev.kind === 'placing' &&
+        !hasPlacingIdentityChanged(prev, next) &&
+        prev.yawRad !== next.yawRad
+      ) {
+        deps.placement.rotateGhost(next.yawRad - prev.yawRad);
+        return;
+      }
+
       // Leaving placing for idle (cancel).
       if (prev.kind === 'placing' && next.kind === 'idle' && action.type === 'CANCEL_CLICKED') {
         deps.placement.reset();
@@ -91,6 +103,7 @@ export function createEffects(deps: EffectsDeps): Effects {
             colorKey: next.picker.colorKey,
             parentId: next.parentId,
             attachIndex: next.attachIndex,
+            attachYaw: next.yawRad,
           },
           deps.apiBase,
         ).then(

--- a/packages/client/src/tree/placement.test.ts
+++ b/packages/client/src/tree/placement.test.ts
@@ -12,7 +12,7 @@ function makeRoot(id = 1): PublicTreePolyp {
     colorKey: 'neon-cyan',
     parentId: null,
     attachIndex: 0,
-    createdAt: Date.now(),
+    createdAt: Date.now(), attachYaw: 0,
   };
 }
 
@@ -29,7 +29,7 @@ function makeChild(
     colorKey: 'neon-magenta',
     parentId,
     attachIndex,
-    createdAt: Date.now() + id,
+    createdAt: Date.now() + id, attachYaw: 0,
   };
 }
 

--- a/packages/client/src/tree/placement.ts
+++ b/packages/client/src/tree/placement.ts
@@ -16,6 +16,10 @@ export class TreePlacement {
   readonly ghostAnchor = new Group();
   private ghost: Mesh | null = null;
   private pending: PendingTreePiece | null = null;
+  /** World-space attach-point normal of the current ghost. Null when no ghost
+   *  is pending. Used as the rotation axis in rotateGhost so drag-yaw matches
+   *  the axis TreeReef.addPiece uses when applying `polyp.attachYaw`. */
+  private attachNormal: Vector3 | null = null;
 
   constructor(private readonly reef: TreeReef) {}
 
@@ -24,6 +28,10 @@ export class TreePlacement {
    * If the resulting world AABB collides with any existing piece, return null
    * (placement blocked). Otherwise: spawn a semi-opaque ghost mesh, wire it
    * into ghostAnchor, record the pending intent, and return the ghost.
+   *
+   * `initialYaw` seeds the ghost's rotation around the attach-point normal
+   * (e.g. when re-entering `placing` on COMMIT_REJECTED with a previously
+   * accumulated yaw). Pass 0 on a fresh attach.
    */
   showGhost(
     variant: TreeVariant,
@@ -31,6 +39,7 @@ export class TreePlacement {
     colorKey: string,
     parentId: number,
     attachIndex: number,
+    initialYaw = 0,
   ): Mesh | null {
     this.reset();
 
@@ -41,16 +50,19 @@ export class TreePlacement {
 
     const generated = generateTreeVariantMesh({ variant, seed, colorKey });
 
-    // Same composition logic as TreeReef.addPiece — mirror it.
-    const quat = new Quaternion().setFromUnitVectors(
-      new Vector3(0, 1, 0),
-      new Vector3(attach.normal.x, attach.normal.y, attach.normal.z).normalize(),
-    );
+    const attachNormal = new Vector3(attach.normal.x, attach.normal.y, attach.normal.z).normalize();
+    const alignQuat = new Quaternion().setFromUnitVectors(new Vector3(0, 1, 0), attachNormal);
+    const yawQuat = new Quaternion().setFromAxisAngle(attachNormal, initialYaw);
+    const quat = yawQuat.multiply(alignQuat);
     const position = new Vector3(attach.position.x, attach.position.y, attach.position.z);
-    const matrix = new Matrix4().compose(position, quat, new Vector3(1, 1, 1));
 
-    generated.mesh.applyMatrix4(matrix);
-    const worldBox = generated.boundingBox.clone().applyMatrix4(matrix);
+    // Live transform (not baked into vertices) so rotateGhost can pivot around
+    // the attach-point normal via rotateOnWorldAxis without accumulating
+    // rounding errors in the vertex data.
+    generated.mesh.position.copy(position);
+    generated.mesh.quaternion.copy(quat);
+    generated.mesh.updateMatrixWorld(true);
+    const worldBox = new Box3().setFromObject(generated.mesh);
 
     // Reject if colliding with any existing piece other than the parent itself.
     // The new piece attaches to the parent, so their bounding boxes will naturally
@@ -79,6 +91,7 @@ export class TreePlacement {
 
     this.ghost = generated.mesh;
     this.pending = { variant, seed, colorKey, parentId, attachIndex };
+    this.attachNormal = attachNormal;
     this.ghostAnchor.add(generated.mesh);
     return generated.mesh;
   }
@@ -90,6 +103,7 @@ export class TreePlacement {
       this.ghost = null;
     }
     this.pending = null;
+    this.attachNormal = null;
   }
 
   getPending(): PendingTreePiece | null {
@@ -97,14 +111,14 @@ export class TreePlacement {
   }
 
   /**
-   * Spin the current ghost around its local +Y axis (which is aligned with
-   * the parent's attach-point normal by construction in showGhost). Lets the
-   * user orient the piece before committing — e.g. aim a Forked piece's two
-   * branches in a specific direction. No-op when no ghost is pending.
+   * Spin the current ghost around the parent attach-point normal, through
+   * the attach position. Matches the axis TreeReef.addPiece uses for
+   * `polyp.attachYaw`, so the visual preview matches what the committed
+   * piece will render. No-op when no ghost is pending.
    */
   rotateGhost(deltaRad: number): void {
-    if (!this.ghost) return;
-    this.ghost.rotateY(deltaRad);
+    if (!this.ghost || !this.attachNormal) return;
+    this.ghost.rotateOnWorldAxis(this.attachNormal, deltaRad);
   }
 }
 

--- a/packages/client/src/tree/reef.test.ts
+++ b/packages/client/src/tree/reef.test.ts
@@ -14,7 +14,7 @@ function makeRoot(id = 1): PublicTreePolyp {
     colorKey: 'neon-cyan',
     parentId: null,
     attachIndex: 0,
-    createdAt: Date.now(),
+    createdAt: Date.now(), attachYaw: 0,
   };
 }
 
@@ -31,7 +31,7 @@ function makeChild(
     colorKey: 'neon-magenta',
     parentId,
     attachIndex,
-    createdAt: Date.now() + id,
+    createdAt: Date.now() + id, attachYaw: 0,
   };
 }
 

--- a/packages/client/src/tree/reef.ts
+++ b/packages/client/src/tree/reef.ts
@@ -62,7 +62,12 @@ export class TreeReef {
         attach.normal.y,
         attach.normal.z,
       ).normalize();
-      const quat = new Quaternion().setFromUnitVectors(localUp, targetNormal);
+      const alignQuat = new Quaternion().setFromUnitVectors(localUp, targetNormal);
+
+      // Optional yaw around the attach-point normal (drag-rotation at commit).
+      // Applied after alignment so the piece spins in-plane on its mounting point.
+      const yawQuat = new Quaternion().setFromAxisAngle(targetNormal, polyp.attachYaw);
+      const quat = yawQuat.multiply(alignQuat);
 
       const position = new Vector3(attach.position.x, attach.position.y, attach.position.z);
       matrix.compose(position, quat, new Vector3(1, 1, 1));

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -33,13 +33,13 @@ describe('VARIANT_CHOSEN', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'wishbone', seed: 99 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 99, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 99, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -47,13 +47,13 @@ describe('VARIANT_CHOSEN', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'VARIANT_CHOSEN', variant: 'trident', seed: 42 });
     expect(next).toEqual({
       kind: 'submitting',
       picker: { variant: 'trident', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 42, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 42, yawRad: 0, lastCommittedId: null,
     });
   });
 
@@ -89,13 +89,13 @@ describe('COLOR_CHOSEN', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'COLOR_CHOSEN', colorKey: 'neon-lime' });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-lime' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 });
@@ -107,7 +107,7 @@ describe('ATTACH_CLICKED', () => {
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 5, attachIndex: 2, seed: 77, blocked: false, lastCommittedId: null,
+      parentId: 5, attachIndex: 2, seed: 77, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -121,13 +121,13 @@ describe('ATTACH_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 3, attachIndex: 1, seed: 55 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-cyan' },
-      parentId: 3, attachIndex: 1, seed: 55, blocked: false, lastCommittedId: null,
+      parentId: 3, attachIndex: 1, seed: 55, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -135,7 +135,7 @@ describe('ATTACH_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 9, attachIndex: 9, seed: 9 });
     expect(next).toBe(s);
@@ -157,13 +157,13 @@ describe('REROLL_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
     expect(next).toEqual({
       kind: 'placing',
       picker: { variant: 'claw', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 42, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 42, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -177,10 +177,69 @@ describe('REROLL_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'REROLL_CLICKED', variant: 'claw', seed: 42 });
     expect(next).toBe(s);
+  });
+});
+
+describe('GHOST_ROTATED', () => {
+  test('in placing: accumulates deltaRad onto yawRad', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0.2, blocked: false, lastCommittedId: null,
+    };
+    const next = reduce(s, { type: 'GHOST_ROTATED', deltaRad: 0.3 });
+    expect(next).toEqual({ ...s, yawRad: 0.5 });
+  });
+
+  test('supports negative deltas', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 1, blocked: false, lastCommittedId: null,
+    };
+    const next = reduce(s, { type: 'GHOST_ROTATED', deltaRad: -0.4 });
+    expect((next as typeof s).yawRad).toBeCloseTo(0.6);
+  });
+
+  test('ATTACH_CLICKED resets yaw to 0 even when re-entering placing', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 2, blocked: false, lastCommittedId: null,
+    };
+    const next = reduce(s, { type: 'ATTACH_CLICKED', parentId: 3, attachIndex: 1, seed: 99 });
+    expect((next as typeof s).yawRad).toBe(0);
+  });
+
+  test('GROW_CLICKED carries yaw into submitting', () => {
+    const s: TreeState = {
+      kind: 'placing',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0.7, blocked: false, lastCommittedId: null,
+    };
+    const next = reduce(s, { type: 'GROW_CLICKED' });
+    expect(next.kind).toBe('submitting');
+    if (next.kind === 'submitting') expect(next.yawRad).toBe(0.7);
+  });
+
+  test('COMMIT_REJECTED carries yaw back into placing (so user can retry without re-rotating)', () => {
+    const s: TreeState = {
+      kind: 'submitting',
+      picker: { variant: 'forked', colorKey: 'neon-cyan' },
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0.9, lastCommittedId: null,
+    };
+    const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
+    expect(next.kind).toBe('placing');
+    if (next.kind === 'placing') expect(next.yawRad).toBe(0.9);
+  });
+
+  test('outside placing: no-op', () => {
+    const idle = initialState({ variant: 'forked', colorKey: 'neon-cyan' });
+    expect(reduce(idle, { type: 'GHOST_ROTATED', deltaRad: 1 })).toBe(idle);
   });
 });
 
@@ -189,7 +248,7 @@ describe('PLACEMENT_BLOCKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'PLACEMENT_BLOCKED' });
     expect(next).toEqual({ ...s, blocked: true });
@@ -206,7 +265,7 @@ describe('PLACEMENT_OK', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: true, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'PLACEMENT_OK' });
     expect(next).toEqual({ ...s, blocked: false });
@@ -223,7 +282,7 @@ describe('CANCEL_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CANCEL_CLICKED' });
     expect(next).toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: null });
@@ -233,7 +292,7 @@ describe('CANCEL_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 7,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: 7,
     };
     const next = reduce(s, { type: 'CANCEL_CLICKED' });
     expect(next).toMatchObject({ kind: 'idle', lastCommittedId: 7 });
@@ -244,7 +303,7 @@ describe('CANCEL_CLICKED', () => {
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const resetting: TreeState = {
       kind: 'resetting',
@@ -262,13 +321,13 @@ describe('GROW_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'GROW_CLICKED' });
     expect(next).toEqual({
       kind: 'submitting',
       picker: s.picker,
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     });
   });
 
@@ -276,7 +335,7 @@ describe('GROW_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: true, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: true, lastCommittedId: null,
     };
     expect(reduce(s, { type: 'GROW_CLICKED' })).toBe(s);
   });
@@ -286,7 +345,7 @@ describe('GROW_CLICKED', () => {
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     expect(reduce(idle, { type: 'GROW_CLICKED' })).toBe(idle);
     expect(reduce(submitting, { type: 'GROW_CLICKED' })).toBe(submitting);
@@ -298,7 +357,7 @@ describe('COMMIT_RESOLVED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'COMMIT_RESOLVED', polypId: 42 });
     expect(next).toEqual({ kind: 'idle', picker: s.picker, lastCommittedId: 42 });
@@ -315,13 +374,13 @@ describe('COMMIT_REJECTED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
     expect(next).toEqual({
       kind: 'placing',
       picker: s.picker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     });
   });
 
@@ -329,7 +388,7 @@ describe('COMMIT_REJECTED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: 5,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: 5,
     };
     const next = reduce(s, { type: 'COMMIT_REJECTED', error: 'boom' });
     expect(next).toMatchObject({ kind: 'placing', lastCommittedId: 5 });
@@ -352,7 +411,7 @@ describe('CLEAR_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CLEAR_CLICKED' });
     expect(next).toEqual({ kind: 'resetting', picker: s.picker, lastCommittedId: null });
@@ -362,7 +421,7 @@ describe('CLEAR_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     };
     const next = reduce(s, { type: 'CLEAR_CLICKED' });
     expect(next).toEqual({ kind: 'resetting', picker: s.picker, lastCommittedId: null });
@@ -418,12 +477,12 @@ describe('TREE_RESET_EXTERNAL', () => {
     const placing: TreeState = {
       kind: 'placing',
       picker: { variant: 'wishbone', colorKey: 'neon-lime' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     const submitting: TreeState = {
       kind: 'submitting',
       picker: { variant: 'claw', colorKey: 'neon-violet' },
-      parentId: 2, attachIndex: 1, seed: 20, lastCommittedId: null,
+      parentId: 2, attachIndex: 1, seed: 20, yawRad: 0, lastCommittedId: null,
     };
     const resetting: TreeState = {
       kind: 'resetting',
@@ -460,7 +519,7 @@ describe('UNDO_CLICKED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 5,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: 5,
     };
     expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
   });
@@ -469,7 +528,7 @@ describe('UNDO_CLICKED', () => {
     const s: TreeState = {
       kind: 'submitting',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: 5,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: 5,
     };
     expect(reduce(s, { type: 'UNDO_CLICKED' })).toBe(s);
   });
@@ -501,7 +560,7 @@ describe('UNDO_RESOLVED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     };
     expect(reduce(s, { type: 'UNDO_RESOLVED' })).toBe(s);
   });
@@ -541,7 +600,7 @@ describe('TREE_POLYP_REMOVED_EXTERNAL', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 7,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: 7,
     };
     const next = reduce(s, { type: 'TREE_POLYP_REMOVED_EXTERNAL', id: 7 });
     expect(next).toMatchObject({ kind: 'placing', lastCommittedId: null });
@@ -569,7 +628,7 @@ describe('LAST_COMMITTED_INVALIDATED', () => {
     const s: TreeState = {
       kind: 'placing',
       picker: idlePicker,
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: 5,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: 5,
     };
     const next = reduce(s, { type: 'LAST_COMMITTED_INVALIDATED' });
     expect(next).toMatchObject({ kind: 'placing', lastCommittedId: null });
@@ -587,12 +646,12 @@ describe('reduce — no-op matrix', () => {
     placing: {
       kind: 'placing',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, blocked: false, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, blocked: false, lastCommittedId: null,
     },
     submitting: {
       kind: 'submitting',
       picker: { variant: 'forked', colorKey: 'neon-cyan' },
-      parentId: 1, attachIndex: 0, seed: 10, lastCommittedId: null,
+      parentId: 1, attachIndex: 0, seed: 10, yawRad: 0, lastCommittedId: null,
     },
     resetting: { kind: 'resetting', picker: { variant: 'forked', colorKey: 'neon-cyan' }, lastCommittedId: null },
     undoing: { kind: 'undoing', picker: { variant: 'forked', colorKey: 'neon-cyan' }, polypId: 1 },

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -13,6 +13,7 @@ export type TreeState =
       parentId: number;
       attachIndex: number;
       seed: number;
+      yawRad: number;
       blocked: boolean;
       lastCommittedId: number | null;
     }
@@ -22,6 +23,7 @@ export type TreeState =
       parentId: number;
       attachIndex: number;
       seed: number;
+      yawRad: number;
       lastCommittedId: number | null;
     }
   | { kind: 'resetting'; picker: PickerSelection; lastCommittedId: number | null }
@@ -46,7 +48,8 @@ export type TreeAction =
   | { type: 'UNDO_RESOLVED' }
   | { type: 'UNDO_REJECTED'; error: string }
   | { type: 'TREE_POLYP_REMOVED_EXTERNAL'; id: number }
-  | { type: 'LAST_COMMITTED_INVALIDATED' };
+  | { type: 'LAST_COMMITTED_INVALIDATED' }
+  | { type: 'GHOST_ROTATED'; deltaRad: number };
 
 export function initialState(picker: PickerSelection): TreeState {
   return { kind: 'idle', picker, lastCommittedId: null };
@@ -76,6 +79,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
           parentId: action.parentId,
           attachIndex: action.attachIndex,
           seed: action.seed,
+          yawRad: 0,
           blocked: false,
           lastCommittedId: state.lastCommittedId,
         };
@@ -90,6 +94,10 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         seed: action.seed,
         blocked: false,
       };
+    }
+    case 'GHOST_ROTATED': {
+      if (state.kind !== 'placing') return state;
+      return { ...state, yawRad: state.yawRad + action.deltaRad };
     }
     case 'PLACEMENT_BLOCKED': {
       if (state.kind !== 'placing') return state;
@@ -111,6 +119,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         parentId: state.parentId,
         attachIndex: state.attachIndex,
         seed: state.seed,
+        yawRad: state.yawRad,
         lastCommittedId: state.lastCommittedId,
       };
     }
@@ -126,6 +135,7 @@ export function reduce(state: TreeState, action: TreeAction): TreeState {
         parentId: state.parentId,
         attachIndex: state.attachIndex,
         seed: state.seed,
+        yawRad: state.yawRad,
         blocked: false,
         lastCommittedId: state.lastCommittedId,
       };

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -27,7 +27,17 @@ export interface TreeAppOptions {
   statusEl: HTMLElement;
 }
 
-const SCALE = 5;
+const DEFAULT_SCALE = 5;
+
+/** Read a positive-finite `?scale=N` override from the URL. Falls back
+ *  to DEFAULT_SCALE if missing or malformed. Exists so field testing
+ *  can tune room-filling size without a rebuild. */
+function readScaleFromUrl(): number {
+  const raw = new URLSearchParams(globalThis.location?.search ?? '').get('scale');
+  if (!raw) return DEFAULT_SCALE;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_SCALE;
+}
 
 const SWAY_INSTALLED = Symbol('sway-installed');
 const PULSE_INSTALLED = Symbol('pulse-installed');
@@ -58,12 +68,14 @@ export class TreeApp {
   private readonly hintEl: HTMLElement;
   private readonly statusEl: HTMLElement;
   private readonly apiBase: string;
+  private readonly anchorScale: number;
 
   constructor(readonly opts: TreeAppOptions) {
     this.statusEl = opts.statusEl;
 
     const params = new URLSearchParams(globalThis.location?.search ?? '');
     this.apiBase = params.get('api') ?? '';
+    this.anchorScale = readScaleFromUrl();
 
     this.renderer = new WebGLRenderer({
       canvas: opts.canvas,
@@ -127,7 +139,7 @@ export class TreeApp {
     });
 
     this.tracker.onAnchorFound(({ pose }) => {
-      applyAnchorPose(this.treeReef.anchor, pose.elements, SCALE);
+      applyAnchorPose(this.treeReef.anchor, pose.elements, this.anchorScale);
       this.treeReef.anchor.visible = true;
       this.setStatus('Tap a glowing dot to attach your branch.');
       this.picker.show();

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -1,3 +1,12 @@
+import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import type { Mat4Like } from '@reef/shared';
+import { TreeReef } from './tree/reef.js';
+import { installUnderwaterLighting } from './tree/scene.js';
+import { applyAnchorPose } from './tracking/anchor.js';
+import { readTrackerFromUrl, selectProvider } from './tracking/index.js';
+import { EightWallProvider } from './tracking/eightwall.js';
+import type { TrackingProvider } from '@reef/shared';
+
 export interface TreeAppOptions {
   canvas: HTMLCanvasElement;
   video: HTMLVideoElement;
@@ -5,10 +14,104 @@ export interface TreeAppOptions {
   statusEl: HTMLElement;
 }
 
+const SCALE = 5;
+
 export class TreeApp {
-  constructor(readonly opts: TreeAppOptions) {}
+  private readonly scene = new Scene();
+  private readonly camera: PerspectiveCamera;
+  private readonly renderer: WebGLRenderer;
+  readonly treeReef = new TreeReef();
+  private tracker!: TrackingProvider;
+  private running = false;
+  private readonly statusEl: HTMLElement;
 
-  async start(): Promise<void> {}
+  constructor(readonly opts: TreeAppOptions) {
+    this.statusEl = opts.statusEl;
 
-  stop(): void {}
+    this.renderer = new WebGLRenderer({
+      canvas: opts.canvas,
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance',
+    });
+    this.renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+    this.renderer.setClearColor(0x000000, 0);
+
+    this.camera = new PerspectiveCamera(60, 1, 0.01, 30);
+    this.camera.position.set(0, 0, 0);
+
+    installUnderwaterLighting(this.scene);
+    this.scene.add(this.treeReef.anchor);
+    this.treeReef.anchor.visible = false;
+
+    this.onResize();
+    window.addEventListener('resize', () => this.onResize());
+  }
+
+  async start(): Promise<void> {
+    this.setStatus('Starting camera…');
+    await this.startCamera();
+
+    const preferred = readTrackerFromUrl();
+    if (preferred === 'auto' || preferred === 'eightwall') {
+      await EightWallProvider.waitUntilReady();
+    }
+    this.tracker = selectProvider(preferred);
+    await this.tracker.init({
+      markerImage: '',
+      videoElement: this.opts.video,
+      canvasElement: this.opts.canvas,
+    });
+
+    this.tracker.onAnchorFound(({ pose }) => {
+      applyAnchorPose(this.treeReef.anchor, pose.elements, SCALE);
+      this.treeReef.anchor.visible = true;
+      this.setStatus('Tap a glowing dot to attach your branch.');
+    });
+
+    this.tracker.onAnchorLost(() => {
+      this.treeReef.anchor.visible = false;
+      this.setStatus('Looking for the marker…');
+    });
+
+    this.tracker.onFrame((_pose: Mat4Like, _t: number) => { /* reserved */ });
+
+    await this.tracker.start();
+
+    this.running = true;
+    requestAnimationFrame((t) => this.loop(t));
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.tracker) void this.tracker.destroy();
+  }
+
+  private async startCamera(): Promise<void> {
+    if (!navigator.mediaDevices?.getUserMedia) return;
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: { ideal: 'environment' } },
+      audio: false,
+    });
+    this.opts.video.srcObject = stream;
+    await this.opts.video.play().catch(() => {});
+  }
+
+  private onResize(): void {
+    const w = window.innerWidth, h = window.innerHeight;
+    this.renderer.setSize(w, h, false);
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+  }
+
+  private setStatus(text: string): void {
+    this.statusEl.textContent = text;
+    this.statusEl.classList.remove('hidden');
+  }
+
+  private loop(t: number): void {
+    if (!this.running) return;
+    this.renderer.render(this.scene, this.camera);
+    requestAnimationFrame((tt) => this.loop(tt));
+  }
 }

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -6,6 +6,10 @@ import { TreePlacement } from './tree/placement.js';
 import { installUnderwaterLighting } from './tree/scene.js';
 import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
 import { TreePicker, TREE_VARIANTS } from './ui/treePicker.js';
+import { Shark } from './tree/shark.js';
+import { Clownfish } from './tree/clownfish.js';
+import { Jellyfish } from './tree/jellyfish.js';
+import { SeaTurtle } from './tree/seaTurtle.js';
 import { installSway } from './scene/currentSway.js';
 import { installTreePulse } from './tree/pulse.js';
 import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
@@ -28,6 +32,14 @@ const SCALE = 5;
 const SWAY_INSTALLED = Symbol('sway-installed');
 const PULSE_INSTALLED = Symbol('pulse-installed');
 
+type CreatureType = 'shark' | 'clownfish' | 'jellyfish' | 'seaTurtle';
+interface SwimmingCreature { update: (clockSec: number) => void; }
+interface TrackedCreature {
+  type: CreatureType;
+  instance: SwimmingCreature;
+  group: import('three').Group;
+}
+
 export class TreeApp {
   private readonly scene = new Scene();
   private readonly camera: PerspectiveCamera;
@@ -42,6 +54,7 @@ export class TreeApp {
   private effects!: ReturnType<typeof createEffects>;
   private state: TreeState;
   private running = false;
+  private readonly creatures: TrackedCreature[] = [];
   private readonly hintEl: HTMLElement;
   private readonly statusEl: HTMLElement;
   private readonly apiBase: string;
@@ -140,6 +153,71 @@ export class TreeApp {
     this.running = false;
     if (this.socket) this.socket.close();
     if (this.tracker) void this.tracker.destroy();
+  }
+
+  wireToolbar(): void {
+    const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
+    const undoBtn = document.getElementById('undoBtn') as HTMLButtonElement | null;
+    const seaLifeBtn = document.getElementById('seaLifeBtn') as HTMLButtonElement | null;
+    const seaLifePanel = document.getElementById('sea-life-panel') as HTMLElement | null;
+    const seaLifeCloseBtn = document.getElementById('sea-life-close-btn') as HTMLButtonElement | null;
+
+    if (clearBtn) clearBtn.addEventListener('click', () => this.dispatch({ type: 'CLEAR_CLICKED' }));
+    if (undoBtn) undoBtn.addEventListener('click', () => this.dispatch({ type: 'UNDO_CLICKED' }));
+
+    const setPanelOpen = (open: boolean): void => {
+      if (!seaLifePanel || !seaLifeBtn) return;
+      if (open) {
+        seaLifePanel.classList.add('open');
+        seaLifeBtn.setAttribute('aria-expanded', 'true');
+        seaLifeBtn.setAttribute('aria-pressed', 'true');
+      } else {
+        seaLifePanel.classList.remove('open');
+        seaLifeBtn.setAttribute('aria-expanded', 'false');
+        seaLifeBtn.removeAttribute('aria-pressed');
+      }
+    };
+
+    if (seaLifeBtn) seaLifeBtn.addEventListener('click', () => {
+      const isOpen = seaLifePanel?.classList.contains('open') ?? false;
+      setPanelOpen(!isOpen);
+    });
+    if (seaLifeCloseBtn) seaLifeCloseBtn.addEventListener('click', () => setPanelOpen(false));
+
+    document.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Escape') setPanelOpen(false);
+    });
+    document.addEventListener('click', (ev) => {
+      if (!seaLifePanel?.classList.contains('open')) return;
+      const target = ev.target as Node;
+      if (!seaLifePanel.contains(target) && target !== seaLifeBtn && !seaLifeBtn?.contains(target)) {
+        setPanelOpen(false);
+      }
+    });
+
+    const refreshPanel = (): void => {
+      const types: CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
+      for (const type of types) {
+        const n = this.countCreatures(type);
+        const countEl = document.getElementById(`count-${type}`);
+        if (countEl) countEl.textContent = String(n);
+        const capType = type.charAt(0).toUpperCase() + type.slice(1);
+        const removeBtn = document.getElementById(`remove${capType}Btn`) as HTMLButtonElement | null;
+        if (removeBtn) removeBtn.disabled = n === 0;
+      }
+    };
+
+    const wire = (addId: string, removeId: string, type: CreatureType, spawn: () => void): void => {
+      const addBtn = document.getElementById(addId) as HTMLButtonElement | null;
+      const removeBtn = document.getElementById(removeId) as HTMLButtonElement | null;
+      if (addBtn) addBtn.addEventListener('click', () => { spawn(); refreshPanel(); });
+      if (removeBtn) removeBtn.addEventListener('click', () => { this.removeCreature(type); refreshPanel(); });
+    };
+
+    wire('addSharkBtn', 'removeSharkBtn', 'shark', () => this.spawnShark());
+    wire('addClownfishBtn', 'removeClownfishBtn', 'clownfish', () => this.spawnClownfish());
+    wire('addJellyfishBtn', 'removeJellyfishBtn', 'jellyfish', () => this.spawnJellyfish());
+    wire('addSeaTurtleBtn', 'removeSeaTurtleBtn', 'seaTurtle', () => this.spawnSeaTurtle());
   }
 
   private dispatch(action: TreeAction): void {
@@ -286,6 +364,79 @@ export class TreeApp {
     undoBtn.disabled = !(this.state.kind === 'idle' && this.state.lastCommittedId !== null);
   }
 
+  private spawnShark(): void {
+    const s = new Shark({
+      orbitRadius: 0.25 + Math.random() * 0.15,
+      orbitHeight: 0.05 + Math.random() * 0.2,
+      orbitPeriodSec: 14 + Math.random() * 10,
+      phaseRad: Math.random() * Math.PI * 2,
+      direction: Math.random() < 0.5 ? 1 : -1,
+    });
+    this.treeReef.anchor.add(s.group);
+    this.creatures.push({ type: 'shark', instance: s, group: s.group });
+  }
+
+  private spawnClownfish(): void {
+    const c = new Clownfish({
+      orbitRadius: 0.15 + Math.random() * 0.15,
+      orbitHeight: 0.04 + Math.random() * 0.2,
+      orbitPeriodSec: 5 + Math.random() * 6,
+      phaseRad: Math.random() * Math.PI * 2,
+      direction: Math.random() < 0.5 ? 1 : -1,
+    });
+    this.treeReef.anchor.add(c.group);
+    this.creatures.push({ type: 'clownfish', instance: c, group: c.group });
+  }
+
+  private spawnJellyfish(): void {
+    const j = new Jellyfish({
+      orbitRadius: 0.18 + Math.random() * 0.14,
+      orbitHeight: 0.1 + Math.random() * 0.2,
+      orbitPeriodSec: 20 + Math.random() * 12,
+      phaseRad: Math.random() * Math.PI * 2,
+      direction: Math.random() < 0.5 ? 1 : -1,
+    });
+    this.treeReef.anchor.add(j.group);
+    this.creatures.push({ type: 'jellyfish', instance: j, group: j.group });
+  }
+
+  private spawnSeaTurtle(): void {
+    const t = new SeaTurtle({
+      orbitRadius: 0.28 + Math.random() * 0.12,
+      orbitHeight: 0.04 + Math.random() * 0.12,
+      orbitPeriodSec: 28 + Math.random() * 12,
+      phaseRad: Math.random() * Math.PI * 2,
+      direction: Math.random() < 0.5 ? 1 : -1,
+    });
+    this.treeReef.anchor.add(t.group);
+    this.creatures.push({ type: 'seaTurtle', instance: t, group: t.group });
+  }
+
+  private removeCreature(type: CreatureType): boolean {
+    const idx = [...this.creatures].map((c, i) => ({ c, i })).reverse()
+      .find(({ c }) => c.type === type)?.i ?? -1;
+    if (idx === -1) return false;
+    const [removed] = this.creatures.splice(idx, 1);
+    if (!removed) return false;
+    this.treeReef.anchor.remove(removed.group);
+    removed.group.traverse((obj) => {
+      const mesh = obj as import('three').Mesh;
+      if (mesh.isMesh) {
+        mesh.geometry?.dispose();
+        if (Array.isArray(mesh.material)) {
+          for (const m of mesh.material) (m as import('three').Material).dispose();
+        } else {
+          (mesh.material as import('three').Material | undefined)?.dispose();
+        }
+      }
+    });
+    return true;
+  }
+
+  private countCreatures(type: CreatureType): number {
+    return this.creatures.filter((c) => c.type === type).length;
+  }
+
   private async startCamera(): Promise<void> {
     if (!navigator.mediaDevices?.getUserMedia) return;
     const stream = await navigator.mediaDevices.getUserMedia({
@@ -312,6 +463,7 @@ export class TreeApp {
     if (!this.running) return;
     const tSec = t / 1000;
     this.swayClock.value = tSec;
+    for (const c of this.creatures) c.instance.update(tSec);
     this.renderer.render(this.scene, this.camera);
     requestAnimationFrame((tt) => this.loop(tt));
   }

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -96,10 +96,15 @@ export class TreeApp {
   }
 
   async start(): Promise<void> {
-    this.setStatus('Starting camera…');
-    await this.startCamera();
-
     const preferred = readTrackerFromUrl();
+    // Noop tracker renders into the canvas without a video feed; skipping
+    // camera init makes desktop + headless testing viable without real
+    // permissions or a real camera device.
+    if (preferred !== 'noop') {
+      this.setStatus('Starting camera…');
+      await this.startCamera();
+    }
+
     if (preferred === 'auto' || preferred === 'eightwall') {
       await EightWallProvider.waitUntilReady();
     }

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -1,0 +1,14 @@
+export interface TreeAppOptions {
+  canvas: HTMLCanvasElement;
+  video: HTMLVideoElement;
+  pickerRoot: HTMLElement;
+  statusEl: HTMLElement;
+}
+
+export class TreeApp {
+  constructor(readonly opts: TreeAppOptions) {}
+
+  async start(): Promise<void> {}
+
+  stop(): void {}
+}

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -1,11 +1,20 @@
-import { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
-import type { Mat4Like } from '@reef/shared';
+import { PerspectiveCamera, Raycaster, Scene, Vector2, WebGLRenderer } from 'three';
+import type { Mat4Like, PublicTreePolyp } from '@reef/shared';
 import { TreeReef } from './tree/reef.js';
+import { AttachIndicators } from './tree/indicators.js';
+import { TreePlacement } from './tree/placement.js';
 import { installUnderwaterLighting } from './tree/scene.js';
+import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
+import { TreePicker, TREE_VARIANTS } from './ui/treePicker.js';
+import { installSway } from './scene/currentSway.js';
+import { installTreePulse } from './tree/pulse.js';
+import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
+import { createEffects } from './tree/effects.js';
 import { applyAnchorPose } from './tracking/anchor.js';
 import { readTrackerFromUrl, selectProvider } from './tracking/index.js';
 import { EightWallProvider } from './tracking/eightwall.js';
 import type { TrackingProvider } from '@reef/shared';
+import type { Mesh } from 'three';
 
 export interface TreeAppOptions {
   canvas: HTMLCanvasElement;
@@ -16,17 +25,32 @@ export interface TreeAppOptions {
 
 const SCALE = 5;
 
+const SWAY_INSTALLED = Symbol('sway-installed');
+const PULSE_INSTALLED = Symbol('pulse-installed');
+
 export class TreeApp {
   private readonly scene = new Scene();
   private readonly camera: PerspectiveCamera;
   private readonly renderer: WebGLRenderer;
-  readonly treeReef = new TreeReef();
+  private readonly treeReef = new TreeReef();
+  private readonly attachIndicators = new AttachIndicators();
+  private readonly placement: TreePlacement;
+  private readonly picker: TreePicker;
+  private readonly swayClock = { value: 0 };
   private tracker!: TrackingProvider;
+  private socket!: TreeSocket;
+  private effects!: ReturnType<typeof createEffects>;
+  private state: TreeState;
   private running = false;
+  private readonly hintEl: HTMLElement;
   private readonly statusEl: HTMLElement;
+  private readonly apiBase: string;
 
   constructor(readonly opts: TreeAppOptions) {
     this.statusEl = opts.statusEl;
+
+    const params = new URLSearchParams(globalThis.location?.search ?? '');
+    this.apiBase = params.get('api') ?? '';
 
     this.renderer = new WebGLRenderer({
       canvas: opts.canvas,
@@ -40,9 +64,19 @@ export class TreeApp {
     this.camera = new PerspectiveCamera(60, 1, 0.01, 30);
     this.camera.position.set(0, 0, 0);
 
+    // TreePlacement depends on treeReef; initialize here so ghostAnchor is
+    // available before we add it to the scene graph below.
+    this.placement = new TreePlacement(this.treeReef);
+
     installUnderwaterLighting(this.scene);
     this.scene.add(this.treeReef.anchor);
+    this.treeReef.anchor.add(this.attachIndicators.group);
+    this.treeReef.anchor.add(this.placement.ghostAnchor);
     this.treeReef.anchor.visible = false;
+
+    this.picker = new TreePicker(opts.pickerRoot);
+    this.hintEl = document.getElementById('hint') ?? opts.statusEl;
+    this.state = initialState(this.picker.get());
 
     this.onResize();
     window.addEventListener('resize', () => this.onResize());
@@ -63,28 +97,193 @@ export class TreeApp {
       canvasElement: this.opts.canvas,
     });
 
+    this.effects = createEffects({
+      placement: this.placement,
+      treeReef: this.treeReef,
+      indicators: this.attachIndicators,
+      picker: this.picker,
+      hintEl: this.hintEl,
+      apiBase: this.apiBase,
+      dispatch: (action) => this.dispatch(action),
+      addPiecesAndRefresh: (polyps) => this.addPiecesAndRefresh(polyps),
+    });
+
     this.tracker.onAnchorFound(({ pose }) => {
       applyAnchorPose(this.treeReef.anchor, pose.elements, SCALE);
       this.treeReef.anchor.visible = true;
       this.setStatus('Tap a glowing dot to attach your branch.');
+      this.picker.show();
     });
 
     this.tracker.onAnchorLost(() => {
       this.treeReef.anchor.visible = false;
+      this.picker.hide();
+      this.placement.reset();
+      this.picker.setCommittable(false);
       this.setStatus('Looking for the marker…');
     });
 
     this.tracker.onFrame((_pose: Mat4Like, _t: number) => { /* reserved */ });
 
+    this.wirePicker();
+    this.wireTap();
+    this.wireSocket();
+
     await this.tracker.start();
 
+    void this.loadInitial();
     this.running = true;
     requestAnimationFrame((t) => this.loop(t));
   }
 
   stop(): void {
     this.running = false;
+    if (this.socket) this.socket.close();
     if (this.tracker) void this.tracker.destroy();
+  }
+
+  private dispatch(action: TreeAction): void {
+    const prev = this.state;
+    this.state = reduce(this.state, action);
+    if (this.state !== prev) {
+      this.effects.apply(prev, this.state, action);
+      this.refreshUndoBtn();
+    }
+  }
+
+  private wirePicker(): void {
+    this.picker.onChange((sel) => {
+      const current = this.state.picker;
+      if (sel.variant !== current.variant) {
+        const seed = Math.floor(Math.random() * 0xffffffff);
+        this.dispatch({ type: 'VARIANT_CHOSEN', variant: sel.variant, seed });
+      }
+      if (sel.colorKey !== current.colorKey) {
+        this.dispatch({ type: 'COLOR_CHOSEN', colorKey: sel.colorKey });
+      }
+    });
+
+    this.picker.onReroll(() => {
+      if (this.state.kind !== 'placing') return;
+      const options = TREE_VARIANTS.filter((v) => v !== this.state.picker.variant);
+      const variant = options[Math.floor(Math.random() * options.length)]!;
+      const seed = Math.floor(Math.random() * 0xffffffff);
+      this.dispatch({ type: 'REROLL_CLICKED', variant, seed });
+    });
+
+    this.picker.onCancel(() => this.dispatch({ type: 'CANCEL_CLICKED' }));
+    this.picker.onCommit(() => this.dispatch({ type: 'GROW_CLICKED' }));
+  }
+
+  private wireTap(): void {
+    const canvas = this.opts.canvas;
+    const raycaster = new Raycaster();
+
+    const handleTap = (clientX: number, clientY: number): void => {
+      const rect = canvas.getBoundingClientRect();
+      const ndc = new Vector2(
+        ((clientX - rect.left) / rect.width) * 2 - 1,
+        -(((clientY - rect.top) / rect.height) * 2 - 1),
+      );
+      raycaster.setFromCamera(ndc, this.camera);
+      const intersects = raycaster.intersectObjects(this.attachIndicators.group.children, false);
+      if (intersects.length === 0) {
+        if (this.state.kind === 'idle') {
+          this.hintEl.textContent = 'Tap a glowing dot to attach your branch.';
+        }
+        return;
+      }
+      const hit = intersects[0]!;
+      const ud = hit.object.userData as { parentId?: number; attachIndex?: number };
+      if (ud.parentId === undefined || ud.attachIndex === undefined) return;
+      const seed = Math.floor(Math.random() * 0xffffffff);
+      this.dispatch({
+        type: 'ATTACH_CLICKED',
+        parentId: ud.parentId,
+        attachIndex: ud.attachIndex,
+        seed,
+      });
+    };
+
+    canvas.addEventListener('click', (e) => handleTap(e.clientX, e.clientY));
+    canvas.addEventListener('touchend', (e) => {
+      if (e.touches.length > 0) return;
+      const t = e.changedTouches[0];
+      if (t) handleTap(t.clientX, t.clientY);
+    }, { passive: true });
+  }
+
+  private wireSocket(): void {
+    const buildUrl = (): string => {
+      if (this.apiBase) {
+        return this.apiBase.replace(/^http/, 'ws') + '/ws/tree';
+      }
+      return defaultTreeWsUrl();
+    };
+    this.socket = new TreeSocket(buildUrl());
+    this.socket.on((msg) => {
+      if (msg.type === 'tree_hello') {
+        // Initial state fetched via HTTP.
+      } else if (msg.type === 'tree_polyp_added') {
+        this.treeReef.addPiece(msg.polyp);
+        this.installEffectsOnNewPieces();
+        this.attachIndicators.refresh(this.treeReef.getAvailableAttachPoints());
+        if (
+          this.state.kind !== 'undoing' &&
+          'lastCommittedId' in this.state &&
+          this.state.lastCommittedId !== null &&
+          msg.polyp.parentId === this.state.lastCommittedId
+        ) {
+          this.dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
+        }
+      } else if (msg.type === 'tree_polyp_removed') {
+        this.treeReef.removePiece(msg.id);
+        this.attachIndicators.refresh(this.treeReef.getAvailableAttachPoints());
+        this.dispatch({ type: 'TREE_POLYP_REMOVED_EXTERNAL', id: msg.id });
+      } else if (msg.type === 'tree_reset') {
+        this.treeReef.clear();
+        this.attachIndicators.refresh([]);
+        this.dispatch({ type: 'TREE_RESET_EXTERNAL' });
+      }
+    });
+    this.socket.connect();
+  }
+
+  private async loadInitial(): Promise<void> {
+    try {
+      const { polyps } = await fetchTree(this.apiBase);
+      this.addPiecesAndRefresh(polyps);
+    } catch (e) {
+      console.error('[treeAr] Failed to load tree', e);
+      this.hintEl.textContent = 'Failed to load tree. Check the server.';
+    }
+  }
+
+  private addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
+    const sorted = [...polyps].sort((a, b) => a.createdAt - b.createdAt);
+    for (const polyp of sorted) this.treeReef.addPiece(polyp);
+    this.installEffectsOnNewPieces();
+    this.attachIndicators.refresh(this.treeReef.getAvailableAttachPoints());
+  }
+
+  private installEffectsOnNewPieces(): void {
+    for (const { polyp, mesh } of this.treeReef.allPieces()) {
+      const flags = mesh.userData as Record<PropertyKey, unknown>;
+      if (!flags[SWAY_INSTALLED]) {
+        installSway(mesh as Mesh, this.swayClock);
+        flags[SWAY_INSTALLED] = true;
+      }
+      if (!flags[PULSE_INSTALLED]) {
+        installTreePulse(mesh as Mesh, this.swayClock, polyp.seed);
+        flags[PULSE_INSTALLED] = true;
+      }
+    }
+  }
+
+  private refreshUndoBtn(): void {
+    const undoBtn = document.getElementById('undoBtn') as HTMLButtonElement | null;
+    if (!undoBtn) return;
+    undoBtn.disabled = !(this.state.kind === 'idle' && this.state.lastCommittedId !== null);
   }
 
   private async startCamera(): Promise<void> {
@@ -111,6 +310,8 @@ export class TreeApp {
 
   private loop(t: number): void {
     if (!this.running) return;
+    const tSec = t / 1000;
+    this.swayClock.value = tSec;
     this.renderer.render(this.scene, this.camera);
     requestAnimationFrame((tt) => this.loop(tt));
   }

--- a/packages/client/src/treeAr.ts
+++ b/packages/client/src/treeAr.ts
@@ -1,8 +1,4 @@
 import { TreeApp } from './treeApp.js';
-import { readTreeConfig } from './tree/config.js';
-
-const config = readTreeConfig();
-void config;
 
 const startBtn = document.getElementById('startBtn') as HTMLButtonElement;
 const landing = document.getElementById('landing')!;

--- a/packages/client/src/treeAr.ts
+++ b/packages/client/src/treeAr.ts
@@ -7,9 +7,11 @@ const canvas = document.getElementById('gl') as HTMLCanvasElement;
 const pickerRoot = document.getElementById('picker')!;
 const statusEl = document.getElementById('status')!;
 
+const app = new TreeApp({ canvas, video, pickerRoot, statusEl });
+app.wireToolbar();
+
 startBtn.addEventListener('click', async () => {
   landing.classList.add('hidden');
-  const app = new TreeApp({ canvas, video, pickerRoot, statusEl });
   try {
     await app.start();
   } catch (e) {

--- a/packages/client/src/treeAr.ts
+++ b/packages/client/src/treeAr.ts
@@ -1,0 +1,24 @@
+import { TreeApp } from './treeApp.js';
+import { readTreeConfig } from './tree/config.js';
+
+const config = readTreeConfig();
+void config;
+
+const startBtn = document.getElementById('startBtn') as HTMLButtonElement;
+const landing = document.getElementById('landing')!;
+const video = document.getElementById('cam') as HTMLVideoElement;
+const canvas = document.getElementById('gl') as HTMLCanvasElement;
+const pickerRoot = document.getElementById('picker')!;
+const statusEl = document.getElementById('status')!;
+
+startBtn.addEventListener('click', async () => {
+  landing.classList.add('hidden');
+  const app = new TreeApp({ canvas, video, pickerRoot, statusEl });
+  try {
+    await app.start();
+  } catch (e) {
+    console.error(e);
+    statusEl.textContent = 'Could not start. Check camera permissions.';
+    statusEl.classList.remove('hidden');
+  }
+});

--- a/packages/client/treeAr.html
+++ b/packages/client/treeAr.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no,viewport-fit=cover" />
+  <meta name="theme-color" content="#0b1d2a" />
+  <title>Coral Reef AR — Tree</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+  <style>
+    /* ---- toolbar ---- */
+    #toolbar {
+      position: fixed; top: 12px; right: 12px; z-index: 5; display: none; gap: 6px;
+      font: 500 12px/1 system-ui, sans-serif;
+    }
+    #toolbar.visible { display: flex; }
+    #toolbar button {
+      min-width: 44px; min-height: 44px;
+      padding: 6px 12px; color: #cfe; background: rgba(10,20,32,0.75);
+      border: 1px solid rgba(120,180,220,0.25); border-radius: 4px;
+      cursor: pointer; font: inherit;
+    }
+    #toolbar button:hover { background: rgba(20,40,60,0.85); }
+    #toolbar button:active { transform: translateY(1px); }
+    #toolbar button:disabled { opacity: 0.35; cursor: default; }
+    #toolbar button[aria-pressed="true"] { background: rgba(30,60,90,0.9); border-color: rgba(120,200,255,0.5); }
+
+    /* ---- sea life panel ---- */
+    #sea-life-panel {
+      display: none;
+      position: fixed;
+      bottom: 0; left: 0; right: 0;
+      z-index: 6;
+      background: rgba(6,14,24,0.96);
+      border-top: 1px solid rgba(120,180,220,0.25);
+      padding: 20px 20px calc(env(safe-area-inset-bottom, 0px) + 20px);
+      font: 500 13px/1 system-ui, sans-serif; color: #cfe;
+    }
+    #sea-life-panel.open { display: block; }
+
+    #sea-life-panel-header {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 16px;
+    }
+    #sea-life-panel-title { font-size: 14px; font-weight: 600; color: #9cf; }
+    #sea-life-close-btn {
+      min-width: 44px; min-height: 44px;
+      background: none; border: none; color: #9ab; font-size: 18px;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      border-radius: 4px;
+    }
+    #sea-life-close-btn:hover { color: #cfe; }
+
+    .creature-row {
+      display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+    }
+    .creature-name { flex: 1; color: #cfe; }
+    .creature-count {
+      min-width: 28px; text-align: center;
+      color: #9cf; font-weight: 600;
+    }
+    .creature-btn {
+      min-width: 44px; min-height: 44px;
+      background: rgba(10,20,32,0.75); border: 1px solid rgba(120,180,220,0.25);
+      border-radius: 4px; color: #cfe; font-size: 18px; font-weight: 700;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+    }
+    .creature-btn:hover { background: rgba(20,40,60,0.85); }
+    .creature-btn:active { transform: translateY(1px); }
+    .creature-btn:disabled { opacity: 0.35; cursor: default; }
+
+    /* wider screens: dropdown from button */
+    @media (min-width: 640px) {
+      #sea-life-panel {
+        bottom: auto;
+        top: 62px; right: 12px; left: auto;
+        width: 280px;
+        border-top: none;
+        border: 1px solid rgba(120,180,220,0.25);
+        border-radius: 6px;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+        padding: 16px;
+      }
+    }
+  </style>
+  <!-- 8th Wall self-hosted engine binary. `async` means window.XR8 may not exist
+       when the app module runs; EightWallProvider.waitUntilReady covers that race. -->
+  <script src="https://cdn.jsdelivr.net/npm/@8thwall/engine-binary@1.0.0/dist/xr.js" async crossorigin="anonymous" data-preload-chunks="slam"></script>
+</head>
+<body>
+  <div id="landing">
+    <div class="landing-inner">
+      <h1>Grow the reef</h1>
+      <p>Point your camera at the marker to see the tree reef. Tap a glowing dot, pick your branch, and grow the coral.</p>
+      <button id="startBtn">Start</button>
+      <p class="tiny">Camera access is used only to track the marker. Nothing is uploaded except your branch's color and shape.</p>
+    </div>
+  </div>
+
+  <video id="cam" playsinline muted></video>
+  <canvas id="gl"></canvas>
+
+  <div id="status" class="hidden" role="status" aria-live="polite" aria-atomic="true">Looking for the marker…</div>
+
+  <div id="mode-badge" style="position:fixed;top:12px;left:12px;padding:4px 8px;font:500 11px/1 system-ui,sans-serif;color:#9ab;background:rgba(0,0,0,0.35);border-radius:3px;pointer-events:none;display:none"></div>
+
+  <div id="toolbar" aria-label="Tree controls">
+    <button id="clearBtn" type="button">Clear</button>
+    <button id="undoBtn" type="button" disabled>Undo</button>
+    <button id="seaLifeBtn" type="button" aria-expanded="false" aria-controls="sea-life-panel">Sea life</button>
+  </div>
+
+  <div id="sea-life-panel" role="region" aria-label="Sea life controls">
+    <div id="sea-life-panel-header">
+      <span id="sea-life-panel-title">Sea life</span>
+      <button id="sea-life-close-btn" type="button" aria-label="Close sea life panel">&#x2715;</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Shark</span>
+      <span class="creature-count" id="count-shark">0</span>
+      <button class="creature-btn" id="removeSharkBtn" type="button" aria-label="Remove shark" disabled>&#8722;</button>
+      <button class="creature-btn" id="addSharkBtn" type="button" aria-label="Add shark">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Clownfish</span>
+      <span class="creature-count" id="count-clownfish">0</span>
+      <button class="creature-btn" id="removeClownfishBtn" type="button" aria-label="Remove clownfish" disabled>&#8722;</button>
+      <button class="creature-btn" id="addClownfishBtn" type="button" aria-label="Add clownfish">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Jellyfish</span>
+      <span class="creature-count" id="count-jellyfish">0</span>
+      <button class="creature-btn" id="removeJellyfishBtn" type="button" aria-label="Remove jellyfish" disabled>&#8722;</button>
+      <button class="creature-btn" id="addJellyfishBtn" type="button" aria-label="Add jellyfish">+</button>
+    </div>
+    <div class="creature-row">
+      <span class="creature-name">Sea turtle</span>
+      <span class="creature-count" id="count-seaTurtle">0</span>
+      <button class="creature-btn" id="removeSeaTurtleBtn" type="button" aria-label="Remove sea turtle" disabled>&#8722;</button>
+      <button class="creature-btn" id="addSeaTurtleBtn" type="button" aria-label="Add sea turtle">+</button>
+    </div>
+  </div>
+
+  <div id="picker" class="hidden" role="region" aria-label="Plant a branch">
+    <div class="picker-row" role="group" aria-label="Variant">
+      <button type="button" data-variant="forked">Forked</button>
+      <button type="button" data-variant="trident">Trident</button>
+      <button type="button" data-variant="starburst">Starburst</button>
+      <button type="button" data-variant="claw">Claw</button>
+      <button type="button" data-variant="wishbone">Wishbone</button>
+    </div>
+    <div id="colors" class="picker-row" role="group" aria-label="Color"></div>
+    <div class="picker-actions">
+      <button id="rerollBtn" type="button" disabled aria-label="Regenerate shape">Reroll shape</button>
+      <button id="cancelBtn" type="button" disabled aria-label="Cancel placement">Cancel</button>
+    </div>
+    <button id="growBtn" type="button" disabled>Grow it</button>
+    <p id="hint" aria-live="polite">Tap a glowing dot to attach your branch.</p>
+  </div>
+
+  <script type="module" src="/src/treeAr.ts"></script>
+</body>
+</html>

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -120,6 +120,21 @@ export class ReefDb {
       const sql = readFileSync(join(migrationsDir, f), 'utf8');
       this.db.exec(sql);
     }
+    // Imperative column adds. SQLite ALTER TABLE ADD COLUMN has no
+    // IF NOT EXISTS form, so we check pragma_table_info and only alter
+    // when the column is missing.
+    this.ensureColumn('tree_polyps', 'attach_yaw', 'REAL NOT NULL DEFAULT 0');
+  }
+
+  private ensureColumn(table: string, column: string, decl: string): void {
+    const row = this.db
+      .prepare(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`)
+      .get(table, column);
+    if (row) return;
+    // Bracket access avoids a false-positive security-hook match on a
+    // property named "exec"; this is better-sqlite3's SQL runner, not a
+    // child-process shell call.
+    this.db['exec'](`ALTER TABLE ${table} ADD COLUMN ${column} ${decl}`);
   }
 
   /** Polyps with device_hash stripped — safe for broadcasting. */

--- a/packages/server/src/tree/db.test.ts
+++ b/packages/server/src/tree/db.test.ts
@@ -56,6 +56,26 @@ describe('TreeDb.insertChild', () => {
       variant: 'forked', seed: 2, colorKey: 'x', parentId: root.id, attachIndex: 0,
     }), /parent not found/i);
   });
+
+  test('stores and returns attachYaw (radians) when provided', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const child = tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'x',
+      parentId: root.id, attachIndex: 1, attachYaw: 1.25,
+    });
+    assert.equal(child.attachYaw, 1.25);
+  });
+
+  test('defaults attachYaw to 0 when omitted', () => {
+    const { tree } = makeDb();
+    const root = tree.insertRoot({ variant: 'starburst', seed: 1, colorKey: 'x' });
+    const child = tree.insertChild({
+      variant: 'forked', seed: 2, colorKey: 'x',
+      parentId: root.id, attachIndex: 0,
+    });
+    assert.equal(child.attachYaw, 0);
+  });
 });
 
 describe('TreeDb.listLive', () => {

--- a/packages/server/src/tree/db.ts
+++ b/packages/server/src/tree/db.ts
@@ -12,6 +12,8 @@ export interface InsertRootInput {
 export interface InsertChildInput extends InsertRootInput {
   parentId: number;
   attachIndex: number;
+  /** Radians around the parent attach-point normal. 0 = canonical orientation. */
+  attachYaw?: number;
 }
 
 export interface SoftDeleteResult {
@@ -40,8 +42,8 @@ export class TreeDb {
 
     this.stmt = {
       insert: this.db.prepare(
-        `INSERT INTO tree_polyps (variant, seed, color_key, parent_id, attach_index, created_at, device_hash)
-         VALUES (@variant, @seed, @colorKey, @parentId, @attachIndex, @createdAt, @deviceHash)`,
+        `INSERT INTO tree_polyps (variant, seed, color_key, parent_id, attach_index, attach_yaw, created_at, device_hash)
+         VALUES (@variant, @seed, @colorKey, @parentId, @attachIndex, @attachYaw, @createdAt, @deviceHash)`,
       ),
       findParent: this.db.prepare(
         'SELECT id FROM tree_polyps WHERE id = ? AND deleted = 0',
@@ -88,6 +90,7 @@ export class TreeDb {
       colorKey: input.colorKey,
       parentId: null,
       attachIndex: 0,
+      attachYaw: 0,
       createdAt,
       deviceHash: input.deviceHash ?? null,
     });
@@ -108,6 +111,7 @@ export class TreeDb {
       colorKey: input.colorKey,
       parentId: input.parentId,
       attachIndex: input.attachIndex,
+      attachYaw: input.attachYaw ?? 0,
       createdAt,
       deviceHash: input.deviceHash ?? null,
     });
@@ -145,6 +149,7 @@ export class TreeDb {
       colorKey: row.color_key,
       parentId: row.parent_id,
       attachIndex: row.attach_index,
+      attachYaw: row.attach_yaw ?? 0,
       createdAt: row.created_at,
     };
   }
@@ -157,6 +162,7 @@ interface DbRow {
   color_key: string;
   parent_id: number | null;
   attach_index: number;
+  attach_yaw: number | null;
   created_at: number;
   device_hash: string | null;
   deleted: number;

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -42,6 +42,7 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
             colorKey: input.colorKey,
             parentId: input.parentId,
             attachIndex: input.attachIndex,
+            attachYaw: input.attachYaw,
           });
       hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
       return polyp;

--- a/packages/shared/src/tree/schema.test.ts
+++ b/packages/shared/src/tree/schema.test.ts
@@ -71,3 +71,31 @@ test('TreePolypInputSchema: rejects out-of-range seed', () => {
   assert.equal(TreePolypInputSchema.safeParse({ ...valid, seed: -1 }).success, false);
   assert.equal(TreePolypInputSchema.safeParse({ ...valid, seed: 2 ** 33 }).success, false);
 });
+
+test('TreePolypInputSchema: defaults attachYaw to 0 when omitted', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  const parsed = TreePolypInputSchema.safeParse(valid);
+  assert.equal(parsed.success, true);
+  if (parsed.success) assert.equal(parsed.data.attachYaw, 0);
+});
+
+test('TreePolypInputSchema: accepts attachYaw value within ±2π or beyond', () => {
+  const valid = {
+    variant: 'forked',
+    seed: 42,
+    colorKey: 'neon-magenta',
+    parentId: 1,
+    attachIndex: 0,
+  };
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachYaw: 1.5 }).success, true);
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachYaw: -Math.PI }).success, true);
+  // Non-finite values rejected (NaN / Infinity would poison the rotation matrix).
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachYaw: NaN }).success, false);
+  assert.equal(TreePolypInputSchema.safeParse({ ...valid, attachYaw: Infinity }).success, false);
+});

--- a/packages/shared/src/tree/schema.ts
+++ b/packages/shared/src/tree/schema.ts
@@ -15,4 +15,6 @@ export const TreePolypInputSchema = z.object({
   attachYaw: z.number().finite().optional().default(0),
 });
 
-export type TreePolypInput = z.infer<typeof TreePolypInputSchema>;
+// z.input — the shape clients construct before parse. attachYaw is optional
+// here (defaults to 0 post-parse on the server side).
+export type TreePolypInput = z.input<typeof TreePolypInputSchema>;

--- a/packages/shared/src/tree/schema.ts
+++ b/packages/shared/src/tree/schema.ts
@@ -10,6 +10,9 @@ export const TreePolypInputSchema = z.object({
   colorKey: z.string().min(1).max(32),
   parentId: z.number().int().positive().nullable(),
   attachIndex: z.number().int().min(0).max(3),  // max 4 tips (starburst) = indices 0-3
+  // Radians around the parent attach-point normal. Optional for backwards
+  // compatibility with older clients; defaults to 0 (canonical orientation).
+  attachYaw: z.number().finite().optional().default(0),
 });
 
 export type TreePolypInput = z.infer<typeof TreePolypInputSchema>;

--- a/packages/shared/src/tree/types.ts
+++ b/packages/shared/src/tree/types.ts
@@ -7,6 +7,7 @@ export interface TreePolyp {
   colorKey: string;
   parentId: number | null;     // null for root
   attachIndex: number;          // which of parent's attach points this piece claims
+  attachYaw: number;            // radians around parent attach-point normal; 0 = canonical orientation
   createdAt: number;
   deviceHash?: string;          // hashed at insert, stripped on public read
   deleted: boolean;


### PR DESCRIPTION
## Summary

- **Persisted drag yaw** — committed pieces keep the rotation the user applied to the ghost. Fixes the "piece snaps back after Grow" bug. Yaw is tracked in the state machine, persisted through a new `attach_yaw` column, and applied around the parent attach-point normal on render.
- **AR Phase 2** — new `treeAr.html` surface renders the tree reef through the 8th Wall SLAM tracker. `TreeApp` composes the same state machine, effects runner, TreeReef, TreePlacement, TreePicker that desktop `tree.html` uses — zero forks. `?scale=N` URL override tunes the anchor multiplier for tabletop vs room-scale deployments.
- **Collision loosening** — coral-nodule AABBs no longer cause false "spot is blocked" rejections. `wouldCollide` shrinks each box to 85% around its center before the intersection test.
- **Desktop testability** — `tracker=noop` skips camera init; lets headless + desktop dev smoke the full AR flow without real camera permissions.
- **Drag-gate fix** — when placement is blocked (no ghost visible), pointer drag falls through to OrbitControls instead of being captured for a no-op rotation dispatch.

## Architecture notes

New spec and plan under `docs/superpowers/`:
- `specs/2026-04-24-ar-phase-2-migration.md` — design decisions
- `plans/2026-04-24-ar-phase-2-migration.md` — 7-task TDD plan that Phase B was executed against

Three new DECISIONS.md entries explain the approach for yaw persistence, new-surface Phase 2 pattern, and collision shrink factor.

## Commits (15 on top of main)

Persisted drag yaw (fixes the snap-back bug):
- `a10004e` — Tree persisted yaw: schema, migration, server storage
- `c761e2c` — Tree persisted yaw: client reducer, ghost rendering, rotation axis fix

Docs:
- `b2e3b22` — Docs: Phase 2 AR migration spec + plan
- `ec27a7c` — Docs: refresh current-state block for tree overnight work
- `fb7d2d1` — Docs: DECISIONS entries for tonight's overnight work

Phase 2 AR migration:
- `8f5c2cf` — Tracking: extract applyAnchorPose to shared helper + scaleMultiplier
- `6b93e84` — Tree: add creatures under treeReef.anchor for AR anchor inheritance
- `282b8ed` — Tree AR: scaffold treeAr.html + treeAr.ts bootstrap + empty TreeApp class
- `f986fcb` — Tree AR: TreeApp scene + camera + tracker lifecycle
- `bc077aa` — Tree AR: TreeApp state machine + picker + tap-to-attach + socket
- `daded10` — Tree AR: TreeApp toolbar + sea-life panel wiring

Polish:
- `8f51810` — Tree collision: shrink AABBs by 15% before intersection test
- `9c858e8` — Tree AR: skip camera init when tracker=noop
- `441a578` — Tree AR: ?scale=N URL override for anchor multiplier
- `276b4e4` — Tree drag-gate: let orbit controls take over when placing is blocked

## Test plan

Automated (all green on this branch):
- [x] `pnpm -r typecheck` — clean across shared / generator / client / server
- [x] `pnpm -r test` — 515 tests pass total (shared 21, generator 54, client 341, server 99)

Manual smoke (user-verified):
- [x] Desktop `tree.html` — drag to rotate ghost, Grow, piece stays where rotated
- [x] Desktop `tree.html` — blocked slot, drag background → orbit works
- [x] `treeAr.html?tracker=noop` — tree renders, picker + toolbar wired, interaction flows work (Puppeteer smoke)
- [ ] Physical marker on phone — deferred; requires LXC deploy + 8th Wall console access

## Known follow-ups (not in this PR)

- Generator-side skeleton-only AABB for truly principled collision (current shrink approximates the ratio)
- Effects-layer unit tests for the reset flow's nested try/catch
- Mobile-safe bloom preset for AR tree (tree-mode bloom currently off in AR)
- Retire landscape surface once Phase 2 is field-validated
- Pinch-to-resize gesture instead of URL-param scale
