### PR TITLE
fix(tree): unstick Grow after a rejected commit + invalidate undo on HTTP load

### DIFF
--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -28,7 +28,13 @@ import { Shark } from './tree/shark.js';
 import { Clownfish } from './tree/clownfish.js';
 import { Jellyfish } from './tree/jellyfish.js';
 import { SeaTurtle } from './tree/seaTurtle.js';
-import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
+import {
+  addedPolypsInvalidateUndo,
+  initialState,
+  reduce,
+  type TreeAction,
+  type TreeState,
+} from './tree/state.js';
 import { createEffects } from './tree/effects.js';
 import { installDragRotate } from './tree/dragRotate.js';
 
@@ -108,6 +114,10 @@ function addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
   for (const polyp of sorted) treeReef.addPiece(polyp);
   installEffectsOnNewPieces();
   attachIndicators.refresh(treeReef.getAvailableAttachPoints());
+  // A child loaded over HTTP (not just over WS) also invalidates our undo.
+  if (addedPolypsInvalidateUndo(state, sorted)) {
+    dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
+  }
 }
 
 // ------------------------------------------------------------------
@@ -427,12 +437,7 @@ socket.on((msg) => {
     attachIndicators.refresh(treeReef.getAvailableAttachPoints());
     // If someone built on top of our last commit, we can no longer undo it
     // (the server enforces leaf-only deletes). Invalidate lastCommittedId.
-    if (
-      state.kind !== 'undoing' &&
-      'lastCommittedId' in state &&
-      state.lastCommittedId !== null &&
-      msg.polyp.parentId === state.lastCommittedId
-    ) {
+    if (addedPolypsInvalidateUndo(state, [msg.polyp])) {
       dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
     }
   } else if (msg.type === 'tree_polyp_removed') {

--- a/packages/client/src/tree/state.test.ts
+++ b/packages/client/src/tree/state.test.ts
@@ -1,7 +1,46 @@
 import { describe, expect, test } from 'vitest';
-import { initialState, reduce, type TreeAction, type TreeState } from './state.js';
+import {
+  addedPolypsInvalidateUndo,
+  initialState,
+  reduce,
+  type TreeAction,
+  type TreeState,
+} from './state.js';
 
 const idlePicker = { variant: 'forked', colorKey: 'neon-cyan' } as const;
+
+describe('addedPolypsInvalidateUndo', () => {
+  const idleWithCommit: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: 42 };
+
+  test('true when a loaded polyp is a child of the last committed piece', () => {
+    expect(addedPolypsInvalidateUndo(idleWithCommit, [{ parentId: 42 }])).toBe(true);
+  });
+
+  test('true when any one of several added polyps is a child', () => {
+    const added = [{ parentId: 1 }, { parentId: 42 }, { parentId: 7 }];
+    expect(addedPolypsInvalidateUndo(idleWithCommit, added)).toBe(true);
+  });
+
+  test('false when no added polyp builds on the last committed piece', () => {
+    expect(addedPolypsInvalidateUndo(idleWithCommit, [{ parentId: 7 }, { parentId: null }])).toBe(
+      false,
+    );
+  });
+
+  test('false when there is no last committed piece', () => {
+    const idle: TreeState = { kind: 'idle', picker: idlePicker, lastCommittedId: null };
+    expect(addedPolypsInvalidateUndo(idle, [{ parentId: 42 }])).toBe(false);
+  });
+
+  test('false while undoing (no lastCommittedId to invalidate)', () => {
+    const undoing: TreeState = { kind: 'undoing', picker: idlePicker, polypId: 42 };
+    expect(addedPolypsInvalidateUndo(undoing, [{ parentId: 42 }])).toBe(false);
+  });
+
+  test('false for an empty added list', () => {
+    expect(addedPolypsInvalidateUndo(idleWithCommit, [])).toBe(false);
+  });
+});
 
 describe('initialState', () => {
   test('returns idle with the provided picker selection', () => {

--- a/packages/client/src/tree/state.ts
+++ b/packages/client/src/tree/state.ts
@@ -55,6 +55,23 @@ export function initialState(picker: PickerSelection): TreeState {
   return { kind: 'idle', picker, lastCommittedId: null };
 }
 
+/**
+ * True when any newly-added polyp builds directly on the piece the local user
+ * last committed. The server enforces leaf-only deletes, so once a child exists
+ * the local undo is no longer valid and `lastCommittedId` must be invalidated.
+ * Shared by the WS `tree_polyp_added` path and the HTTP load/refresh path so
+ * both invalidate undo identically regardless of how the child arrives.
+ */
+export function addedPolypsInvalidateUndo(
+  state: TreeState,
+  added: ReadonlyArray<{ parentId: number | null }>,
+): boolean {
+  if (state.kind === 'undoing') return false;
+  const committedId = state.lastCommittedId;
+  if (committedId === null) return false;
+  return added.some((p) => p.parentId === committedId);
+}
+
 export function reduce(state: TreeState, action: TreeAction): TreeState {
   switch (action.type) {
     case 'VARIANT_CHOSEN': {

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -12,7 +12,13 @@ import { Jellyfish } from './tree/jellyfish.js';
 import { SeaTurtle } from './tree/seaTurtle.js';
 import { installSway } from './scene/currentSway.js';
 import { installTreePulse } from './tree/pulse.js';
-import { initialState, reduce, type TreeAction, type TreeState } from './tree/state.js';
+import {
+  addedPolypsInvalidateUndo,
+  initialState,
+  reduce,
+  type TreeAction,
+  type TreeState,
+} from './tree/state.js';
 import { createEffects } from './tree/effects.js';
 import { applyAnchorPose } from './tracking/anchor.js';
 import { readTrackerFromUrl, selectProvider } from './tracking/index.js';
@@ -323,12 +329,7 @@ export class TreeApp {
         this.treeReef.addPiece(msg.polyp);
         this.installEffectsOnNewPieces();
         this.attachIndicators.refresh(this.treeReef.getAvailableAttachPoints());
-        if (
-          this.state.kind !== 'undoing' &&
-          'lastCommittedId' in this.state &&
-          this.state.lastCommittedId !== null &&
-          msg.polyp.parentId === this.state.lastCommittedId
-        ) {
+        if (addedPolypsInvalidateUndo(this.state, [msg.polyp])) {
           this.dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
         }
       } else if (msg.type === 'tree_polyp_removed') {
@@ -359,6 +360,10 @@ export class TreeApp {
     for (const polyp of sorted) this.treeReef.addPiece(polyp);
     this.installEffectsOnNewPieces();
     this.attachIndicators.refresh(this.treeReef.getAvailableAttachPoints());
+    // A child loaded over HTTP (not just over WS) also invalidates our undo.
+    if (addedPolypsInvalidateUndo(this.state, sorted)) {
+      this.dispatch({ type: 'LAST_COMMITTED_INVALIDATED' });
+    }
   }
 
   private installEffectsOnNewPieces(): void {

--- a/packages/client/src/ui/picker.test.ts
+++ b/packages/client/src/ui/picker.test.ts
@@ -108,6 +108,32 @@ describe('Picker', () => {
     expect(grow.textContent).toBe('Grow it');
   });
 
+  test('setSubmitting(false) re-enables actions when committable (rejected-commit path)', () => {
+    const p = new Picker(mountPickerDom());
+    const grow = document.getElementById('growBtn') as HTMLButtonElement;
+    const reroll = document.getElementById('rerollBtn') as HTMLButtonElement;
+    const cancel = document.getElementById('cancelBtn') as HTMLButtonElement;
+    // Placing a ghost makes the picker committable, then a commit is attempted.
+    p.setCommittable(true);
+    p.setSubmitting(true);
+    expect(grow.disabled).toBe(true);
+    // The commit is rejected: it unwinds via setSubmitting(false) alone, with no
+    // following setCommittable. The Grow button must become usable again.
+    p.setSubmitting(false);
+    expect(grow.disabled).toBe(false);
+    expect(reroll.disabled).toBe(false);
+    expect(cancel.disabled).toBe(false);
+  });
+
+  test('setSubmitting(false) keeps actions disabled when not committable', () => {
+    const p = new Picker(mountPickerDom());
+    const grow = document.getElementById('growBtn') as HTMLButtonElement;
+    p.setCommittable(false);
+    p.setSubmitting(true);
+    p.setSubmitting(false);
+    expect(grow.disabled).toBe(true);
+  });
+
   test('setHint updates the #hint text', () => {
     const p = new Picker(mountPickerDom());
     p.setHint('now with a longer message');

--- a/packages/client/src/ui/picker.ts
+++ b/packages/client/src/ui/picker.ts
@@ -29,17 +29,24 @@ export class Picker {
   onChange(l: PickerListener): void { this.listeners.push(l); }
   get(): PickerState { return this.state; }
 
+  private committable = false;
+
   setCommittable(ok: boolean): void {
+    this.committable = ok;
     this.growBtn.disabled = !ok;
     this.rerollBtn.disabled = !ok;
     this.cancelBtn.disabled = !ok;
   }
 
   setSubmitting(inFlight: boolean): void {
-    this.growBtn.disabled = inFlight || this.growBtn.disabled;
+    // While a commit is in flight every control is disabled. When it settles,
+    // restore them to the committable state rather than leaving them stuck
+    // disabled (a rejected commit unwinds via setSubmitting(false) alone).
+    const disabled = inFlight || !this.committable;
+    this.growBtn.disabled = disabled;
     this.growBtn.textContent = inFlight ? 'Growing…' : 'Grow it';
-    this.rerollBtn.disabled = inFlight;
-    this.cancelBtn.disabled = inFlight;
+    this.rerollBtn.disabled = disabled;
+    this.cancelBtn.disabled = disabled;
   }
 
   onCommit(cb: () => void): void { this.growBtn.addEventListener('click', cb); }

--- a/packages/client/src/ui/treePicker.test.ts
+++ b/packages/client/src/ui/treePicker.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { TreePicker } from './treePicker.js';
+
+function makeButton(id: string, text: string, disabled = false): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.id = id;
+  b.textContent = text;
+  b.disabled = disabled;
+  return b;
+}
+
+function mountTreePickerDom(): HTMLElement {
+  document.body.replaceChildren();
+  const picker = document.createElement('div');
+  picker.id = 'picker';
+
+  const variantRow = document.createElement('div');
+  variantRow.setAttribute('role', 'group');
+  variantRow.setAttribute('aria-label', 'Variant');
+  for (const v of ['forked', 'trident']) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.dataset.variant = v;
+    b.textContent = v;
+    variantRow.appendChild(b);
+  }
+  picker.appendChild(variantRow);
+
+  const colors = document.createElement('div');
+  colors.id = 'colors';
+  picker.appendChild(colors);
+
+  picker.appendChild(makeButton('rerollBtn', 'Reroll', true));
+  picker.appendChild(makeButton('cancelBtn', 'Cancel', true));
+  picker.appendChild(makeButton('growBtn', 'Grow it', true));
+
+  document.body.appendChild(picker);
+  return picker;
+}
+
+describe('TreePicker submit/commit button state', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('setSubmitting(false) re-enables actions when committable (rejected-commit path)', () => {
+    const p = new TreePicker(mountTreePickerDom());
+    const grow = document.getElementById('growBtn') as HTMLButtonElement;
+    const reroll = document.getElementById('rerollBtn') as HTMLButtonElement;
+    const cancel = document.getElementById('cancelBtn') as HTMLButtonElement;
+    p.setCommittable(true);
+    p.setSubmitting(true);
+    expect(grow.disabled).toBe(true);
+    // Rejected commit unwinds via setSubmitting(false) with no following
+    // setCommittable; the Grow button must become usable again.
+    p.setSubmitting(false);
+    expect(grow.disabled).toBe(false);
+    expect(reroll.disabled).toBe(false);
+    expect(cancel.disabled).toBe(false);
+  });
+
+  test('setSubmitting(false) keeps actions disabled when not committable', () => {
+    const p = new TreePicker(mountTreePickerDom());
+    const grow = document.getElementById('growBtn') as HTMLButtonElement;
+    p.setCommittable(false);
+    p.setSubmitting(true);
+    p.setSubmitting(false);
+    expect(grow.disabled).toBe(true);
+  });
+
+  test('setSubmitting(true) renames Grow and disables actions', () => {
+    const p = new TreePicker(mountTreePickerDom());
+    const grow = document.getElementById('growBtn') as HTMLButtonElement;
+    p.setCommittable(true);
+    p.setSubmitting(true);
+    expect(grow.textContent).toBe('Growing…');
+    expect(grow.disabled).toBe(true);
+    p.setSubmitting(false);
+    expect(grow.textContent).toBe('Grow it');
+  });
+});

--- a/packages/client/src/ui/treePicker.ts
+++ b/packages/client/src/ui/treePicker.ts
@@ -50,17 +50,24 @@ export class TreePicker {
     this.emit();
   }
 
+  private committable = false;
+
   setCommittable(ok: boolean): void {
+    this.committable = ok;
     this.growBtn.disabled = !ok;
     this.rerollBtn.disabled = !ok;
     this.cancelBtn.disabled = !ok;
   }
 
   setSubmitting(inFlight: boolean): void {
-    this.growBtn.disabled = inFlight || this.growBtn.disabled;
+    // While a commit is in flight every control is disabled. When it settles,
+    // restore them to the committable state rather than leaving them stuck
+    // disabled (a rejected commit unwinds via setSubmitting(false) alone).
+    const disabled = inFlight || !this.committable;
+    this.growBtn.disabled = disabled;
     this.growBtn.textContent = inFlight ? 'Growing…' : 'Grow it';
-    this.rerollBtn.disabled = inFlight;
-    this.cancelBtn.disabled = inFlight;
+    this.rerollBtn.disabled = disabled;
+    this.cancelBtn.disabled = disabled;
   }
 
   onCommit(cb: () => void): void { this.growBtn.addEventListener('click', cb); }


### PR DESCRIPTION
## Summary
Fixes two tree-mode UI state bugs from issue #100.

## Bug 1: Grow button stuck disabled after a rejected commit
`setSubmitting(inFlight)` did `growBtn.disabled = inFlight || growBtn.disabled`, a latch that could never re-enable the button. The rejected-commit path (`tree/effects.ts` unwinds via `setSubmitting(false)` with no following `setCommittable`) left Grow disabled on a still-valid placement, so a user couldn't retry after a rate-limit or network error without changing selection.

Fix: track a `committable` field and restore all three controls to it when a submission settles. Applied to both `Picker` and `TreePicker`.

## Bug 2: undo not invalidated on the HTTP load path
A child built on the user's last-committed piece must disable undo (the server enforces leaf-only deletes). That check existed only in the WS `tree_polyp_added` handler, not in `addPiecesAndRefresh` (the HTTP load/refresh path).

Fix: extract a pure `addedPolypsInvalidateUndo(state, added)` helper in `tree/state.ts`, called from both the WS handler and `addPiecesAndRefresh` in `tree.ts` and `treeApp.ts`.

## Test plan
- [x] `addedPolypsInvalidateUndo` unit tests (6 cases: child match, multi-add, no match, no commit, undoing, empty)
- [x] `Picker` + `TreePicker` setSubmitting re-enable regression tests
- [x] `pnpm lint`, `pnpm --filter @reef/client typecheck` clean
- [x] Full client suite green (360 tests)

Closes #100