### PR TITLE
fix(server): count a device across window boundaries to close the rate-limit double-dip

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -52,5 +52,6 @@ point, not a measured one.
   attacker with a VPN and a second device bypasses the per-device write limit.
   Acceptable for a gallery/installation; for public-internet scale, add a
   CAPTCHA or proof-of-work in front of writes.
-- The rotating salt changes each window, so a device straddling a window
-  boundary can briefly exceed the limit by one. Bounded and accepted.
+- The per-window salt is reconstructible (HMAC of a per-process secret), and
+  the limiter counts a device under both the current and previous window's
+  hash, so crossing a window boundary no longer resets the count.

--- a/packages/server/src/deviceHash.test.ts
+++ b/packages/server/src/deviceHash.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, test } from 'node:test';
-import { deviceHash } from './deviceHash.js';
+import { deviceHash, deviceHashesForCounting } from './deviceHash.js';
 
 describe('deviceHash', () => {
   let realNow: () => number;
@@ -52,5 +52,34 @@ describe('deviceHash', () => {
     const out = deviceHash('UA', 'IP', 1000);
     assert.equal(out.length, 64);
     assert.match(out, /^[0-9a-f]{64}$/);
+  });
+
+  test('counting hashes: first entry equals the current store hash', () => {
+    Date.now = () => 6_000_500;
+    const windowMs = 1000;
+    const stored = deviceHash('UA', 'IP', windowMs);
+    const [current] = deviceHashesForCounting('UA', 'IP', windowMs);
+    assert.equal(current, stored);
+  });
+
+  test('counting hashes: current and previous entries differ', () => {
+    Date.now = () => 7_000_500;
+    const [current, previous] = deviceHashesForCounting('UA', 'IP', 1000);
+    assert.notEqual(current, previous);
+  });
+
+  test('boundary fix: a polyp stored last window is still attributed this window', () => {
+    const windowMs = 1000;
+    // Store under bucket 8000's hash.
+    Date.now = () => 8_000_500;
+    const storedLastWindow = deviceHash('UA', 'IP', windowMs);
+    // One window later (bucket 8001): the counting set must include the prior
+    // hash, so the device can't shed its earlier polyp by crossing the boundary.
+    Date.now = () => 8_001_500;
+    const counting = deviceHashesForCounting('UA', 'IP', windowMs);
+    assert.ok(
+      counting.includes(storedLastWindow),
+      'previous-window hash must be in the counting set',
+    );
   });
 });

--- a/packages/server/src/deviceHash.ts
+++ b/packages/server/src/deviceHash.ts
@@ -1,22 +1,42 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, createHmac, randomBytes } from 'node:crypto';
 
-let currentSalt = '';
-let currentBucket = -1;
+// Per-process secret. Each window's salt is derived from it via HMAC, so any
+// bucket's salt is reconstructible on demand — needed to count a device under
+// the PREVIOUS window's hash without retaining mutable salt state. The secret
+// is fresh per process, so a device hash is still not a durable cross-restart
+// identifier (restarting resets rate-limit state, same as before).
+const SERVER_SECRET = randomBytes(32);
 
