### PR TITLE
feat(server): bound sim_state growth with a retention window

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,10 +13,26 @@ export const config = {
   readRateLimitPerMin: Number(process.env.READ_RATE_LIMIT_PER_MIN ?? 0),
   simIntervalMs: Number(process.env.SIM_INTERVAL_MS ?? 3_600_000),
   snapshotIntervalMs: Number(process.env.SNAPSHOT_INTERVAL_MS ?? 86_400_000),
+  // Sim deltas (barnacle/algae/weather decorations) older than this are pruned
+  // after each tick, and GET /api/reef only returns deltas inside this window,
+  // so sim_state and the reef payload stay bounded instead of growing forever.
+  // The reef shows a rolling window of decorations (an aging-reef look); set
+  // higher to keep them longer, or 0 to disable pruning and keep everything.
+  simRetentionMs: Number(process.env.SIM_RETENTION_MS ?? 30 * 86_400_000),
   corsOrigins: (process.env.CORS_ORIGINS ?? '*').split(',').map((s) => s.trim()),
   // Absolute path to the built Vite client bundle. When set, the server
   // serves the static files and SPA index fallbacks. Leave unset in dev so
   // the Vite dev server keeps handling the frontend.
   clientDistDir: process.env.CLIENT_DIST_DIR,
 };
