### PR TITLE
fix(tree): gate reset/delete behind the admin token when one is configured

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,13 @@ and any coordinated disclosure.
 
 Relevant threats for this project:
 
-- **Unauthenticated writes**: all POST/DELETE paths should require the
-  right capability. Admin routes are bearer-token gated.
+- **Unauthenticated writes**: reef admin routes are unconditionally
+  bearer-token gated. Destructive tree routes (`POST /api/tree/reset`,
+  `DELETE /api/tree/polyp/:id`) are gated behind the same admin token
+  whenever `ADMIN_TOKEN` is configured; with no token set (the
+  single-installation default) they stay open so the in-app Clear/Undo
+  buttons work. Polyp creation is open by design and bounded by the rate
+  limits below.
 - **Rate-limit bypass**: one polyp per device per hour is the public
   contract; deviceHash + per-IP token bucket enforce it.
 - **Resource exhaustion**: WebSocket frames have a 64 KB payload cap;

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,46 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { config } from './config.js';
+
+export function requireAdmin(token: string | undefined): boolean {
+  if (!token || !config.adminToken) return false;
+  // Hash both to fixed-size 32-byte digests before timingSafeEqual so the
+  // comparison runs in constant time regardless of the submitted token's
+  // length. Raw-buffer compare leaks length through an early-return branch.
+  const a = createHash('sha256').update(token).digest();
+  const b = createHash('sha256').update(config.adminToken).digest();
+  return timingSafeEqual(a, b);
+}
+
+function bearerToken(req: FastifyRequest): string | undefined {
+  const auth = req.headers['authorization'];
+  return auth?.toString().replace(/^Bearer\s+/i, '');
+}
+
+/**
+ * Require a valid admin token. Returns true on success; on failure writes a 401
+ * response and returns false — callers should return immediately. Use for
+ * unconditionally admin-only routes (e.g. the reef admin panel).
+ */
+export function checkAdminAuth(req: FastifyRequest, reply: FastifyReply): boolean {
+  if (!requireAdmin(bearerToken(req))) {
+    void reply.status(401).send({ error: 'unauthorized' });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Gate a destructive route behind the admin token ONLY when one is configured.
+ * With no `ADMIN_TOKEN` set (the single-installation / testing default) the
+ * route stays open so user-facing actions like tree Clear/Undo keep working.
+ * Once an operator sets `ADMIN_TOKEN` for a public deploy, the route requires
+ * it — random visitors can no longer wipe or delete shared state. Mirrors the
+ * "secure-by-config, open-while-testing" posture of the rate limits.
+ *
+ * Returns true to proceed; on failure writes 401 and returns false.
+ */
+export function enforceAdminIfConfigured(req: FastifyRequest, reply: FastifyReply): boolean {
+  if (!config.adminToken) return true;
+  return checkAdminAuth(req, reply);
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,30 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { createHash, timingSafeEqual } from 'node:crypto';
-import { config } from '../config.js';
 import type { ReefDb } from '../db.js';
 import type { Hub } from '../hub.js';
-
-function requireAdmin(token: string | undefined): boolean {
-  if (!token || !config.adminToken) return false;
-  // Hash both to fixed-size 32-byte digests before timingSafeEqual so the
-  // comparison runs in constant time regardless of the submitted token's
-  // length. Raw-buffer compare leaks length through an early-return branch.
-  const a = createHash('sha256').update(token).digest();
-  const b = createHash('sha256').update(config.adminToken).digest();
-  return timingSafeEqual(a, b);
-}
-
-// Check admin bearer token. Returns true on success; on failure writes a
-// 401 response and returns false — callers should return immediately.
-function checkAdminAuth(req: FastifyRequest, reply: FastifyReply): boolean {
-  const auth = req.headers['authorization'];
-  const token = auth?.toString().replace(/^Bearer\s+/i, '');
-  if (!requireAdmin(token)) {
-    void reply.status(401).send({ error: 'unauthorized' });
-    return false;
-  }
-  return true;
-}
+import { checkAdminAuth } from '../auth.js';
 
 // Parse admin auth + :id path param. Returns the id on success, or null after
 // writing a 401/400 response — callers should return immediately when null.

--- a/packages/server/src/tree/routes.test.ts
+++ b/packages/server/src/tree/routes.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import Fastify from 'fastify';
 import { ReefDb } from '../db.js';
 import { Hub } from '../hub.js';
+import { config } from '../config.js';
 import { TreeDb } from './db.js';
 import { registerTreeRoutes } from './routes.js';
 
@@ -208,5 +209,76 @@ describe('DELETE /api/tree/polyp/:id', () => {
     assert.equal(messages.length, 1);
     assert.deepEqual(messages[0], { type: 'tree_polyp_removed', id: rootId });
     await app2.close();
+  });
+});
+
+describe('tree mutation auth gate', () => {
+  test('reset is open when no admin token is configured', async () => {
+    const prev = config.adminToken;
+    config.adminToken = '';
+    const { app, close } = await makeServer();
+    try {
+      const res = await app.inject({ method: 'POST', url: '/api/tree/reset' });
+      assert.equal(res.statusCode, 200);
+    } finally {
+      await close();
+      config.adminToken = prev;
+    }
+  });
+
+  test('reset requires the admin token once one is configured', async () => {
+    const prev = config.adminToken;
+    config.adminToken = 'tree-secret';
+    const { app, close } = await makeServer();
+    try {
+      const unauth = await app.inject({ method: 'POST', url: '/api/tree/reset' });
+      assert.equal(unauth.statusCode, 401);
+      const wrong = await app.inject({
+        method: 'POST', url: '/api/tree/reset',
+        headers: { authorization: 'Bearer nope' },
+      });
+      assert.equal(wrong.statusCode, 401);
+      const ok = await app.inject({
+        method: 'POST', url: '/api/tree/reset',
+        headers: { authorization: 'Bearer tree-secret' },
+      });
+      assert.equal(ok.statusCode, 200);
+    } finally {
+      await close();
+      config.adminToken = prev;
+    }
+  });
+
+  test('delete is gated, but planting stays open, once an admin token is set', async () => {
+    const prev = config.adminToken;
+    config.adminToken = 'tree-secret';
+    const { app, close } = await makeServer();
+    try {
+      // Planting is NOT gated even with a token configured.
+      const root = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+      });
+      assert.equal(root.statusCode, 200);
+      const rootId = (JSON.parse(root.body) as { id: number }).id;
+      const child = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'forked', seed: 2, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 0 },
+      });
+      assert.equal(child.statusCode, 200);
+      const childId = (JSON.parse(child.body) as { id: number }).id;
+
+      // Deleting requires the token.
+      const unauth = await app.inject({ method: 'DELETE', url: `/api/tree/polyp/${childId}` });
+      assert.equal(unauth.statusCode, 401);
+      const ok = await app.inject({
+        method: 'DELETE', url: `/api/tree/polyp/${childId}`,
+        headers: { authorization: 'Bearer tree-secret' },
+      });
+      assert.equal(ok.statusCode, 200);
+    } finally {
+      await close();
+      config.adminToken = prev;
+    }
   });
 });

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -3,6 +3,7 @@ import { TreePolypInputSchema } from '@reef/shared';
 import type { Hub } from '../hub.js';
 import type { TreeDb } from './db.js';
 import { seedRootIfEmpty } from './seed.js';