-// Salt turns over on the same cadence as the rate-limit window so the
-// device-hash key stays stable for the whole window. A calendar-day rotation
-// creates a hole at midnight: a device limited at 23:59 would get a new hash
-// at 00:00 and escape the counter.
-function rollSalt(windowMs: number): string {
-  const bucket = Math.floor(Date.now() / windowMs);
-  if (bucket !== currentBucket) {
-    currentSalt = randomBytes(16).toString('hex');
-    currentBucket = bucket;
-  }
-  return currentSalt;
+function saltForBucket(bucket: number): string {
+  return createHmac('sha256', SERVER_SECRET).update(String(bucket)).digest('hex');
 }
 
-export function deviceHash(userAgent: string, ip: string, windowMs: number): string {
-  const salt = rollSalt(windowMs);
+function hashFor(userAgent: string, ip: string, bucket: number): string {
+  const salt = saltForBucket(bucket);
   return createHash('sha256').update(`${userAgent}|${ip}|${salt}`).digest('hex');
+}
+
+/**
+ * Device fingerprint for the CURRENT window. Used when STORING a polyp's
+ * device_hash. The per-window salt means the hash isn't a durable identifier.
+ */
+export function deviceHash(userAgent: string, ip: string, windowMs: number): string {
+  return hashFor(userAgent, ip, Math.floor(Date.now() / windowMs));
+}
+
+/**
+ * The device's hashes for the CURRENT and PREVIOUS window. Used when COUNTING
+ * so a device can't reset its rate-limit count by crossing a window boundary:
+ * a polyp stored last window (under the previous salt) is still attributed to
+ * the same device this window. Sum the per-hash counts — a polyp has exactly
+ * one device_hash, and the two hashes always differ, so nothing is counted
+ * twice.
+ */
+export function deviceHashesForCounting(
+  userAgent: string,
+  ip: string,
+  windowMs: number,
+): string[] {
+  const bucket = Math.floor(Date.now() / windowMs);
+  return [hashFor(userAgent, ip, bucket), hashFor(userAgent, ip, bucket - 1)];
 }

--- a/packages/server/src/routes/reef.test.ts
+++ b/packages/server/src/routes/reef.test.ts
@@ -100,6 +100,34 @@ test('POST /api/reef/polyp returns 429 with retryAfterMs when RATE_LIMIT_MAX ena
   }
 });
 