+
+// Fail loud on a malformed SIM_RETENTION_MS rather than silently coercing to
+// NaN, which would disable pruning and quietly re-introduce the unbounded
+// sim_state growth this knob exists to prevent.
+if (!Number.isFinite(config.simRetentionMs) || config.simRetentionMs < 0) {
+  throw new Error(
+    `SIM_RETENTION_MS must be a non-negative number of milliseconds (0 disables pruning), ` +
+      `got ${JSON.stringify(process.env.SIM_RETENTION_MS)}`,
+  );
+}
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -45,6 +45,8 @@ export class ReefDb {
     countByDevice: Database.Statement;
     oldestByDevice: Database.Statement;
     listSim: Database.Statement;
+    listSimSince: Database.Statement;
+    pruneSim: Database.Statement;
     insertSim: Database.Statement;
     insertSnapshot: Database.Statement;
     listSnapshots: Database.Statement;
@@ -99,6 +101,10 @@ export class ReefDb {
         'SELECT MIN(created_at) as t FROM polyps WHERE device_hash = ? AND created_at >= ? AND deleted = 0',
       ),
       listSim: this.db.prepare('SELECT * FROM sim_state ORDER BY created_at ASC'),
+      listSimSince: this.db.prepare(
+        'SELECT * FROM sim_state WHERE created_at >= ? ORDER BY created_at ASC',
+      ),
+      pruneSim: this.db.prepare('DELETE FROM sim_state WHERE created_at < ?'),
       insertSim: this.db.prepare(
         'INSERT INTO sim_state (polyp_id, kind, params, created_at) VALUES (?, ?, ?, ?)',
       ),
@@ -198,16 +204,31 @@ export class ReefDb {
     return row.t;
   }
 
-  listSim(): SimDelta[] {
-    const rows = this.stmt.listSim.all() as Array<{
-      polyp_id: number; kind: string; params: string; created_at: number;
-    }>;
+  private mapSimRows(
+    rows: Array<{ polyp_id: number; kind: string; params: string; created_at: number }>,
+  ): SimDelta[] {
     return rows.map((r) => ({
       polypId: r.polyp_id,
       kind: r.kind as SimKind,
       params: JSON.parse(r.params) as Record<string, number | string>,
       createdAt: r.created_at,
     }));
+  }
+
+  listSim(): SimDelta[] {
+    return this.mapSimRows(this.stmt.listSim.all() as Parameters<typeof this.mapSimRows>[0]);
+  }
+
+  /** Sim deltas created at or after `sinceMs`. Used to bound the GET payload. */
+  listSimSince(sinceMs: number): SimDelta[] {
+    return this.mapSimRows(
+      this.stmt.listSimSince.all(sinceMs) as Parameters<typeof this.mapSimRows>[0],
+    );
+  }
+
+  /** Delete sim deltas older than `cutoffMs`. Returns the number removed. */
+  pruneSimBefore(cutoffMs: number): number {
+    return this.stmt.pruneSim.run(cutoffMs).changes;
   }
 
   insertSim(delta: SimDelta): void {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -131,7 +131,7 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
 async function main(): Promise<void> {
   const { app, db, hub, treeHub } = await makeServer();
 
-  const sim = new SimWorker(db, hub, config.simIntervalMs);
+  const sim = new SimWorker(db, hub, config.simIntervalMs, config.simRetentionMs);
   sim.start();
   const snapshots = new SnapshotWorker(db, config.snapshotIntervalMs);
   snapshots.start();

--- a/packages/server/src/routes/reef.ts
+++ b/packages/server/src/routes/reef.ts
@@ -24,9 +24,14 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
         return reply.status(429).send({ error: 'rate_limited' });
       }
     }
+    // Bound the sim payload to the retention window so this response can't grow
+    // without limit as decorations accumulate. 0 = retention disabled → all.
+    const sim = config.simRetentionMs > 0
+      ? db.listSimSince(Date.now() - config.simRetentionMs)
+      : db.listSim();
     const state: ReefState = {
       polyps: db.listPublicPolyps(),
-      sim: db.listSim(),
+      sim,
       serverTime: Date.now(),
     };
     return state;

--- a/packages/server/src/sim.test.ts
+++ b/packages/server/src/sim.test.ts
@@ -59,6 +59,62 @@ test('sim: sim_update deltas persist via transaction', () => {
   }
 });
 
+const DAY = 86_400_000;
+
+test('db: pruneSimBefore deletes only deltas older than the cutoff', () => {
+  const db = freshDb();
+  const now = Date.now();
+  // sim_state.polyp_id is a FK, so reference real polyps.
+  const oldP = db.insertPolyp(polypAgedDays(0));
+  const newP = db.insertPolyp(polypAgedDays(0));
+  db.insertSim({ polypId: oldP.id, kind: 'barnacle', params: {}, createdAt: now - 40 * DAY });
+  db.insertSim({ polypId: newP.id, kind: 'algae', params: {}, createdAt: now - 5 * DAY });
+  const removed = db.pruneSimBefore(now - 30 * DAY);
+  assert.equal(removed, 1);
+  const left = db.listSim();
+  assert.equal(left.length, 1);
+  assert.equal(left[0]!.polypId, newP.id);
+});
+
+test('db: listSimSince returns only deltas inside the window', () => {
+  const db = freshDb();
+  const now = Date.now();
+  const oldP = db.insertPolyp(polypAgedDays(0));
+  const newP = db.insertPolyp(polypAgedDays(0));
+  db.insertSim({ polypId: oldP.id, kind: 'barnacle', params: {}, createdAt: now - 40 * DAY });
+  db.insertSim({ polypId: newP.id, kind: 'algae', params: {}, createdAt: now - 2 * DAY });
+  const recent = db.listSimSince(now - 30 * DAY);
+  assert.equal(recent.length, 1);
+  assert.equal(recent[0]!.polypId, newP.id);
+  // listSim still returns everything (used by the snapshot path).
+  assert.equal(db.listSim().length, 2);
+});
+
+test('sim: tick prunes deltas older than the retention window', () => {
+  const db = freshDb();
+  const now = Date.now();
+  const oldP = db.insertPolyp(polypAgedDays(0));
+  const newP = db.insertPolyp(polypAgedDays(0));
+  // Old + recent deltas; the polyps are <30d so tick adds nothing new.
+  db.insertSim({ polypId: oldP.id, kind: 'barnacle', params: {}, createdAt: now - 40 * DAY });
+  db.insertSim({ polypId: newP.id, kind: 'algae', params: {}, createdAt: now - 1 * DAY });
+  const sim = new SimWorker(db, new Hub(), 3600_000, 30 * DAY);
+  sim.tick();
+  const left = db.listSim();
+  assert.equal(left.length, 1);
+  assert.equal(left[0]!.polypId, newP.id);
+});
+
+test('sim: retentionMs=0 prunes nothing (pruning disabled)', () => {
+  const db = freshDb();
+  const now = Date.now();
+  const p = db.insertPolyp(polypAgedDays(0));
+  db.insertSim({ polypId: p.id, kind: 'barnacle', params: {}, createdAt: now - 400 * DAY });
+  const sim = new SimWorker(db, new Hub(), 3600_000, 0);
+  sim.tick();
+  assert.equal(db.listSim().length, 1);
+});
+
 test('snapshot: take() writes JSON snapshot of current state', () => {
   const db = freshDb();
   db.insertPolyp(polypAgedDays(1));

--- a/packages/server/src/sim.ts
+++ b/packages/server/src/sim.ts
@@ -15,6 +15,8 @@ export class SimWorker {
     private readonly db: ReefDb,
     private readonly hub: Hub,
     private readonly intervalMs: number,
+    // Sim deltas older than this are pruned each tick. 0 disables pruning.
+    private readonly retentionMs = 0,
   ) {}
 
   start(): void {
@@ -60,6 +62,12 @@ export class SimWorker {
         for (const u of updates) this.db.insertSim(u);
       });
       this.hub.broadcast({ type: 'sim_update', updates });
+    }
+
+    // Prune aged deltas every tick (even when nothing grew) so sim_state stays
+    // bounded by the retention window rather than growing forever.
+    if (this.retentionMs > 0) {
+      this.db.pruneSimBefore(now - this.retentionMs);
     }
     return updates;
   }


### PR DESCRIPTION
## Summary
Closes #92. `sim_state` grew without limit (`SELECT *` with no LIMIT, a row appended every hour per aged polyp forever), and `GET /api/reef` returned the whole table every request, blocking the event loop on an ever-larger synchronous scan.

## What changed
- New `SIM_RETENTION_MS` config (default 30 days, `0` disables).
- `SimWorker.tick()` prunes deltas older than the window each tick (new `db.pruneSimBefore`), even on ticks with no growth.
- `GET /api/reef` returns only deltas inside the window (new `db.listSimSince`), falling back to the full set when retention is disabled.
- `retentionMs` is injected into `SimWorker` like `intervalMs` (default 0 = off, so existing callers/tests are unchanged) and wired from config in `index.ts`.
- A malformed `SIM_RETENTION_MS` throws at boot rather than silently coercing to NaN and disabling pruning (which would re-introduce the unbounded growth this fixes).

## ⚠️ Behavior decision — please confirm
Sim deltas are **accumulating visual decorations** (barnacle/algae/weather), so pruning means decorations older than the window **disappear from the reef** — it becomes a rolling "aging reef" look rather than permanent accumulation. This is a defensible reading of the issue ("clients only need enough to decorate live polyps") and 30 days is generous, but it's a visible behavior change. If you'd rather keep decorations permanent and bound growth a different way (e.g. cap deltas per polyp), say so and I'll switch the approach. Set `SIM_RETENTION_MS=0` to keep everything.

Snapshots still capture the full sim state — bounding snapshot growth is the separate concern tracked by #44.

## Test plan
- [x] `pruneSimBefore` deletes only old deltas; boundary delta kept
- [x] `listSimSince` returns only the window; `listSim` still returns all (snapshot path)
- [x] `tick` prunes aged deltas; `retentionMs=0` prunes nothing
- [x] Malformed `SIM_RETENTION_MS` throws at boot (verified)
- [x] Server suite green (109), lint + typecheck clean

Closes #92