### PR TITLE
chore: enable read rate limit + cache in prod env and add an ops runbook

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,56 @@
+# Operations runbook
+
+Short operational notes for running the CoralReefAR server in production. The
+canonical deployment config is `fly.toml`; this file explains the *why* and the
+day-2 tuning.
+
+## Production environment
+
+Every protection ships **off by default in code** so local and hands-on testing
+isn't throttled. Production turns them on via `fly.toml`'s `[env]` block (or the
+container environment for a self-hosted deploy):
+
+| Env var | Prod value | Effect |
+|---|---|---|
+| `RATE_LIMIT_WINDOW_MS` | `3600000` (1h) | Sliding window for the per-device write limit. |
+| `RATE_LIMIT_MAX` | `1` | Polyps per device per window. Also bounds tree writes. `0` = off. |
+| `READ_RATE_LIMIT_PER_MIN` | `60` | Per-IP token bucket on `GET /api/reef` and `/api/stats`. `0` = off. |
+| `READ_CACHE_TTL_MS` | `1000` | Coalesce read scans within this window. `0` = off. |
+| `WS_MAX_CLIENTS` | `1000` (default) | Max concurrent WebSocket connections per hub (reef + tree counted separately). `0` = unlimited. |
+| `SIM_RETENTION_MS` | `2592000000` (30d, default) | Prune sim decorations older than this. `0` = keep all. |
+| `SNAPSHOT_RETENTION_COUNT` | `90` (default) | Keep the N most recent daily snapshots. `0` = keep all. |
+| `ADMIN_TOKEN` | secret | Gates the reef admin routes and (when set) the destructive tree reset/delete. |
+| `METRICS_TOKEN` | secret (optional) | When set, `GET /metrics` requires `Authorization: Bearer <token>`. |
+| `CORS_ORIGINS` | the deployed origin | Comma-separated allowlist. |
+
+Set the secrets out of band: `fly secrets set ADMIN_TOKEN=... METRICS_TOKEN=... CORS_ORIGINS=...`.
+
+## Watching the rate limiter
+
+`reef_rate_limited_total` (a counter at `GET /metrics`) increments once per
+request rejected by either the write limit or the read limit, across the reef
+and tree routes.
+
+- **Healthy:** near-flat, occasional bumps. A handful per day is normal — a
+  visitor double-tapping, a refresh storm, a scraper.
+- **Climbing steadily:** the limits may be too tight for real usage. With
+  `RATE_LIMIT_MAX=1/hour` a genuinely engaged visitor who wants to plant a
+  second polyp is blocked; if you see sustained growth alongside organic
+  traffic, widen the window or raise the max.
+- **Spiking:** likely abuse (a bot hammering writes) or a misbehaving client.
+  Check `reef_ws_clients` and the access logs; the cap (`WS_MAX_CLIENTS`) and
+  the limits are doing their job.
+
+After a few days of real traffic, compare `reef_rate_limited_total` growth
+against `reef_polyps_total` growth and adjust `RATE_LIMIT_MAX` /
+`RATE_LIMIT_WINDOW_MS` to taste. The 1-per-hour default is a hand-tuned starting
+point, not a measured one.
+
+## Known limitations (accepted for the installation context)
+
+- The device key is `sha256(user-agent, ip, rotating-salt)`. A motivated
+  attacker with a VPN and a second device bypasses the per-device write limit.
+  Acceptable for a gallery/installation; for public-internet scale, add a
+  CAPTCHA or proof-of-work in front of writes.
+- The rotating salt changes each window, so a device straddling a window
+  boundary can briefly exceed the limit by one. Bounded and accepted.

--- a/fly.toml
+++ b/fly.toml
@@ -24,8 +24,14 @@ primary_region = "iad"
   DB_PATH = "/data/reef.db"
   NODE_ENV = "production"
   CLIENT_DIST_DIR = "/app/packages/client/dist"
-  RATE_LIMIT_WINDOW_MS = "3600000"
-  RATE_LIMIT_MAX = "1"
+  # Production protections — all default OFF in code so local/dev testing isn't
+  # throttled; turned ON here for real-visitor traffic. See docs/runbook.md.
+  RATE_LIMIT_WINDOW_MS = "3600000"   # 1 hour sliding window for the write limit
+  RATE_LIMIT_MAX = "1"               # polyps per device per window
+  READ_RATE_LIMIT_PER_MIN = "60"     # reads per IP per minute on /api/reef + /api/stats
+  READ_CACHE_TTL_MS = "1000"         # coalesce read scans within 1s
+  # WS_MAX_CLIENTS (default 1000/hub), SIM_RETENTION_MS (30d), and
+  # SNAPSHOT_RETENTION_COUNT (90) already default to safe production values.
 
 [[mounts]]
   source = "reef_data"


### PR DESCRIPTION
## Summary
Closes #25. The rate-limit machinery is all default-off in code (so hands-on testing isn't throttled); this bakes the production values into the deploy config and documents the operational side.

## What changed
- **fly.toml** already set the per-device write limit (`RATE_LIMIT_MAX=1`, `RATE_LIMIT_WINDOW_MS`). Added the read-side protections from this batch: `READ_RATE_LIMIT_PER_MIN=60` and `READ_CACHE_TTL_MS=1000`. `WS_MAX_CLIENTS` (1000), `SIM_RETENTION_MS` (30d), and `SNAPSHOT_RETENTION_COUNT` (90) already default to safe production values.
- **docs/runbook.md** (new): the production env table (every protection, prod value, effect), how to read `reef_rate_limited_total` (healthy / climbing / spiking) and tune `RATE_LIMIT_MAX`/`RATE_LIMIT_WINDOW_MS`, and the accepted device-key limitations (VPN+second-device bypass, window-boundary off-by-one).

## Notes
No code change — limits stay default-off in code so local/dev isn't throttled; production turns them on via env. Every env var name, value, and behavior claim in the runbook was verified against `config.ts` and the route code.

## Test plan
- [x] All 10 env var names match `config.ts` keys
- [x] Runbook behavior claims verified against source (write limit bounds tree writes too, read limit applies to /api/reef + /api/stats, `reef_rate_limited_total` counts both, token gates accurate, retention defaults correct)
- [x] `pnpm lint` clean; no code changed so the suite is unaffected

Closes #25