+test('POST /api/reef/polyp: crossing a window boundary does not reset the count', async () => {
+  // Regression for the salt-rotation double-dip: a device that plants in one
+  // window must still be counted in the next, so it can't replant by waiting
+  // for the boundary.
+  const savedMax = config.rateLimitMax;
+  const savedWindow = config.rateLimitWindowMs;
+  const realNow = Date.now;
+  config.rateLimitMax = 1;
+  config.rateLimitWindowMs = 1000;
+  try {
+    const { app } = buildApp();
+    // Plant in bucket 10000.
+    Date.now = () => 10_000_400;
+    const first = await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
+    assert.equal(first.statusCode, 201);
+    // One window later (bucket 10001): the salt rotated, but the device's prior
+    // polyp is still within the sliding window and must still count → 429.
+    Date.now = () => 10_001_400;
+    const second = await app.inject({ method: 'POST', url: '/api/reef/polyp', payload: valid });
+    assert.equal(second.statusCode, 429);
+    await app.close();
+  } finally {
+    Date.now = realNow;
+    config.rateLimitMax = savedMax;
+    config.rateLimitWindowMs = savedWindow;
+  }
+});
+
 test('POST /api/reef/polyp accepts unlimited requests when rate limit is off (default)', async () => {
   const savedMax = config.rateLimitMax;
   config.rateLimitMax = 0;

--- a/packages/server/src/routes/reef.ts
+++ b/packages/server/src/routes/reef.ts
@@ -4,7 +4,7 @@ import { config } from '../config.js';
 import type { ReefDb } from '../db.js';
 import { toPublicPolyp } from '../db.js';
 import type { Hub } from '../hub.js';
-import { deviceHash } from '../deviceHash.js';
+import { deviceHash, deviceHashesForCounting } from '../deviceHash.js';
 import { perIpRateLimit, ttlCache } from '../security.js';
 import { counters } from '../metrics-registry.js';
 
@@ -53,10 +53,16 @@ export function registerReefRoutes(app: FastifyInstance, db: ReefDb, hub: Hub): 
     const dh = deviceHash(String(ua), String(ip), config.rateLimitWindowMs);
 
     const windowStart = Date.now() - config.rateLimitWindowMs;
-    const already = db.countByDeviceSince(dh, windowStart);
+    // Count under the current AND previous window's hash so crossing a window
+    // boundary can't reset the count (see deviceHashesForCounting).
+    const countHashes = deviceHashesForCounting(String(ua), String(ip), config.rateLimitWindowMs);
+    const already = countHashes.reduce((n, h) => n + db.countByDeviceSince(h, windowStart), 0);
     if (config.rateLimitMax > 0 && already >= config.rateLimitMax) {
       counters.inc('rate_limited');
-      const oldest = db.oldestPolypSince(dh, windowStart);
+      const oldests = countHashes
+        .map((h) => db.oldestPolypSince(h, windowStart))
+        .filter((t): t is number => t !== null);
+      const oldest = oldests.length ? Math.min(...oldests) : null;
       const retryAfterMs = oldest !== null
         ? Math.max(0, oldest + config.rateLimitWindowMs - Date.now())
         : config.rateLimitWindowMs;

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -4,7 +4,7 @@ import type { Hub } from '../hub.js';
 import type { TreeDb } from './db.js';
 import { seedRootIfEmpty } from './seed.js';
 import { enforceAdminIfConfigured } from '../auth.js';
-import { deviceHash } from '../deviceHash.js';
+import { deviceHash, deviceHashesForCounting } from '../deviceHash.js';
 import { config } from '../config.js';
 import { counters } from '../metrics-registry.js';
 
@@ -46,9 +46,16 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
     const ip = req.ip || req.headers['x-forwarded-for']?.toString() || 'unknown';
     const dh = deviceHash(String(ua), String(ip), config.rateLimitWindowMs);
     const windowStart = Date.now() - config.rateLimitWindowMs;
-    if (config.rateLimitMax > 0 && tree.countByDeviceSince(dh, windowStart) >= config.rateLimitMax) {
+    // Count under the current AND previous window's hash so crossing a window
+    // boundary can't reset the count (see deviceHashesForCounting).
+    const countHashes = deviceHashesForCounting(String(ua), String(ip), config.rateLimitWindowMs);
+    const already = countHashes.reduce((n, h) => n + tree.countByDeviceSince(h, windowStart), 0);
+    if (config.rateLimitMax > 0 && already >= config.rateLimitMax) {
       counters.inc('rate_limited');
-      const oldest = tree.oldestByDeviceSince(dh, windowStart);
+      const oldests = countHashes
+        .map((h) => tree.oldestByDeviceSince(h, windowStart))
+        .filter((t): t is number => t !== null);
+      const oldest = oldests.length ? Math.min(...oldests) : null;
       const retryAfterMs = oldest !== null
         ? Math.max(0, oldest + config.rateLimitWindowMs - Date.now())
         : config.rateLimitWindowMs;


### PR DESCRIPTION
## Summary
Closes #104. The device salt rotated per fixed window bucket (`floor(now/windowMs)`) while the count window slid (`now - windowMs`). At a boundary a device got a new hash and its prior-window polyps stopped counting under the new hash, so it could replant immediately by waiting for the boundary (the rate-limit double-dip).

## Fix
- `deviceHash.ts`: derive each bucket's salt via **HMAC of a per-process secret** so any bucket's salt is reconstructible without retaining mutable state. The secret is fresh per process, so the hash is still not a durable cross-restart identifier (matching the old in-memory-salt behavior).
- Keep `deviceHash()` for **storing** under the current-window hash; add `deviceHashesForCounting()` returning `[current, previous]`.
- The reef and tree write routes **sum** the per-device count over both hashes (a polyp has exactly one `device_hash` and the two hashes always differ → nothing counted twice) and take the earliest oldest across both for `Retry-After`.

Current + previous is sufficient: a polyp two buckets old is always older than the sliding-window start, so it's filtered out regardless of hash.

## Test plan
- [x] `deviceHashesForCounting[0]` equals the store hash; current/previous differ; a polyp stored last window is in this window's counting set
- [x] Integration: planting in bucket N then attempting in bucket N+1 still returns 429 (regression test — fails on the old single-hash code)
- [x] No behavior change off-boundary (previous-bucket hash has 0 stored polyps within one window) — existing rate-limit tests unchanged
- [x] runbook.md updated (this was previously listed as "accepted")
- [x] Server suite green (129), lint + typecheck clean

Closes #104