### PR TITLE
feat(tree): per-device write rate limit on POST /api/tree/polyp

### DIFF
--- a/packages/server/src/tree/db.ts
+++ b/packages/server/src/tree/db.ts
@@ -33,6 +33,8 @@ export class TreeDb {
     softDelete: Database.Statement;
     hasAny: Database.Statement;
     softDeleteAll: Database.Statement;
+    countByDevice: Database.Statement;
+    oldestByDevice: Database.Statement;
   };
 
   // ReefDb owns the underlying sqlite handle. Share it so migrations run once
@@ -69,7 +71,26 @@ export class TreeDb {
       softDeleteAll: this.db.prepare(
         'UPDATE tree_polyps SET deleted = 1 WHERE deleted = 0',
       ),
+      // Mirrors ReefDb's per-device counting (live rows only) so the tree
+      // write path can rate-limit by device hash the same way the reef does.
+      // Counting deleted=0 only means an undo-then-replant can stay under the
+      // cap; that's intentional parity with reef (a coarse abuse throttle, not
+      // an accounting control). Tighten both together if it ever matters.
+      countByDevice: this.db.prepare(
+        'SELECT COUNT(*) AS n FROM tree_polyps WHERE device_hash = ? AND created_at >= ? AND deleted = 0',
+      ),
+      oldestByDevice: this.db.prepare(
+        'SELECT MIN(created_at) AS t FROM tree_polyps WHERE device_hash = ? AND created_at >= ? AND deleted = 0',
+      ),
     };