+import { enforceAdminIfConfigured } from '../auth.js';
 
 const NUMERIC_ID_RE = /^\d+$/;
 
@@ -15,7 +16,10 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
   // Reset: soft-delete every live polyp, then seed a fresh Starburst root so
   // the tree never boots into a "no attach point" state. Clients re-fetch
   // after the call (see packages/client/src/tree/api.ts).
-  app.post('/api/tree/reset', async () => {
+  // Destructive (wipes the whole shared tree): gated behind the admin token
+  // whenever one is configured, so a public deploy can't be wiped by anyone.
+  app.post('/api/tree/reset', async (req, reply) => {
+    if (!enforceAdminIfConfigured(req, reply)) return reply;
     tree.deleteAll();
     seedRootIfEmpty(tree);
     const polyps = tree.listLive();
@@ -56,6 +60,10 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
   });
 
   app.delete('/api/tree/polyp/:id', async (req, reply) => {
+    // Deleting a leaf is also gated once an admin token is configured: in a
+    // public deploy, removing shared pieces is an operator action, not a
+    // visitor one. Without a token (single-install / testing) Undo stays open.
+    if (!enforceAdminIfConfigured(req, reply)) return reply;
     const { id: rawId } = req.params as { id: string };
     if (!NUMERIC_ID_RE.test(rawId)) {
       reply.code(400);


### PR DESCRIPTION
## Summary
Closes issue #89. `POST /api/tree/reset` (wipes the whole shared tree) and `DELETE /api/tree/polyp/:id` were completely unauthenticated.

## The catch
Both endpoints are wired to user-facing buttons: reset backs **Clear**, delete backs **Undo**, and the client sends no auth token. Gating them unconditionally would break both features.

## Design decision (please sanity-check)
`enforceAdminIfConfigured`: the route is **open when no `ADMIN_TOKEN` is set** (the single-installation / testing default, so Clear/Undo keep working) and **requires the bearer token once an operator configures `ADMIN_TOKEN`** for a public deploy. This mirrors the repo's existing rate-limit posture (default-off in testing, #25): one lever (`ADMIN_TOKEN`) locks down the deploy.

Tradeoff to be explicit about: in the **default** config these destructive routes stay open. The fix makes them **lockable**, not locked-by-default. In a public install with a token set, Clear/Undo become operator-only, which is the right installation policy. If you'd rather they be gated unconditionally (which would require the client to send a token for Clear/Undo, or removing those buttons), say so and I'll switch the approach.

## What changed
- New `packages/server/src/auth.ts`: `requireAdmin` / `checkAdminAuth` (moved verbatim from admin.ts) + `enforceAdminIfConfigured`.
- `admin.ts` refactored to import from it; reef admin routes stay **unconditionally** gated.
- `tree/routes.ts`: reset + delete now call `enforceAdminIfConfigured`; planting and GET stay open.
- `SECURITY.md` corrected (it claimed all destructive paths were gated).

## Test plan
- [x] Reset/delete open with no token (existing tests + new); 401 without/with-wrong token and 200 with correct token once configured; planting stays open even with a token set
- [x] Reef admin route tests unchanged and green (refactor is behavior-preserving)
- [x] Server suite green (103), lint + typecheck clean

Closes #89