### PR TITLE
feat(server): gate /metrics and count polyps cheaply to kill scrape amplification

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -2,14 +2,18 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { config } from './config.js';
 
-export function requireAdmin(token: string | undefined): boolean {
-  if (!token || !config.adminToken) return false;
+function tokenMatches(token: string | undefined, expected: string): boolean {
+  if (!token || !expected) return false;
   // Hash both to fixed-size 32-byte digests before timingSafeEqual so the
   // comparison runs in constant time regardless of the submitted token's
   // length. Raw-buffer compare leaks length through an early-return branch.
   const a = createHash('sha256').update(token).digest();
-  const b = createHash('sha256').update(config.adminToken).digest();
+  const b = createHash('sha256').update(expected).digest();
   return timingSafeEqual(a, b);
+}
+
+export function requireAdmin(token: string | undefined): boolean {
+  return tokenMatches(token, config.adminToken);
 }
 
 function bearerToken(req: FastifyRequest): string | undefined {
@@ -41,6 +45,24 @@ export function checkAdminAuth(req: FastifyRequest, reply: FastifyReply): boolea
  * Returns true to proceed; on failure writes 401 and returns false.
  */
 export function enforceAdminIfConfigured(req: FastifyRequest, reply: FastifyReply): boolean {
-  if (!config.adminToken) return true;
-  return checkAdminAuth(req, reply);
+  return enforceBearerIfConfigured(req, reply, config.adminToken);
+}
+
+/**
+ * Generic conditional bearer gate: open when `expected` is empty, otherwise
+ * requires `Authorization: Bearer <expected>` (timing-safe). On failure writes
+ * 401 and returns false. Used for /metrics (METRICS_TOKEN) and as the basis for
+ * the admin gate above.
+ */
+export function enforceBearerIfConfigured(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  expected: string,
+): boolean {
+  if (!expected) return true;
+  if (!tokenMatches(bearerToken(req), expected)) {
+    void reply.status(401).send({ error: 'unauthorized' });
+    return false;
+  }
+  return true;
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -3,6 +3,10 @@ export const config = {
   host: process.env.HOST ?? '0.0.0.0',
   dbPath: process.env.DB_PATH ?? './data/reef.db',
   adminToken: process.env.ADMIN_TOKEN ?? '',
+  // When set, GET /metrics requires `Authorization: Bearer <METRICS_TOKEN>`
+  // (Prometheus-style scrape auth). Unset = open, for a network-isolated
+  // scrape target.
+  metricsToken: process.env.METRICS_TOKEN ?? '',
   rateLimitWindowMs: Number(process.env.RATE_LIMIT_WINDOW_MS ?? 3_600_000),
   // 0 = disabled. Default off while the project is in testing; before
   // productionalizing set RATE_LIMIT_MAX to something like 1. Follow-up

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -34,6 +34,7 @@ export class ReefDb {
   readonly db: Database.Database;
   private readonly stmt: {
     listPolyps: Database.Statement;
+    countLivePolyps: Database.Statement;
     statsOverview: Database.Statement;
     statsRecent: Database.Statement;
     statsBySpecies: Database.Statement;
@@ -65,6 +66,7 @@ export class ReefDb {
       listPolyps: this.db.prepare(
         'SELECT * FROM polyps WHERE deleted = 0 ORDER BY created_at ASC',
       ),
+      countLivePolyps: this.db.prepare('SELECT COUNT(*) AS n FROM polyps WHERE deleted = 0'),
       statsOverview: this.db.prepare(
         `SELECT COUNT(*) AS total,
                 COUNT(DISTINCT device_hash) AS uniqueDevices,
@@ -187,6 +189,14 @@ export class ReefDb {
   /** Polyps with device_hash stripped — safe for broadcasting. */
   listPublicPolyps(): PublicPolyp[] {
     return (this.stmt.listPolyps.all() as PolypRow[]).map(rowToPublicPolyp);
+  }
+
+  /**
+   * Count of live polyps via a single aggregate — no row materialization. Used
+   * by /metrics so a scrape doesn't hydrate and strip every row each time.
+   */
+  countLivePolyps(): number {
+    return (this.stmt.countLivePolyps.get() as { n: number }).n;
   }
 
   insertPolyp(p: Omit<Polyp, 'id' | 'deleted'>): Polyp {

--- a/packages/server/src/routes/metrics.test.ts
+++ b/packages/server/src/routes/metrics.test.ts
@@ -8,6 +8,7 @@ import { ReefDb } from '../db.js';
 import { Hub } from '../hub.js';
 import { registerMetricsRoutes } from './metrics.js';
 import { counters } from '../metrics-registry.js';
+import { config } from '../config.js';
 
 function buildApp(): { app: FastifyInstance; db: ReefDb; hub: Hub } {
   const dir = mkdtempSync(join(tmpdir(), 'reef-metrics-'));
@@ -71,6 +72,43 @@ test('metrics: exposes reef_rate_limited_total as a monotonic counter', async ()
     assert.match(body, /^reef_rate_limited_total 3$/m);
   } finally {
     await app.close();
+  }
+});
+
+test('metrics: open when METRICS_TOKEN is unset', async () => {
+  const prev = config.metricsToken;
+  config.metricsToken = '';
+  const { app } = buildApp();
+  try {
+    const r = await app.inject({ method: 'GET', url: '/metrics' });
+    assert.equal(r.statusCode, 200);
+  } finally {
+    await app.close();
+    config.metricsToken = prev;
+  }
+});
+
+test('metrics: requires the bearer token once METRICS_TOKEN is set', async () => {
+  const prev = config.metricsToken;
+  config.metricsToken = 'scrape-secret';
+  const { app } = buildApp();
+  try {
+    assert.equal((await app.inject({ method: 'GET', url: '/metrics' })).statusCode, 401);
+    assert.equal(
+      (await app.inject({
+        method: 'GET', url: '/metrics', headers: { authorization: 'Bearer wrong' },
+      })).statusCode,
+      401,
+    );
+    assert.equal(
+      (await app.inject({
+        method: 'GET', url: '/metrics', headers: { authorization: 'Bearer scrape-secret' },
+      })).statusCode,
+      200,
+    );
+  } finally {
+    await app.close();
+    config.metricsToken = prev;
   }
 });
 

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import type { ReefDb } from '../db.js';
 import type { Hub } from '../hub.js';
 import { counters } from '../metrics-registry.js';
+import { config } from '../config.js';
+import { enforceBearerIfConfigured } from '../auth.js';
 
 // Minimal Prometheus text-format emitter. Any HELP/TYPE line whose value
 // contains `\n` or `\\` would need escaping — we control these strings so no
@@ -11,11 +13,15 @@ function metric(name: string, help: string, type: 'gauge' | 'counter', value: nu
 }
 
 export function registerMetricsRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): void {
-  app.get('/metrics', async (_req, reply) => {
+  app.get('/metrics', async (req, reply) => {
+    // Gated when METRICS_TOKEN is set (open otherwise, for a network-isolated
+    // scrape target). Returns 401 before doing any work on an unauthorized hit.
+    if (!enforceBearerIfConfigured(req, reply, config.metricsToken)) return reply;
     // application/openmetrics-text would also be acceptable, but Prometheus
     // 2.x default scraping expects the classic text format.
     reply.type('text/plain; version=0.0.4; charset=utf-8');
-    const polyps = db.listPublicPolyps().length;
+    // Cheap aggregate count — no per-scrape row hydration / device_hash strip.
+    const polyps = db.countLivePolyps();
     const clients = hub.size();
     return [
       metric('reef_polyps_total', 'Number of live (non-deleted) polyps.', 'gauge', polyps),


### PR DESCRIPTION
## Summary
Closes #43. `GET /metrics` was unauthenticated and ran `db.listPublicPolyps()` (full row hydration + `device_hash` strip) on every Prometheus scrape.

## What changed
- **Gate**: `/metrics` requires `Authorization: Bearer <METRICS_TOKEN>` when `METRICS_TOKEN` is set, open otherwise (for a network-isolated scrape target). Returns 401 before doing any DB work. Generalized the admin auth into `enforceBearerIfConfigured(req, reply, expected)` + a `tokenMatches(token, expected)` timing-safe compare; `enforceAdminIfConfigured` now delegates to it. Reef admin routes stay **unconditionally** gated (no behavior change).
- **Amplification**: replace `listPublicPolyps().length` with `db.countLivePolyps()` (`SELECT COUNT(*) WHERE deleted = 0`) — a single aggregate, no per-scrape row materialization.

## Test plan
- [x] `/metrics` open when `METRICS_TOKEN` unset; 401 without/with-wrong token and 200 with correct token once set
- [x] `reef_polyps_total` still equals the live count after the COUNT(*) swap (existing test)
- [x] Admin + tree-route auth tests unchanged and green (refactor behavior-preserving)
- [x] Server suite green (117), lint + typecheck clean

Closes #43