+  }
+
+  countByDeviceSince(deviceHash: string, sinceMs: number): number {
+    return (this.stmt.countByDevice.get(deviceHash, sinceMs) as { n: number }).n;
+  }
+
+  oldestByDeviceSince(deviceHash: string, sinceMs: number): number | null {
+    return (this.stmt.oldestByDevice.get(deviceHash, sinceMs) as { t: number | null }).t;
   }
 
   /**

--- a/packages/server/src/tree/routes.test.ts
+++ b/packages/server/src/tree/routes.test.ts
@@ -212,6 +212,66 @@ describe('DELETE /api/tree/polyp/:id', () => {
   });
 });
 
+describe('tree write rate limit', () => {
+  test('planting is unlimited when RATE_LIMIT_MAX is 0 (default)', async () => {
+    const prevMax = config.rateLimitMax;
+    config.rateLimitMax = 0;
+    const { app, close } = await makeServer();
+    try {
+      const root = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+      });
+      const rootId = (JSON.parse(root.body) as { id: number }).id;
+      // Many children from the same device all succeed with the limit off.
+      for (let i = 0; i < 3; i++) {
+        const child = await app.inject({
+          method: 'POST', url: '/api/tree/polyp',
+          payload: { variant: 'forked', seed: i, colorKey: 'neon-cyan', parentId: rootId, attachIndex: i },
+        });
+        assert.equal(child.statusCode, 200);
+      }
+    } finally {
+      await close();
+      config.rateLimitMax = prevMax;
+    }
+  });
+
+  test('returns 429 with Retry-After once a device exceeds RATE_LIMIT_MAX', async () => {
+    const prevMax = config.rateLimitMax;
+    config.rateLimitMax = 2;
+    const { app, close } = await makeServer();
+    try {
+      // Root counts as the device's first piece.
+      const root = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'starburst', seed: 1, colorKey: 'neon-cyan', parentId: null, attachIndex: 0 },
+      });
+      assert.equal(root.statusCode, 200);
+      const rootId = (JSON.parse(root.body) as { id: number }).id;
+      // Second piece still under the limit.
+      const second = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'forked', seed: 2, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 0 },
+      });
+      assert.equal(second.statusCode, 200);
+      // Third trips the limit.
+      const third = await app.inject({
+        method: 'POST', url: '/api/tree/polyp',
+        payload: { variant: 'claw', seed: 3, colorKey: 'neon-cyan', parentId: rootId, attachIndex: 1 },
+      });
+      assert.equal(third.statusCode, 429);
+      const body = JSON.parse(third.body) as { error: string; retryAfterMs: number };
+      assert.equal(body.error, 'rate_limited');
+      assert.ok(body.retryAfterMs > 0);
+      assert.ok(third.headers['retry-after'] !== undefined);
+    } finally {
+      await close();
+      config.rateLimitMax = prevMax;
+    }
+  });
+});
+
 describe('tree mutation auth gate', () => {
   test('reset is open when no admin token is configured', async () => {
     const prev = config.adminToken;

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -4,6 +4,9 @@ import type { Hub } from '../hub.js';
 import type { TreeDb } from './db.js';
 import { seedRootIfEmpty } from './seed.js';
 import { enforceAdminIfConfigured } from '../auth.js';
+import { deviceHash } from '../deviceHash.js';
+import { config } from '../config.js';
+import { counters } from '../metrics-registry.js';
 
 const NUMERIC_ID_RE = /^\d+$/;
 
@@ -36,10 +39,29 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
       reply.code(400);
       return { error: 'invalid payload', issues: parsed.error.issues };
     }
+
+    // Per-device write limit, mirroring the reef route. Off by default
+    // (RATE_LIMIT_MAX=0); counts this device's live tree pieces in the window.
+    const ua = req.headers['user-agent'] ?? 'unknown';
+    const ip = req.ip || req.headers['x-forwarded-for']?.toString() || 'unknown';
+    const dh = deviceHash(String(ua), String(ip), config.rateLimitWindowMs);
+    const windowStart = Date.now() - config.rateLimitWindowMs;
+    if (config.rateLimitMax > 0 && tree.countByDeviceSince(dh, windowStart) >= config.rateLimitMax) {
+      counters.inc('rate_limited');
+      const oldest = tree.oldestByDeviceSince(dh, windowStart);
+      const retryAfterMs = oldest !== null
+        ? Math.max(0, oldest + config.rateLimitWindowMs - Date.now())
+        : config.rateLimitWindowMs;
+      reply.header('Retry-After', Math.ceil(retryAfterMs / 1000));
+      reply.code(429);
+      return { error: 'rate_limited', retryAfterMs };
+    }
+
     const input = parsed.data;
+    let polyp;
     try {
-      const polyp = input.parentId === null
-        ? tree.insertRoot({ variant: input.variant, seed: input.seed, colorKey: input.colorKey })
+      polyp = input.parentId === null
+        ? tree.insertRoot({ variant: input.variant, seed: input.seed, colorKey: input.colorKey, deviceHash: dh })
         : tree.insertChild({
             variant: input.variant,
             seed: input.seed,
@@ -47,9 +69,8 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
             parentId: input.parentId,
             attachIndex: input.attachIndex,
             attachYaw: input.attachYaw,
+            deviceHash: dh,
           });
-      hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
-      return polyp;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (/parent not found/i.test(msg)) { reply.code(404); return { error: msg }; }
@@ -57,6 +78,15 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
       reply.code(500);
       return { error: msg };
     }
+    // Best-effort notification: a broadcast failure must not turn a
+    // successfully persisted polyp into a 500 the client would retry — a retry
+    // would re-insert and inflate the device's rate-limit count. Mirrors reef.
+    try {
+      hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
+    } catch (err) {
+      req.log.warn({ err, polypId: polyp.id }, 'tree hub broadcast failed after insert');
+    }
+    return polyp;
   });
 
   app.delete('/api/tree/polyp/:id', async (req, reply) => {


### PR DESCRIPTION
## Summary
Closes #90. The tree write route had no rate limiting while the reef route does. This ports the reef per-device write limit to `POST /api/tree/polyp`.

## What changed
- Compute `deviceHash(ua, ip, window)` and count the device's live tree pieces in the window via new `TreeDb.countByDeviceSince` / `oldestByDeviceSince`.
- Return 429 with `Retry-After` + `retryAfterMs` when `config.rateLimitMax > 0` and the device is over, incrementing the existing `rate_limited` counter.
- Persist `deviceHash` on tree rows (the `device_hash` column and insert param already existed but were never populated). `device_hash` is not exposed in the public polyp shape.
- Off by default (`RATE_LIMIT_MAX=0`): no behavior change until an operator opts in.

## Also (review-driven)
- Made the post-insert `hub.broadcast` best-effort (moved out of the insert try/catch), matching reef. A broadcast failure must not 500 a successfully persisted polyp, since the client retry would re-insert and inflate the new rate-limit count.
- Documented that counting `deleted=0` rows only (undo-then-replant can stay under the cap) is intentional parity with reef.

## Test plan
- [x] Planting unlimited with `RATE_LIMIT_MAX=0` (default)
- [x] 429 + Retry-After once a device exceeds the limit (root counts as the first piece; exact off-by-one parity with reef)
- [x] `device_hash` not leaked to clients
- [x] Server suite green (105), lint + typecheck clean

Closes #90