### PR TITLE
feat(server): cap snapshot retention so the snapshots table stays bounded

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -19,6 +19,10 @@ export const config = {
   // The reef shows a rolling window of decorations (an aging-reef look); set
   // higher to keep them longer, or 0 to disable pruning and keep everything.
   simRetentionMs: Number(process.env.SIM_RETENTION_MS ?? 30 * 86_400_000),
+  // Keep at most this many of the most recent snapshots; older ones are pruned
+  // after each new snapshot so the snapshots table (full-state JSON blobs)
+  // doesn't grow forever. 0 = keep all (pruning disabled).
+  snapshotRetentionCount: Number(process.env.SNAPSHOT_RETENTION_COUNT ?? 90),
   corsOrigins: (process.env.CORS_ORIGINS ?? '*').split(',').map((s) => s.trim()),
   // Absolute path to the built Vite client bundle. When set, the server
   // serves the static files and SPA index fallbacks. Leave unset in dev so
@@ -33,6 +37,13 @@ if (!Number.isFinite(config.simRetentionMs) || config.simRetentionMs < 0) {
   throw new Error(
     `SIM_RETENTION_MS must be a non-negative number of milliseconds (0 disables pruning), ` +
       `got ${JSON.stringify(process.env.SIM_RETENTION_MS)}`,
+  );
+}
+
+if (!Number.isInteger(config.snapshotRetentionCount) || config.snapshotRetentionCount < 0) {
+  throw new Error(
+    `SNAPSHOT_RETENTION_COUNT must be a non-negative integer (0 keeps all), ` +
+      `got ${JSON.stringify(process.env.SNAPSHOT_RETENTION_COUNT)}`,
   );
 }
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -51,6 +51,7 @@ export class ReefDb {
     insertSnapshot: Database.Statement;
     listSnapshots: Database.Statement;
     getSnapshot: Database.Statement;
+    pruneSnapshots: Database.Statement;
   };
 
   constructor(path: string) {
@@ -116,6 +117,13 @@ export class ReefDb {
       ),
       getSnapshot: this.db.prepare(
         'SELECT id, taken_at as takenAt, polyp_count as polypCount, state_json as stateJson FROM snapshots WHERE id = ?',
+      ),
+      // Keep the `?` most recent snapshots (by taken_at, id as tiebreak),
+      // delete the rest.
+      pruneSnapshots: this.db.prepare(
+        `DELETE FROM snapshots WHERE id NOT IN (
+           SELECT id FROM snapshots ORDER BY taken_at DESC, id DESC LIMIT ?
+         )`,
       ),
     };
   }
@@ -272,6 +280,11 @@ export class ReefDb {
 
   getSnapshot(id: number): { id: number; takenAt: number; polypCount: number; stateJson: string } | undefined {
     return this.stmt.getSnapshot.get(id) as { id: number; takenAt: number; polypCount: number; stateJson: string } | undefined;
+  }
+
+  /** Keep the `keep` most recent snapshots, delete older ones. Returns removed count. */
+  pruneOldSnapshots(keep: number): number {
+    return this.stmt.pruneSnapshots.run(Math.floor(keep)).changes;
   }
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
 
   const sim = new SimWorker(db, hub, config.simIntervalMs, config.simRetentionMs);
   sim.start();
-  const snapshots = new SnapshotWorker(db, config.snapshotIntervalMs);
+  const snapshots = new SnapshotWorker(db, config.snapshotIntervalMs, config.snapshotRetentionCount);
   snapshots.start();
   hub.startHeartbeat();
   treeHub.startHeartbeat();

--- a/packages/server/src/sim.test.ts
+++ b/packages/server/src/sim.test.ts
@@ -125,3 +125,31 @@ test('snapshot: take() writes JSON snapshot of current state', () => {
   const parsed = JSON.parse(snap!.stateJson) as { polyps: unknown[] };
   assert.equal(parsed.polyps.length, 1);
 });
+
+test('db: pruneOldSnapshots keeps the N most recent', () => {
+  const db = freshDb();
+  db.insertPolyp(polypAgedDays(1));
+  const ids: number[] = [];
+  for (let i = 0; i < 5; i++) ids.push(db.insertSnapshot(1, JSON.stringify({ n: i })));
+  const removed = db.pruneOldSnapshots(2);
+  assert.equal(removed, 3);
+  const left = db.listSnapshots().map((s) => s.id).sort((a, b) => a - b);
+  // The two highest ids (most recent) survive.
+  assert.deepEqual(left, ids.slice(-2));
+});
+
+test('snapshot: take() prunes to retentionCount across repeated runs', () => {
+  const db = freshDb();
+  db.insertPolyp(polypAgedDays(1));
+  const w = new SnapshotWorker(db, 86_400_000, 3);
+  for (let i = 0; i < 6; i++) w.take();
+  assert.equal(db.listSnapshots().length, 3);
+});
+
+test('snapshot: retentionCount=0 keeps every snapshot', () => {
+  const db = freshDb();
+  db.insertPolyp(polypAgedDays(1));
+  const w = new SnapshotWorker(db, 86_400_000, 0);
+  for (let i = 0; i < 4; i++) w.take();
+  assert.equal(db.listSnapshots().length, 4);
+});

--- a/packages/server/src/sim.ts
+++ b/packages/server/src/sim.ts
@@ -79,6 +79,9 @@ export class SnapshotWorker {
   constructor(
     private readonly db: ReefDb,
     private readonly intervalMs: number,
+    // Keep at most this many recent snapshots; older ones are pruned after each
+    // new one. 0 disables pruning (keep all).
+    private readonly retentionCount = 0,
   ) {}
 
   start(): void {
@@ -94,6 +97,10 @@ export class SnapshotWorker {
     const polyps = this.db.listPublicPolyps();
     const sim = this.db.listSim();
     const stateJson = JSON.stringify({ polyps, sim });
-    return this.db.insertSnapshot(polyps.length, stateJson);
+    const id = this.db.insertSnapshot(polyps.length, stateJson);
+    if (this.retentionCount > 0) {
+      this.db.pruneOldSnapshots(this.retentionCount);
+    }
+    return id;
   }
 }


### PR DESCRIPTION
## Summary
Closes #44. `SnapshotWorker` wrote a full-state JSON snapshot every 24h forever, so the `snapshots` table (each row a full `state_json` blob) grew without limit.

## What changed
- New `SNAPSHOT_RETENTION_COUNT` config (default 90, `0` = keep all), validated as a non-negative integer at boot (a typo throws rather than silently disabling pruning).
- After inserting a snapshot, `take()` prunes to the N most recent (new `db.pruneOldSnapshots`, keeping by `taken_at` then `id`).
- `retentionCount` injected into `SnapshotWorker` like the interval and wired from config; default `0` keeps existing callers/tests unchanged.

Mirrors the sim_state retention pattern from #92 (just merged).

## Test plan
- [x] `pruneOldSnapshots` keeps exactly the N most recent, deletes the rest
- [x] `take()` converges to `retentionCount` across repeated runs; `retentionCount=0` keeps all
- [x] Fewer-than-N snapshots → deletes nothing; the just-inserted snapshot is always kept (valid `getSnapshot`)
- [x] Malformed `SNAPSHOT_RETENTION_COUNT` (non-integer / negative) throws at boot (verified)
- [x] Server suite green (112), lint + typecheck clean

Closes #44