### PR TITLE
fix(tree): handle pointercancel so mobile gestures can't wedge OrbitControls

### DIFF
--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -30,6 +30,7 @@ import { Jellyfish } from './tree/jellyfish.js';
 import { SeaTurtle } from './tree/seaTurtle.js';
 import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
 import { createEffects } from './tree/effects.js';
+import { installDragRotate } from './tree/dragRotate.js';
 
 // ------------------------------------------------------------------
 // Config + canvas
@@ -322,40 +323,21 @@ function refreshUndoBtn(): void {
 // ------------------------------------------------------------------
 // Pointer-drag: rotate ghost in place instead of orbiting while placing.
 // ------------------------------------------------------------------
-let dragState: { lastX: number; moved: boolean } | null = null;
 let suppressNextClick = false;
-const DRAG_THRESHOLD_PX = 3;
-const ROT_SENSITIVITY = 0.0055;
 
-canvas.addEventListener(
-  'pointerdown',
-  (ev) => {
-    // Drag-to-rotate only engages when a ghost is actually pending. When
-    // placing is blocked there's no ghost on-screen, so drags should fall
-    // through to OrbitControls (camera orbit) rather than being captured
-    // for a no-op GHOST_ROTATED dispatch.
-    if (state.kind !== 'placing' || state.blocked) return;
-    if (config.mode !== 'screen') controls.enabled = false;
-    dragState = { lastX: ev.clientX, moved: false };
-    canvas.setPointerCapture(ev.pointerId);
+// Drag-to-rotate only engages when a ghost is actually pending. When placing is
+// blocked there's no ghost on-screen, so drags fall through to OrbitControls
+// (camera orbit) rather than being captured for a no-op GHOST_ROTATED dispatch.
+installDragRotate(canvas, {
+  canRotate: () => state.kind === 'placing' && !state.blocked,
+  keepControlsEnabled: config.mode === 'screen',
+  setControlsEnabled: (enabled) => {
+    controls.enabled = enabled;
   },
-  { capture: true },
-);
-canvas.addEventListener('pointermove', (ev) => {
-  if (!dragState) return;
-  const dx = ev.clientX - dragState.lastX;
-  if (!dragState.moved && Math.abs(dx) > DRAG_THRESHOLD_PX) dragState.moved = true;
-  if (dragState.moved) {
-    dispatch({ type: 'GHOST_ROTATED', deltaRad: dx * ROT_SENSITIVITY });
-    dragState.lastX = ev.clientX;
-  }
-});
-canvas.addEventListener('pointerup', (ev) => {
-  if (!dragState) return;
-  if (canvas.hasPointerCapture(ev.pointerId)) canvas.releasePointerCapture(ev.pointerId);
-  suppressNextClick = dragState.moved;
-  dragState = null;
-  if (config.mode !== 'screen') controls.enabled = true;
+  onRotate: (deltaRad) => dispatch({ type: 'GHOST_ROTATED', deltaRad }),
+  onDragEnd: (moved) => {
+    suppressNextClick = moved;
+  },
 });
 
 // ------------------------------------------------------------------

--- a/packages/client/src/tree/dragRotate.test.ts
+++ b/packages/client/src/tree/dragRotate.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { installDragRotate, type DragRotateDeps } from './dragRotate.js';
+
+// happy-dom doesn't implement pointer capture; stub it so the handlers that
+// guard on hasPointerCapture exercise the same branch they would in a browser.
+function makeCanvas(): HTMLElement {
+  const el = document.createElement('div');
+  const captured = new Set<number>();
+  el.setPointerCapture = (id: number) => {
+    captured.add(id);
+  };
+  el.releasePointerCapture = (id: number) => {
+    captured.delete(id);
+  };
+  el.hasPointerCapture = (id: number) => captured.has(id);
+  return el;
+}
+
+function pointer(type: string, clientX = 0, pointerId = 1): Event {
+  const ev = new Event(type, { bubbles: true });
+  Object.assign(ev, { clientX, pointerId });
+  return ev;
+}
+
+function makeDeps(over: Partial<DragRotateDeps> = {}): DragRotateDeps {
+  return {
+    canRotate: () => true,
+    keepControlsEnabled: false,
+    setControlsEnabled: vi.fn(),
+    onRotate: vi.fn(),
+    onDragEnd: vi.fn(),
+    ...over,
+  };
+}
+
+describe('installDragRotate', () => {
+  let canvas: HTMLElement;
+
+  beforeEach(() => {
+    canvas = makeCanvas();
+  });
+
+  test('does not engage when canRotate() is false', () => {
+    const deps = makeDeps({ canRotate: () => false });
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    canvas.dispatchEvent(pointer('pointermove', 50));
+    expect(deps.setControlsEnabled).not.toHaveBeenCalled();
+    expect(deps.onRotate).not.toHaveBeenCalled();
+    expect(canvas.hasPointerCapture(1)).toBe(false);
+  });
+
+  test('disables controls on down, rotates on move past threshold, re-enables and suppresses click on up', () => {
+    const deps = makeDeps();
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    expect(deps.setControlsEnabled).toHaveBeenLastCalledWith(false);
+    expect(canvas.hasPointerCapture(1)).toBe(true);
+
+    canvas.dispatchEvent(pointer('pointermove', 1)); // under 3px threshold
+    expect(deps.onRotate).not.toHaveBeenCalled();
+    canvas.dispatchEvent(pointer('pointermove', 20)); // past threshold
+    expect(deps.onRotate).toHaveBeenCalledTimes(1);
+
+    canvas.dispatchEvent(pointer('pointerup', 20));
+    expect(deps.setControlsEnabled).toHaveBeenLastCalledWith(true);
+    expect(deps.onDragEnd).toHaveBeenCalledWith(true);
+    expect(canvas.hasPointerCapture(1)).toBe(false);
+  });
+
+  test('a tap (no movement) ends with moved=false so the click is not suppressed', () => {
+    const deps = makeDeps();
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 5));
+    canvas.dispatchEvent(pointer('pointerup', 5));
+    expect(deps.onDragEnd).toHaveBeenCalledWith(false);
+  });
+
+  test('pointercancel mid-drag releases capture, re-enables controls, and reports moved=false', () => {
+    const deps = makeDeps();
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    canvas.dispatchEvent(pointer('pointermove', 40));
+    expect(deps.onRotate).toHaveBeenCalled();
+
+    // System gesture interrupts the drag: pointercancel, never pointerup.
+    canvas.dispatchEvent(pointer('pointercancel', 40));
+    expect(canvas.hasPointerCapture(1)).toBe(false);
+    expect(deps.setControlsEnabled).toHaveBeenLastCalledWith(true);
+    expect(deps.onDragEnd).toHaveBeenCalledWith(false);
+
+    // Controls must not be wedged off: a fresh drag still works afterward.
+    (deps.setControlsEnabled as ReturnType<typeof vi.fn>).mockClear();
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    expect(deps.setControlsEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  test('screen mode keeps controls enabled throughout the drag', () => {
+    const deps = makeDeps({ keepControlsEnabled: true });
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    canvas.dispatchEvent(pointer('pointermove', 40));
+    canvas.dispatchEvent(pointer('pointercancel', 40));
+    expect(deps.setControlsEnabled).not.toHaveBeenCalled();
+    expect(deps.onRotate).toHaveBeenCalled();
+  });
+
+  test('setPointerCapture throwing leaves controls untouched and lets the next drag arm', () => {
+    const deps = makeDeps();
+    canvas.setPointerCapture = () => {
+      throw new DOMException('not active', 'InvalidStateError');
+    };
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    // Controls must not be disabled for a drag that never armed.
+    expect(deps.setControlsEnabled).not.toHaveBeenCalled();
+    canvas.dispatchEvent(pointer('pointermove', 40));
+    expect(deps.onRotate).not.toHaveBeenCalled();
+
+    // Recover: capture works again, a normal drag arms.
+    canvas = makeCanvas();
+    const deps2 = makeDeps();
+    installDragRotate(canvas, deps2);
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    expect(deps2.setControlsEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  test('a second pointer does not tear down the active drag', () => {
+    const deps = makeDeps();
+    installDragRotate(canvas, deps);
+    canvas.dispatchEvent(pointer('pointerdown', 0, 1));
+    // A different pointer releasing must not end the captured drag.
+    canvas.dispatchEvent(pointer('pointerup', 5, 2));
+    expect(deps.onDragEnd).not.toHaveBeenCalled();
+    expect(canvas.hasPointerCapture(1)).toBe(true);
+    // The captured pointer still rotates.
+    canvas.dispatchEvent(pointer('pointermove', 40, 1));
+    expect(deps.onRotate).toHaveBeenCalled();
+  });
+
+  test('disposer removes listeners', () => {
+    const deps = makeDeps();
+    const dispose = installDragRotate(canvas, deps);
+    dispose();
+    canvas.dispatchEvent(pointer('pointerdown', 0));
+    expect(deps.setControlsEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/tree/dragRotate.ts
+++ b/packages/client/src/tree/dragRotate.ts
@@ -1,0 +1,80 @@
+// Pointer-drag-to-rotate: while a ghost piece is pending, horizontal drags
+// rotate it in place instead of orbiting the camera. Extracted from tree.ts so
+// the pointer lifecycle (including pointercancel) is unit-testable.
+
+export interface DragRotateDeps {
+  /** True when a ghost is pending and drag-to-rotate should engage. */
+  canRotate: () => boolean;
+  /** When true (screen mode) OrbitControls stays enabled during the drag. */
+  keepControlsEnabled: boolean;
+  setControlsEnabled: (enabled: boolean) => void;
+  onRotate: (deltaRad: number) => void;
+  /**
+   * Called once when a drag ends. `moved` is true when the pointer passed the
+   * drag threshold, so the synthetic click that follows a pointerup should be
+   * suppressed. A pointercancel always reports `moved: false` because no click
+   * follows an aborted gesture.
+   */
+  onDragEnd: (moved: boolean) => void;
+}
+
+const DRAG_THRESHOLD_PX = 3;
+const ROT_SENSITIVITY = 0.0055;
+
+/**
+ * Wires pointer-drag-to-rotate onto `canvas`. Returns a disposer that removes
+ * the listeners. Handles pointerup AND pointercancel so a system gesture that
+ * aborts a drag mid-flight (notification, back-swipe) still releases pointer
+ * capture and re-enables OrbitControls instead of wedging them off.
+ */
+export function installDragRotate(canvas: HTMLElement, deps: DragRotateDeps): () => void {
+  let dragState: { pointerId: number; lastX: number; moved: boolean } | null = null;
+
+  const onDown = (ev: PointerEvent) => {
+    if (!deps.canRotate()) return;
+    // Capture first: setPointerCapture throws InvalidStateError for a pointer
+    // that isn't in the active-buttons state. Committing the controls toggle
+    // and dragState only after it succeeds guarantees we never disable
+    // OrbitControls for a drag that never armed.
+    try {
+      canvas.setPointerCapture(ev.pointerId);
+    } catch {
+      return;
+    }
+    if (!deps.keepControlsEnabled) deps.setControlsEnabled(false);
+    dragState = { pointerId: ev.pointerId, lastX: ev.clientX, moved: false };
+  };
+
+  const onMove = (ev: PointerEvent) => {
+    if (!dragState || ev.pointerId !== dragState.pointerId) return;
+    const dx = ev.clientX - dragState.lastX;
+    if (!dragState.moved && Math.abs(dx) > DRAG_THRESHOLD_PX) dragState.moved = true;
+    if (dragState.moved) {
+      deps.onRotate(dx * ROT_SENSITIVITY);
+      dragState.lastX = ev.clientX;
+    }
+  };
+
+  const endDrag = (ev: PointerEvent, moved: boolean) => {
+    if (!dragState || ev.pointerId !== dragState.pointerId) return;
+    if (canvas.hasPointerCapture(ev.pointerId)) canvas.releasePointerCapture(ev.pointerId);
+    dragState = null;
+    if (!deps.keepControlsEnabled) deps.setControlsEnabled(true);
+    deps.onDragEnd(moved);
+  };
+
+  const onUp = (ev: PointerEvent) => endDrag(ev, dragState?.moved ?? false);
+  const onCancel = (ev: PointerEvent) => endDrag(ev, false);
+
+  canvas.addEventListener('pointerdown', onDown, { capture: true });
+  canvas.addEventListener('pointermove', onMove);
+  canvas.addEventListener('pointerup', onUp);
+  canvas.addEventListener('pointercancel', onCancel);
+
+  return () => {
+    canvas.removeEventListener('pointerdown', onDown, { capture: true });
+    canvas.removeEventListener('pointermove', onMove);
+    canvas.removeEventListener('pointerup', onUp);
+    canvas.removeEventListener('pointercancel', onCancel);
+  };
+}


### PR DESCRIPTION
## Summary
Tree mode disabled OrbitControls on `pointerdown` and only re-enabled it on `pointerup`. A mobile system gesture (notification shade, back-swipe) mid-drag fires `pointercancel` instead of `pointerup`, leaving OrbitControls disabled and pointer capture held until a page reload.

## Why
The drag-to-rotate handlers had no `pointercancel` path, so any aborted gesture wedged the camera controls off. Fixing it also surfaced a latent ordering bug: `controls.enabled = false` was set before `setPointerCapture`, which can throw for a non-active pointer and strand controls in the off state.

## What changed
- Extracted the drag-rotate pointer lifecycle from `tree.ts` into a testable `installDragRotate` helper (`packages/client/src/tree/dragRotate.ts`), behavior-preserving.
- Added a `pointercancel` handler mirroring `pointerup` cleanup, reporting `moved: false` (an aborted gesture produces no click to suppress).
- Capture the pointer before committing the controls toggle, so a `setPointerCapture` throw can't wedge controls off.
- Gate move/up/cancel on the captured `pointerId` so a second touch can't tear down an active drag.

## Test plan
- [x] New `dragRotate.test.ts` (8 cases): engage/threshold, tap vs drag, pointercancel recovery, screen-mode, capture-throw recovery, multi-touch, dispose
- [x] `pnpm lint` clean, `pnpm --filter @reef/client typecheck` clean
- [x] Full client suite green (349 tests)
- [ ] Manual: drag-rotate a ghost on a touch device, trigger a system gesture mid-drag, confirm controls recover

Closes #96