### PR TITLE
feat(server): read-side rate limit on /api/stats + short-TTL read cache

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,8 +13,13 @@ export const config = {
   // tracked in the repo issue list.
   rateLimitMax: Number(process.env.RATE_LIMIT_MAX ?? 0),
   // 0 = disabled. Default off; set READ_RATE_LIMIT_PER_MIN=60 (or similar)
-  // to re-enable the per-IP read-side token bucket.
+  // to re-enable the per-IP read-side token bucket on /api/reef and /api/stats.
   readRateLimitPerMin: Number(process.env.READ_RATE_LIMIT_PER_MIN ?? 0),
+  // Short-TTL read cache (ms) for /api/reef and /api/stats so a burst of reads
+  // coalesces into one DB scan. 0 = disabled (default, matching the testing
+  // posture). Set e.g. 1000 in production. Staleness is bounded by this value;
+  // WS keeps connected clients live regardless.
+  readCacheTtlMs: Number(process.env.READ_CACHE_TTL_MS ?? 0),
   simIntervalMs: Number(process.env.SIM_INTERVAL_MS ?? 3_600_000),
   snapshotIntervalMs: Number(process.env.SNAPSHOT_INTERVAL_MS ?? 86_400_000),
   // Sim deltas (barnacle/algae/weather decorations) older than this are pruned
@@ -48,6 +53,13 @@ if (!Number.isInteger(config.snapshotRetentionCount) || config.snapshotRetention
   throw new Error(
     `SNAPSHOT_RETENTION_COUNT must be a non-negative integer (0 keeps all), ` +
       `got ${JSON.stringify(process.env.SNAPSHOT_RETENTION_COUNT)}`,
+  );
+}
+
+if (!Number.isFinite(config.readCacheTtlMs) || config.readCacheTtlMs < 0) {
+  throw new Error(
+    `READ_CACHE_TTL_MS must be a non-negative number of milliseconds (0 disables), ` +
+      `got ${JSON.stringify(process.env.READ_CACHE_TTL_MS)}`,
   );
 }
 

--- a/packages/server/src/routes/reef.ts
+++ b/packages/server/src/routes/reef.ts
@@ -5,7 +5,7 @@ import type { ReefDb } from '../db.js';
 import { toPublicPolyp } from '../db.js';
 import type { Hub } from '../hub.js';
 import { deviceHash } from '../deviceHash.js';
-import { perIpRateLimit } from '../security.js';
+import { perIpRateLimit, ttlCache } from '../security.js';
 import { counters } from '../metrics-registry.js';
 
 export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): void {
@@ -14,6 +14,19 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
   const readLimit = config.readRateLimitPerMin > 0
     ? perIpRateLimit({ tokensPerInterval: config.readRateLimitPerMin, intervalMs: 60_000 })
     : null;
+
+  // The polyps + sim scans are the expensive part of GET /api/reef. Cache them
+  // for READ_CACHE_TTL_MS so a burst of reads coalesces into one scan. The sim
+  // payload is bounded to the retention window (0 = retention disabled → all).
+  const buildSnapshot = (): Pick<ReefState, 'polyps' | 'sim'> => ({
+    polyps: db.listPublicPolyps(),
+    sim: config.simRetentionMs > 0
+      ? db.listSimSince(Date.now() - config.simRetentionMs)
+      : db.listSim(),
+  });
+  const readSnapshot = config.readCacheTtlMs > 0
+    ? ttlCache(buildSnapshot, config.readCacheTtlMs)
+    : buildSnapshot;
 
   app.get('/api/reef', async (req, reply) => {
     if (readLimit) {
@@ -24,16 +37,8 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
         return reply.status(429).send({ error: 'rate_limited' });
       }
     }
-    // Bound the sim payload to the retention window so this response can't grow
-    // without limit as decorations accumulate. 0 = retention disabled → all.
-    const sim = config.simRetentionMs > 0
-      ? db.listSimSince(Date.now() - config.simRetentionMs)
-      : db.listSim();
-    const state: ReefState = {
-      polyps: db.listPublicPolyps(),
-      sim,
-      serverTime: Date.now(),
-    };
+    // serverTime is always fresh even when the scans are served from cache.
+    const state: ReefState = { ...readSnapshot(), serverTime: Date.now() };
     return state;
   });
 

--- a/packages/server/src/routes/stats.test.ts
+++ b/packages/server/src/routes/stats.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { ReefDb } from '../db.js';
 import { registerStatsRoutes } from './stats.js';
