### PR TITLE
fix(server): track applied migrations in a schema_migrations table

### DIFF
--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -10,6 +10,54 @@ function freshDb(): ReefDb {
   return new ReefDb(join(dir, 'reef.db'));
 }
 
+function appliedMigrations(db: ReefDb): string[] {
+  return (db.db.prepare('SELECT filename FROM schema_migrations ORDER BY filename').all() as Array<{
+    filename: string;
+  }>).map((r) => r.filename);
+}
+
+test('migrations: each .sql file is recorded in schema_migrations exactly once', () => {
+  const db = freshDb();
+  const applied = appliedMigrations(db);
+  assert.ok(applied.includes('001_init.sql'));
+  assert.ok(applied.includes('003_tree_polyps.sql'));
+  // No duplicates.
+  assert.equal(new Set(applied).size, applied.length);
+});
+
+test('migrations: re-opening the same db file does not re-run or duplicate', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'reef-migrate-'));
+  const path = join(dir, 'reef.db');
+  const db1 = new ReefDb(path);
+  db1.insertPolyp(basePolyp());
+  const firstApplied = appliedMigrations(db1);
+  db1.db.close();
+
+  // Re-open the same file: migrate() runs again but must skip recorded files
+  // and must not error or wipe data.
+  const db2 = new ReefDb(path);
+  assert.deepEqual(appliedMigrations(db2), firstApplied);
+  assert.equal(db2.listPublicPolyps().length, 1);
+});
+
+test('migrations: back-fills an existing db that has tables but no tracking row', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'reef-backfill-'));
+  const path = join(dir, 'reef.db');
+  // Simulate a DB created by the OLD code: tables + data exist, but there is
+  // no schema_migrations table.
+  const db1 = new ReefDb(path);
+  db1.insertPolyp(basePolyp());
+  const expected = appliedMigrations(db1);
+  db1.db.exec('DROP TABLE schema_migrations');
+  db1.db.close();
+
+  // New code re-opening must recreate the tracking table, re-run the (no-op,
+  // IF NOT EXISTS) files, record them, and leave existing data intact.
+  const db2 = new ReefDb(path);
+  assert.deepEqual(appliedMigrations(db2), expected);
+  assert.equal(db2.listPublicPolyps().length, 1);
+});
+
 const basePolyp = () => ({
   species: 'branching' as const,
   seed: 1,

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -129,14 +129,47 @@ export class ReefDb {
   }
 
   private migrate(): void {
+    // Track which .sql files have run so each applies exactly once. Without
+    // this, every file re-exec'd on every boot — fine only because they all use
+    // CREATE ... IF NOT EXISTS. Any future migration that ALTERs or backfills
+    // data would re-run on every restart. The tracking table fixes that: a
+    // recorded file is skipped. Existing DBs (tables already present, but no
+    // schema_migrations row) back-fill cleanly on first run because the
+    // IF NOT EXISTS statements are no-ops and then get recorded.
+    this.db.exec(
+      `CREATE TABLE IF NOT EXISTS schema_migrations (
+         filename   TEXT PRIMARY KEY,
+         applied_at INTEGER NOT NULL
+       )`,
+    );
+    const applied = new Set(
+      (this.db.prepare('SELECT filename FROM schema_migrations').all() as Array<{ filename: string }>)
+        .map((r) => r.filename),
+    );
+    const record = this.db.prepare(
+      'INSERT OR IGNORE INTO schema_migrations (filename, applied_at) VALUES (?, ?)',
+    );
+
+    // Apply each file and record it atomically: exec + the bookkeeping row
+    // commit or roll back together, so a statement that throws mid-file can't
+    // leave the schema partially applied while the file is marked done (or
+    // vice versa). Migration files therefore must not contain their own
+    // BEGIN/COMMIT; current files are CREATE TABLE/INDEX, all transaction-safe.
+    const applyOne = this.db.transaction((f: string, sql: string) => {
+      this.db.exec(sql);
+      record.run(f, Date.now());
+    });
+
     const files = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).sort();
     for (const f of files) {
-      const sql = readFileSync(join(migrationsDir, f), 'utf8');
-      this.db.exec(sql);
+      if (applied.has(f)) continue;
+      applyOne(f, readFileSync(join(migrationsDir, f), 'utf8'));
     }
-    // Imperative column adds. SQLite ALTER TABLE ADD COLUMN has no
-    // IF NOT EXISTS form, so we check pragma_table_info and only alter
-    // when the column is missing.
+
+    // attach_yaw was added imperatively before the tracking table existed, and
+    // ALTER TABLE ADD COLUMN has no IF NOT EXISTS form. Keep the pragma-guarded
+    // add for DBs that predate it. New schema changes should be .sql migration
+    // files now that they run exactly once.
     this.ensureColumn('tree_polyps', 'attach_yaw', 'REAL NOT NULL DEFAULT 0');
   }
 


### PR DESCRIPTION
## Summary
Closes #95. The migration runner re-exec'd every `.sql` file on every boot, safe only because all current files use `CREATE ... IF NOT EXISTS`. The first future migration that `ALTER`s or backfills data would silently re-run on every restart.

## What changed
- New `schema_migrations(filename, applied_at)` table; files already recorded are skipped.
- Each file's `exec` + its bookkeeping row are applied **atomically in one transaction**, so a statement that throws mid-file can't leave the schema partially applied while the file is marked done (migration files must not contain their own `BEGIN/COMMIT`; current files are `CREATE TABLE/INDEX`, all transaction-safe).
- Existing databases (tables present, no tracking row) back-fill cleanly: the `IF NOT EXISTS` statements are no-ops, then recorded.
- `attach_yaw` `ensureColumn` patch kept (`ALTER TABLE ADD COLUMN` has no `IF NOT EXISTS`); new schema changes should be `.sql` files now that they run once.

## Test plan
- [x] Each `.sql` file is recorded in `schema_migrations` exactly once (no dupes)
- [x] Re-opening the same db file doesn't re-run or duplicate, data intact
- [x] **Back-fill path**: an existing db with tables but no `schema_migrations` row (simulated old-code DB) gets the table recreated, files re-run as no-ops and recorded, data preserved
- [x] Boot smoke test still green; server suite 115, lint + typecheck clean

Closes #95