### PR TITLE
feat(server): cap concurrent WebSocket connections per hub

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -32,6 +32,10 @@ export const config = {
   // after each new snapshot so the snapshots table (full-state JSON blobs)
   // doesn't grow forever. 0 = keep all (pruning disabled).
   snapshotRetentionCount: Number(process.env.SNAPSHOT_RETENTION_COUNT ?? 90),
+  // Max concurrent WebSocket connections per hub (reef and tree count
+  // separately). 0 = unlimited. Bounds a connection flood from exhausting
+  // memory / file descriptors before the heartbeat reaps idle sockets.
+  wsMaxClients: Number(process.env.WS_MAX_CLIENTS ?? 1000),
   corsOrigins: (process.env.CORS_ORIGINS ?? '*').split(',').map((s) => s.trim()),
   // Absolute path to the built Vite client bundle. When set, the server
   // serves the static files and SPA index fallbacks. Leave unset in dev so
@@ -60,6 +64,13 @@ if (!Number.isFinite(config.readCacheTtlMs) || config.readCacheTtlMs < 0) {
   throw new Error(
     `READ_CACHE_TTL_MS must be a non-negative number of milliseconds (0 disables), ` +
       `got ${JSON.stringify(process.env.READ_CACHE_TTL_MS)}`,
+  );
+}
+
+if (!Number.isInteger(config.wsMaxClients) || config.wsMaxClients < 0) {
+  throw new Error(
+    `WS_MAX_CLIENTS must be a non-negative integer (0 = unlimited), ` +
+      `got ${JSON.stringify(process.env.WS_MAX_CLIENTS)}`,
   );
 }
 

--- a/packages/server/src/hub.test.ts
+++ b/packages/server/src/hub.test.ts
@@ -37,6 +37,51 @@ function fakeSocket(readyState = 1): FakeWebSocket {
   return sock;
 }
 
+test('hub: caps concurrent clients and refuses over the limit', () => {
+  const hub = new Hub(2);
+  const a = fakeSocket();
+  const b = fakeSocket();
+  const c = fakeSocket();
+  assert.equal(hub.add(a), true);
+  assert.equal(hub.add(b), true);
+  // Third connection over the cap is refused and closed.
+  assert.equal(hub.add(c), false);
+  assert.equal(hub.size(), 2);
+  assert.equal(c.readyState, 3); // close() set it to CLOSED
+  // The refused socket gets no broadcasts.
+  hub.broadcast({ type: 'polyp_removed', id: 1 });
+  assert.equal(c.sent.length, 0);
+  assert.equal(a.sent.length, 1);
+});
+
+test('hub: a refused socket whose close() throws still gets terminated', () => {
+  const hub = new Hub(1);
+  hub.add(fakeSocket());
+  const bad = fakeSocket();
+  bad.close = () => { throw new Error('close failed'); };
+  assert.equal(hub.add(bad), false);
+  // Fallback teardown ran so the refused socket can't linger as an orphan FD.
+  assert.equal(bad.terminated, true);
+});
+
+test('hub: a freed slot can be reused after a client disconnects', () => {
+  const hub = new Hub(1);
+  const a = fakeSocket();
+  const b = fakeSocket();
+  assert.equal(hub.add(a), true);
+  assert.equal(hub.add(b), false);
+  a.close(); // a disconnects, freeing the slot
+  assert.equal(hub.size(), 0);
+  assert.equal(hub.add(b), true);
+  assert.equal(hub.size(), 1);
+});
+
+test('hub: default (no cap) admits many clients', () => {
+  const hub = new Hub();
+  for (let i = 0; i < 50; i++) assert.equal(hub.add(fakeSocket()), true);
+  assert.equal(hub.size(), 50);
+});
+
 test('hub: broadcast reaches all open clients', () => {
   const hub = new Hub();
   const a = fakeSocket();

--- a/packages/server/src/hub.ts
+++ b/packages/server/src/hub.ts
@@ -16,6 +16,7 @@ type WebSocket = {
   on(event: 'close' | 'pong', cb: () => void): void;
   ping?(): void;
   terminate?(): void;
+  close?(code?: number, reason?: string): void;
 };
 
 interface LivenessState {
@@ -26,7 +27,28 @@ export class Hub {
   private clients = new Map<WebSocket, LivenessState>();
   private heartbeat: NodeJS.Timeout | undefined;
 
-  add(ws: WebSocket): void {
+  // 0 = unlimited. Bounds concurrent connections so a connection flood can't
+  // exhaust memory / file descriptors before the heartbeat reaps idle sockets.
+  constructor(private readonly maxClients = 0) {}
+
+  /**
+   * Register a socket. Returns false (and closes the socket) when the hub is at
+   * capacity, so the caller must skip its hello/setup on a false result.
+   */
+  add(ws: WebSocket): boolean {
+    if (this.maxClients > 0 && this.clients.size >= this.maxClients) {
+      // At capacity: refuse with 1013 "Try Again Later" so clients can back off.
+      // A refused socket is never added to the map, so the heartbeat won't reap
+      // it — fall back to an abrupt terminate if close() is missing OR throws,
+      // so it can't linger as an orphaned FD (the leak the cap exists to stop).
+      try {
+        if (ws.close) ws.close(1013, 'server at capacity');
+        else ws.terminate?.();
+      } catch {
+        try { ws.terminate?.(); } catch { /* already torn down */ }
+      }
+      return false;
+    }
     const state: LivenessState = { alive: true };
     // The pong listener must be wired before join so we never miss the
     // first keepalive response. 'close' wired here for the same reason.
@@ -35,6 +57,7 @@ export class Hub {
       this.clients.delete(ws);
     });
     this.clients.set(ws, state);
+    return true;
   }
 
   broadcast(msg: ServerMessage): void {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -50,9 +50,9 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
   const useLogger = opts.logger ?? true;
 
   const db = new ReefDb(dbPath);
-  const hub = new Hub();
+  const hub = new Hub(config.wsMaxClients);
   const treeDb = new TreeDb(db);
-  const treeHub = new Hub();
+  const treeHub = new Hub(config.wsMaxClients);
   seedRootIfEmpty(treeDb);
 
   // 8 KB fits the largest valid polyp (schema-bounded). Fastify's 1 MB
@@ -101,7 +101,8 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
       ping?(): void;
       terminate?(): void;
     };
-    hub.add(ws);
+    // add() closes the socket and returns false when the hub is at capacity.
+    if (!hub.add(ws)) return;
     ws.send(JSON.stringify({
       type: 'hello',
       polypCount: db.listPublicPolyps().length,
@@ -117,7 +118,7 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
       ping?(): void;
       terminate?(): void;
     };
-    treeHub.add(ws);
+    if (!treeHub.add(ws)) return;
     ws.send(JSON.stringify({
       type: 'tree_hello',
       polypCount: treeDb.listLive().length,


### PR DESCRIPTION
## Summary
Closes #46. WS connections were uncapped, so a connection flood could exhaust memory / file descriptors before the heartbeat reaps idle sockets.

## What changed
- `Hub` takes `maxClients` (0 = unlimited; default for the no-arg constructor used widely in tests, so existing callers are unaffected).
- `add()` returns a boolean. At capacity it refuses the socket: closes with 1013 "Try Again Later", falling back to `terminate()` if `close()` is missing **or throws** (so a refused socket can't linger as an orphaned FD — the leak the cap exists to prevent), and returns false. The refused socket is never added to the map.
- `/ws` and `/ws/tree` handlers skip their hello/setup on a false result.
- New `WS_MAX_CLIENTS` config (default **1000**, validated integer ≥ 0; `0` = unlimited), wired into both hubs (reef and tree count separately).

Default 1000 (not 0): this is an availability safeguard, not a policy knob — 1000/hub is far above any plausible legitimate concurrency and only bites a flood. `WS_MAX_CLIENTS=0` restores unlimited.

## Test plan
- [x] Cap admits exactly `maxClients`, refuses the next (off-by-one), refused socket closed and gets no broadcasts
- [x] A freed slot (client disconnects) is reusable
- [x] A refused socket whose `close()` throws still gets `terminate()`d
- [x] No-cap default admits many clients (backward compat)
- [x] Server suite green (125), lint + typecheck clean

Closes #46