### PR TITLE
fix(tree): validate colorKey against the palette and never throw on a bad key

### DIFF
--- a/packages/client/src/tree/variants.ts
+++ b/packages/client/src/tree/variants.ts
@@ -6,7 +6,7 @@ import {
   SphereGeometry,
   Vector3,
 } from 'three';
-import { paletteByKey, type AttachPoint, type TreeVariant } from '@reef/shared';
+import { paletteByKeyOrDefault, type AttachPoint, type TreeVariant } from '@reef/shared';
 import { generateTreeVariant } from '@reef/generator';
 import { polypMesh } from '../scene/meshAdapter.js';
 import { applyTreeMaterial } from './material.js';
@@ -31,7 +31,7 @@ export function generateTreeVariantMesh(input: {
   const { mesh: meshData, attachPoints, boundingBox: bb } = generateTreeVariant(input);
 
   const mesh = polypMesh(meshData);
-  const hex = paletteByKey(input.colorKey).hex;
+  const hex = paletteByKeyOrDefault(input.colorKey).hex;
   applyTreeMaterial(mesh, hex);
 
   // Joint sphere at local (0,0,0). When the piece is placed at a parent's

--- a/packages/generator/src/generate.ts
+++ b/packages/generator/src/generate.ts
@@ -1,4 +1,4 @@
-import { hexToRgb, paletteByKey, type Species } from '@reef/shared';
+import { hexToRgb, paletteByKeyOrDefault, type Species } from '@reef/shared';
 import { RNG } from './rng.js';
 import type { MeshData } from './meshdata.js';
 import { generateBranching } from './species/branching.js';
@@ -31,6 +31,9 @@ const BUILDERS: Record<Species, Builder> = {
 
 export function generatePolyp(opts: GenerateOptions): GeneratedPolyp {
   const rng = new RNG(opts.seed);
-  const color = hexToRgb(paletteByKey(opts.colorKey).hex);
+  // Tolerant resolve: an unknown colorKey (only reachable from a stale row
+  // predating the schema enum) renders with the fallback colour instead of
+  // throwing and blanking the whole reef. The write path validates via zod.
+  const color = hexToRgb(paletteByKeyOrDefault(opts.colorKey).hex);
   return BUILDERS[opts.species]!(rng, color);
 }

--- a/packages/generator/src/species/_common.ts
+++ b/packages/generator/src/species/_common.ts
@@ -1,4 +1,4 @@
-import { hexToRgb, paletteByKey } from '@reef/shared';
+import { hexToRgb, paletteByKeyOrDefault } from '@reef/shared';
 import type { RNG } from '../rng.js';
 
 export type Rgb = [number, number, number];
@@ -6,9 +6,11 @@ export type Rgb = [number, number, number];
 /**
  * Resolve a palette key to a normalised [r, g, b] triple in [0, 1]^3.
  * Used by tree-mode variant generators that receive a colorKey string.
+ * Falls back to the default palette colour on an unknown key (warning once)
+ * so a single malformed row can't throw and brick the whole reef render.
  */
 export function colorVec3(colorKey: string): Rgb {
-  return hexToRgb(paletteByKey(colorKey).hex);
+  return hexToRgb(paletteByKeyOrDefault(colorKey).hex);
 }
 
 export function tintColor(rng: RNG, base: Rgb, jitter = 0.12): Rgb {

--- a/packages/generator/src/tree/index.test.ts
+++ b/packages/generator/src/tree/index.test.ts
@@ -1,6 +1,8 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
+import { TREE_VARIANT_ATTACH_COUNTS, type TreeVariant } from '@reef/shared';
 import { generateTreeVariant } from './index.js';
+import { generatePolyp } from '../generate.js';
 
 describe('generateTreeVariant', () => {
   test('dispatches to each of the 5 variants', () => {
@@ -22,5 +24,37 @@ describe('generateTreeVariant', () => {
     assert.throws(() => generateTreeVariant({
       variant: 'rubbish' as never, seed: 1, colorKey: 'neon-magenta',
     }));
+  });
+
+  // Sync guard: the shared schema's attachIndex bound is derived from
+  // TREE_VARIANT_ATTACH_COUNTS. If a variant builder's real attach-point count
+  // ever diverges from the declared map, this fails so the schema gets updated
+  // instead of silently 400-ing valid placements.
+  test('each variant exposes exactly its declared attach-point count', () => {
+    for (const [variant, count] of Object.entries(TREE_VARIANT_ATTACH_COUNTS) as [
+      TreeVariant,
+      number,
+    ][]) {
+      const out = generateTreeVariant({ variant, seed: 7, colorKey: 'neon-cyan' });
+      assert.equal(
+        out.attachPoints.length,
+        count,
+        `${variant} exposes ${out.attachPoints.length} attach points, map says ${count}`,
+      );
+    }
+  });
+
+  test('unknown colorKey falls back instead of throwing', () => {
+    assert.doesNotThrow(() =>
+      generateTreeVariant({ variant: 'forked', seed: 1, colorKey: 'not-a-real-key' }),
+    );
+  });
+});
+
+describe('generatePolyp (reef) colorKey resilience', () => {
+  test('unknown colorKey falls back instead of throwing the whole reef render', () => {
+    assert.doesNotThrow(() =>
+      generatePolyp({ species: 'branching', seed: 1, colorKey: 'stale-bad-key' }),
+    );
   });
 });

--- a/packages/server/src/tree/routes.test.ts
+++ b/packages/server/src/tree/routes.test.ts
@@ -46,13 +46,13 @@ describe('POST /api/tree/polyp', () => {
     const { app, close } = await makeServer();
     const root = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     const rootId = (JSON.parse(root.body) as { id: number }).id;
 
     const child = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 1 },
+      payload: { variant: 'forked', seed: 2, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 1 },
     });
     assert.equal(child.statusCode, 200);
     assert.equal((JSON.parse(child.body) as { parentId: number }).parentId, rootId);
@@ -63,17 +63,17 @@ describe('POST /api/tree/polyp', () => {
     const { app, close } = await makeServer();
     const root = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     const rootId = (JSON.parse(root.body) as { id: number }).id;
 
     await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+      payload: { variant: 'forked', seed: 2, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 0 },
     });
     const dup = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'claw', seed: 3, colorKey: 'x', parentId: rootId, attachIndex: 0 },
+      payload: { variant: 'claw', seed: 3, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 0 },
     });
     assert.equal(dup.statusCode, 409);
     assert.match(JSON.parse(dup.body).error as string, /claim/i);
@@ -84,7 +84,7 @@ describe('POST /api/tree/polyp', () => {
     const { app, close } = await makeServer();
     const res = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'forked', seed: 1, colorKey: 'x', parentId: 99999, attachIndex: 0 },
+      payload: { variant: 'forked', seed: 1, colorKey: 'neon-cyan', parentId: 99999, attachIndex: 0 },
     });
     assert.equal(res.statusCode, 404);
     await close();
@@ -94,7 +94,17 @@ describe('POST /api/tree/polyp', () => {
     const { app, close } = await makeServer();
     const res = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'branching', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'branching', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+    });
+    assert.equal(res.statusCode, 400);
+    await close();
+  });
+
+  test('returns 400 when colorKey is not in the palette (poison-key guard)', async () => {
+    const { app, close } = await makeServer();
+    const res = await app.inject({
+      method: 'POST', url: '/api/tree/polyp',
+      payload: { variant: 'starburst', seed: 1, colorKey: 'evil-key', parentId: null, attachIndex: 0 },
     });
     assert.equal(res.statusCode, 400);
     await close();
@@ -117,7 +127,7 @@ describe('POST /api/tree/polyp', () => {
     await app2.ready();
     await app2.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     assert.equal((received as { type: string } | null)?.type, 'tree_polyp_added');
     await app2.close();
@@ -130,7 +140,7 @@ describe('DELETE /api/tree/polyp/:id', () => {
     const { app, close } = await makeServer();
     const root = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     const rootId = (JSON.parse(root.body) as { id: number }).id;
     const res = await app.inject({ method: 'DELETE', url: `/api/tree/polyp/${rootId}` });
@@ -155,12 +165,12 @@ describe('DELETE /api/tree/polyp/:id', () => {
     const { app, close } = await makeServer();
     const root = await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     const rootId = (JSON.parse(root.body) as { id: number }).id;
     await app.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'forked', seed: 2, colorKey: 'x', parentId: rootId, attachIndex: 1 },
+      payload: { variant: 'forked', seed: 2, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 1 },
     });
     const res = await app.inject({ method: 'DELETE', url: `/api/tree/polyp/${rootId}` });
     assert.equal(res.statusCode, 409);
@@ -190,7 +200,7 @@ describe('DELETE /api/tree/polyp/:id', () => {
     await app2.ready();
     const root = await app2.inject({
       method: 'POST', url: '/api/tree/polyp',
-      payload: { variant: 'starburst', seed: 1, colorKey: 'x', parentId: null, attachIndex: 0 },
+      payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
     });
     const rootId = (JSON.parse(root.body) as { id: number }).id;
     messages.length = 0; // clear the polyp_added broadcast

--- a/packages/shared/src/palette.test.ts
+++ b/packages/shared/src/palette.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { REEF_PALETTE, paletteByKey, paletteByKeyOrDefault } from './palette.js';
+
+test('paletteByKey returns the matching entry', () => {
+  const entry = paletteByKey('neon-cyan');
+  assert.equal(entry.key, 'neon-cyan');
+});
+
+test('paletteByKey throws on an unknown key (validated write path)', () => {
+  assert.throws(() => paletteByKey('not-a-key'), /Unknown palette key/);
+});
+
+test('paletteByKeyOrDefault returns the matching entry for a known key', () => {
+  assert.equal(paletteByKeyOrDefault('teal').key, 'teal');
+});
+
+test('paletteByKeyOrDefault falls back to the first palette entry for an unknown key', () => {
+  const original = console.warn;
+  let warned = 0;
+  console.warn = () => {
+    warned += 1;
+  };
+  try {
+    const a = paletteByKeyOrDefault('definitely-not-a-key');
+    assert.equal(a.key, REEF_PALETTE[0]!.key);
+    // Warns once per distinct unknown key, not on every call.
+    paletteByKeyOrDefault('definitely-not-a-key');
+    assert.equal(warned, 1);
+  } finally {
+    console.warn = original;
+  }
+});

--- a/packages/shared/src/palette.ts
+++ b/packages/shared/src/palette.ts
@@ -30,6 +30,25 @@ export function paletteByKey(key: string): PaletteEntry {
   return entry;
 }
 
+const warnedMissingKeys = new Set<string>();
+
+/**
+ * Like `paletteByKey` but never throws: an unknown key resolves to the first
+ * palette entry and warns once per key. Use on the rendering path so a single
+ * malformed `colorKey` already persisted in the database can't brick the whole
+ * scene. The write path validates `colorKey` against the palette via zod, so
+ * fresh submissions can't reach here with a bad key.
+ */
+export function paletteByKeyOrDefault(key: string): PaletteEntry {
+  const entry = byKey.get(key);
+  if (entry) return entry;
+  if (!warnedMissingKeys.has(key)) {
+    warnedMissingKeys.add(key);
+    console.warn(`Unknown palette key "${key}", falling back to "${REEF_PALETTE[0]!.key}"`);
+  }
+  return REEF_PALETTE[0]!;
+}
+
 export function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace('#', '');
   const n = parseInt(h, 16);

--- a/packages/shared/src/tree/schema.test.ts
+++ b/packages/shared/src/tree/schema.test.ts
@@ -1,6 +1,12 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { TreePolypInputSchema, TreeVariantSchema } from './schema.js';
+import {
+  MAX_TREE_ATTACH_INDEX,
+  TREE_VARIANT_ATTACH_COUNTS,
+  TreePolypInputSchema,
+  TreeVariantSchema,
+} from './schema.js';
+import { REEF_PALETTE } from '../palette.js';
 
 test('TreeVariantSchema: accepts the five variants', () => {
   for (const v of ['forked', 'trident', 'starburst', 'claw', 'wishbone']) {
@@ -34,6 +40,34 @@ test('TreePolypInputSchema: allows parentId=null for root pieces', () => {
   };
   const root = { ...valid, parentId: null };
   assert.equal(TreePolypInputSchema.safeParse(root).success, true);
+});
+
+test('TreePolypInputSchema: accepts every real palette colorKey', () => {
+  const base = { variant: 'forked', seed: 42, parentId: 1, attachIndex: 0 };
+  for (const entry of REEF_PALETTE) {
+    assert.equal(
+      TreePolypInputSchema.safeParse({ ...base, colorKey: entry.key }).success,
+      true,
+      `palette key ${entry.key} should be accepted`,
+    );
+  }
+});
+
+test('TreePolypInputSchema: rejects a colorKey not in the palette', () => {
+  const base = { variant: 'forked', seed: 42, parentId: 1, attachIndex: 0 };
+  assert.equal(TreePolypInputSchema.safeParse({ ...base, colorKey: 'not-a-color' }).success, false);
+  assert.equal(TreePolypInputSchema.safeParse({ ...base, colorKey: '' }).success, false);
+  // The pre-fix schema accepted any string up to 32 chars; this is the poison key.
+  assert.equal(
+    TreePolypInputSchema.safeParse({ ...base, colorKey: 'a'.repeat(20) }).success,
+    false,
+  );
+});
+
+test('MAX_TREE_ATTACH_INDEX is derived from the attach-count map', () => {
+  assert.equal(MAX_TREE_ATTACH_INDEX, Math.max(...Object.values(TREE_VARIANT_ATTACH_COUNTS)) - 1);
+  // starburst has the most tips (4), so indices run 0..3.
+  assert.equal(MAX_TREE_ATTACH_INDEX, 3);
 });
 
 test('TreePolypInputSchema: rejects negative or non-integer attachIndex', () => {

--- a/packages/shared/src/tree/schema.ts
+++ b/packages/shared/src/tree/schema.ts
@@ -1,15 +1,38 @@
 import { z } from 'zod';
+import { REEF_PALETTE } from '../palette.js';
+import type { TreeVariant } from './types.js';
 
 export const TreeVariantSchema = z.enum([
   'forked', 'trident', 'starburst', 'claw', 'wishbone',
 ]);
 
+/**
+ * Number of attach points (tips a child can grow from) each variant exposes.
+ * The generator's variant builders are the source of truth for the geometry;
+ * a generator test asserts each builder's `attachPoints.length` matches this
+ * map, so adding a tip without updating this (and the schema bound below) fails
+ * CI rather than silently 400-ing valid placements.
+ */
+export const TREE_VARIANT_ATTACH_COUNTS: Record<TreeVariant, number> = {
+  forked: 2,
+  trident: 3,
+  starburst: 4,
+  claw: 2,
+  wishbone: 2,
+};
+
+/** Highest valid attachIndex across all variants (starburst's 4 tips → 0..3). */
+export const MAX_TREE_ATTACH_INDEX =
+  Math.max(...Object.values(TREE_VARIANT_ATTACH_COUNTS)) - 1;
+
+const treeColorKeys = REEF_PALETTE.map((p) => p.key) as [string, ...string[]];
+
 export const TreePolypInputSchema = z.object({
   variant: TreeVariantSchema,
   seed: z.number().int().nonnegative().max(0xffffffff),
-  colorKey: z.string().min(1).max(32),
+  colorKey: z.enum(treeColorKeys),
   parentId: z.number().int().positive().nullable(),
-  attachIndex: z.number().int().min(0).max(3),  // max 4 tips (starburst) = indices 0-3
+  attachIndex: z.number().int().min(0).max(MAX_TREE_ATTACH_INDEX),
   // Radians around the parent attach-point normal. Optional for backwards
   // compatibility with older clients; defaults to 0 (canonical orientation).
   attachYaw: z.number().finite().optional().default(0),


### PR DESCRIPTION
## Summary
Closes the poison-colorKey DoS from issue #91. The tree polyp schema accepted any 1-32 char `colorKey`, and tree mesh generation throws (`paletteByKey`) on an unknown key, so one unauthenticated POST with a garbage `colorKey` persisted a polyp that crashed tree rendering for every client that loaded it.

## What changed
- **`shared/tree/schema.ts`**: `colorKey` is now `z.enum(...)` derived from `REEF_PALETTE`, matching the reef schema. Garbage keys are rejected at the write boundary with 400.
- **Derived attachIndex bound**: new `TREE_VARIANT_ATTACH_COUNTS` map + `MAX_TREE_ATTACH_INDEX` replace the hard-coded `3`. A generator test asserts each variant builder's real attach-point count matches the map, so a future 5-tip variant fails CI instead of silently 400-ing valid placements.
- **`shared/palette.ts`**: new `paletteByKeyOrDefault` (fallback to the first palette entry, warn once per key). Wired into both render paths (`generator` `colorVec3` for tree variants, `generatePolyp` for reef species, and the client tree mesh builder) so a stale bad row already in the DB renders with a fallback colour instead of throwing and blanking the whole scene. The throwing `paletteByKey` stays on the validated write path.

## Defense in depth
1. Write boundary: zod enum rejects unknown keys (the actual fix).
2. Render path: tolerant resolver so any pre-existing bad row degrades to one wrong-coloured polyp, not a blank scene.

## Test plan
- [x] Schema: accepts every palette key, rejects out-of-palette / empty / arbitrary strings
- [x] `MAX_TREE_ATTACH_INDEX` derivation + generator attach-count sync guard
- [x] Reef + tree generation fall back (don't throw) on an unknown key
- [x] `paletteByKeyOrDefault` warn-once
- [x] Server route returns 400 on a non-palette colorKey
- [x] Generator goldens unchanged (valid keys resolve identically); lint + typecheck clean; all suites green

Closes #91