+import { config } from '../config.js';
 
 function buildApp(): { app: FastifyInstance; db: ReefDb } {
   const dir = mkdtempSync(join(tmpdir(), 'reef-stats-'));
@@ -59,4 +60,38 @@ test('stats: counts unique devices and species breakdown', async () => {
   assert.equal(j.bySpecies.bulbous, 2);
   assert.equal(j.bySpecies.fan, 1);
   await app.close();
+});
+
+test('stats: per-IP read rate limit returns 429 once exceeded', async () => {
+  // The limiter is created at route-registration time, so set config first.
+  const prev = config.readRateLimitPerMin;
+  config.readRateLimitPerMin = 1;
+  const { app } = buildApp();
+  try {
+    assert.equal((await app.inject({ method: 'GET', url: '/api/stats' })).statusCode, 200);
+    const second = await app.inject({ method: 'GET', url: '/api/stats' });
+    assert.equal(second.statusCode, 429);
+    assert.ok(second.headers['retry-after'] !== undefined);
+  } finally {
+    await app.close();
+    config.readRateLimitPerMin = prev;
+  }
+});
+
+test('stats: read cache serves a snapshot for the TTL window', async () => {
+  // Large TTL so the second read is guaranteed cached.
+  const prev = config.readCacheTtlMs;
+  config.readCacheTtlMs = 60_000;
+  const { app, db } = buildApp();
+  try {
+    const first = (await app.inject({ method: 'GET', url: '/api/stats' })).json() as { total: number };
+    assert.equal(first.total, 0);
+    // Insert after the cache was filled; the cached response must not reflect it.
+    db.insertPolyp(base());
+    const second = (await app.inject({ method: 'GET', url: '/api/stats' })).json() as { total: number };
+    assert.equal(second.total, 0);
+  } finally {
+    await app.close();
+    config.readCacheTtlMs = prev;
+  }
 });

--- a/packages/server/src/routes/stats.ts
+++ b/packages/server/src/routes/stats.ts
@@ -1,6 +1,26 @@
 import type { FastifyInstance } from 'fastify';
+import { config } from '../config.js';
 import type { ReefDb } from '../db.js';
+import { perIpRateLimit, ttlCache } from '../security.js';
+import { counters } from '../metrics-registry.js';
 
 export function registerStatsRoutes(app: FastifyInstance, db: ReefDb): void {
-  app.get('/api/stats', async () => db.stats());
+  const readLimit = config.readRateLimitPerMin > 0
+    ? perIpRateLimit({ tokensPerInterval: config.readRateLimitPerMin, intervalMs: 60_000 })
+    : null;
+  const readStats = config.readCacheTtlMs > 0
+    ? ttlCache(() => db.stats(), config.readCacheTtlMs)
+    : (): ReturnType<ReefDb['stats']> => db.stats();
+
+  app.get('/api/stats', async (req, reply) => {
+    if (readLimit) {
+      const check = readLimit(req.ip || 'unknown');
+      if (!check.ok) {
+        counters.inc('rate_limited');
+        reply.header('Retry-After', Math.ceil(check.retryAfterMs / 1000));
+        return reply.status(429).send({ error: 'rate_limited' });
+      }
+    }
+    return readStats();
+  });
 }

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -1,6 +1,23 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { perIpRateLimit } from './security.js';
+import { perIpRateLimit, ttlCache } from './security.js';
+
+test('ttlCache: reuses the cached value within the TTL (one production)', () => {
+  let calls = 0;
+  const cached = ttlCache(() => ++calls, 10_000);
+  assert.equal(cached(), 1);
+  assert.equal(cached(), 1);
+  assert.equal(cached(), 1);
+  assert.equal(calls, 1);
+});
+
+test('ttlCache: a zero TTL recomputes every call', () => {
+  let calls = 0;
+  const cached = ttlCache(() => ++calls, 0);
+  assert.equal(cached(), 1);
+  assert.equal(cached(), 2);
+  assert.equal(calls, 2);
+});
 
 test('perIpRateLimit admits tokens up to budget', () => {
   const limit = perIpRateLimit({ tokensPerInterval: 3, intervalMs: 10_000 });

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -62,3 +62,25 @@ export function perIpRateLimit(opts: { tokensPerInterval: number; intervalMs: nu
     return { ok: false, retryAfterMs };
   };
 }
+
+/**
+ * Wrap an expensive read so repeated calls within `ttlMs` share one result.
+ * Coalesces a burst of identical reads (e.g. many clients loading /api/reef at
+ * once) into a single DB scan per window. Bounded staleness only — there is no
+ * invalidation, so keep `ttlMs` small. Single-threaded event loop, so no lock
+ * needed: a value computed mid-window is simply reused until it expires.
+ *
+ * The same object reference is returned to every caller within the window, so
+ * callers MUST treat the result as read-only — mutating it corrupts the cached
+ * value for every subsequent request until the TTL expires.
+ */
+export function ttlCache<T>(produce: () => T, ttlMs: number): () => T {
+  let cached: { value: T; at: number } | null = null;
+  return () => {
+    const now = Date.now();
+    if (cached && now - cached.at < ttlMs) return cached.value;
+    const value = produce();
+    cached = { value, at: now };
+    return value;
+  };
+}


### PR DESCRIPTION
## Summary
Closes #45. `/api/reef` already had the per-IP read rate limit; `/api/stats` had neither, and both endpoints re-scan the DB on every read.

## What changed
- **Rate limit**: extend the existing per-IP read limit (`READ_RATE_LIMIT_PER_MIN`) to `/api/stats`.
- **Cache**: new `ttlCache(produce, ttlMs)` helper applied to the expensive scans on both routes — `/api/reef` (polyps + sim, with `serverTime` stamped fresh per response) and `/api/stats` — so a burst of reads coalesces into one DB scan per window. New `READ_CACHE_TTL_MS` (default `0` = disabled, validated; set e.g. `1000` in production).

Both default off, matching the existing rate-limit testing posture, so no behavior change until an operator opts in. Staleness is bounded by the TTL, and WS keeps connected clients live regardless (the GET is a cold-load/refresh path).

## Test plan
- [x] `ttlCache` reuses within TTL (one production), recomputes when disabled
- [x] `/api/stats` returns 429 with `Retry-After` once the per-IP limit is exceeded
- [x] `/api/stats` read cache serves a snapshot for the TTL window (insert after fill not reflected until expiry)
- [x] Default-off preserves prior behavior on both routes; `serverTime` always fresh on `/api/reef`
- [x] Server suite green (121), lint + typecheck clean

Closes #45