### PR TITLE
fix(server): fail closed on CORS in production

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -21,7 +21,7 @@ container environment for a self-hosted deploy):
 | `SNAPSHOT_RETENTION_COUNT` | `90` (default) | Keep the N most recent daily snapshots. `0` = keep all. |
 | `ADMIN_TOKEN` | secret | Gates the reef admin routes and (when set) the destructive tree reset/delete. |
 | `METRICS_TOKEN` | secret (optional) | When set, `GET /metrics` requires `Authorization: Bearer <token>`. |
-| `CORS_ORIGINS` | the deployed origin | Comma-separated allowlist. |
+| `CORS_ORIGINS` | the deployed origin | Comma-separated allowlist. **Required in production**: with `NODE_ENV=production` the server refuses to start if this is `*` or unset (fail-closed). `*` stays the convenient default in dev/test. |
 
 Set the secrets out of band: `fly secrets set ADMIN_TOKEN=... METRICS_TOKEN=... CORS_ORIGINS=...`.
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,3 +1,5 @@
+import { assertProductionCorsSafe } from './cors.js';
+
 export const config = {
   port: Number(process.env.PORT ?? 8787),
   host: process.env.HOST ?? '0.0.0.0',
@@ -73,4 +75,8 @@ if (!Number.isInteger(config.wsMaxClients) || config.wsMaxClients < 0) {
       `got ${JSON.stringify(process.env.WS_MAX_CLIENTS)}`,
   );
 }
+
+// Fail closed on CORS in production: refuse to start if origins are wide-open
+// or unset. Testing keeps the convenient `*` default.
+assertProductionCorsSafe(config.corsOrigins, process.env.NODE_ENV);
 

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { resolveCorsOrigin, corsIsWideOpenOrEmpty, assertProductionCorsSafe } from './cors.js';
+
+test('resolveCorsOrigin: "*" → true (wide open)', () => {
+  assert.equal(resolveCorsOrigin(['*']), true);
+});
+
+test('resolveCorsOrigin: explicit origins → the cleaned allowlist', () => {
+  assert.deepEqual(resolveCorsOrigin(['https://a.com', ' https://b.com ']), [
+    'https://a.com',
+    'https://b.com',
+  ]);
+});
+
+test('resolveCorsOrigin: empty/whitespace → [] (deny all cross-origin)', () => {
+  assert.deepEqual(resolveCorsOrigin(['']), []);
+  assert.deepEqual(resolveCorsOrigin([' ', '']), []);
+});
+
+test('corsIsWideOpenOrEmpty', () => {
+  assert.equal(corsIsWideOpenOrEmpty(['*']), true);
+  assert.equal(corsIsWideOpenOrEmpty(['']), true);
+  assert.equal(corsIsWideOpenOrEmpty(['https://a.com']), false);
+  assert.equal(corsIsWideOpenOrEmpty(['https://a.com', '*']), true);
+});
+
+test('assertProductionCorsSafe: throws in production on wide-open or empty', () => {
+  assert.throws(() => assertProductionCorsSafe(['*'], 'production'), /wide-open/);
+  assert.throws(() => assertProductionCorsSafe([''], 'production'), /empty/);
+});
+
+test('assertProductionCorsSafe: passes in production with explicit origins', () => {
+  assert.doesNotThrow(() => assertProductionCorsSafe(['https://reef.example.com'], 'production'));
+});
+
+test('assertProductionCorsSafe: never throws outside production', () => {
+  assert.doesNotThrow(() => assertProductionCorsSafe(['*'], undefined));
+  assert.doesNotThrow(() => assertProductionCorsSafe(['*'], 'development'));
+  assert.doesNotThrow(() => assertProductionCorsSafe([''], 'test'));
+});

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -1,0 +1,37 @@
+function cleanOrigins(origins: string[]): string[] {
+  return origins.map((o) => o.trim()).filter(Boolean);
+}
+
+/**
+ * Resolve configured CORS origins into a @fastify/cors `origin` value.
+ * `*` (wide open) → `true`; otherwise the cleaned allowlist. Empty/whitespace
+ * entries are dropped, so an empty result denies all cross-origin requests
+ * (fail-closed).
+ */
+export function resolveCorsOrigin(origins: string[]): boolean | string[] {
+  const cleaned = cleanOrigins(origins);
+  if (cleaned.includes('*')) return true;
+  return cleaned;
+}
+
+/** True when the configured origins are wide-open (`*`) or effectively empty. */
+export function corsIsWideOpenOrEmpty(origins: string[]): boolean {
+  const cleaned = cleanOrigins(origins);
+  return cleaned.length === 0 || cleaned.includes('*');
+}
+
+/**
+ * Fail closed in production: a real-visitor deploy must pin explicit origins so
+ * arbitrary sites can't drive writes from a visitor's browser. Wide-open (`*`)
+ * or empty `CORS_ORIGINS` under `NODE_ENV=production` is a fatal misconfig and
+ * refuses to start. Non-production keeps `*` for testing convenience.
+ */
+export function assertProductionCorsSafe(origins: string[], nodeEnv: string | undefined): void {
+  if (nodeEnv === 'production' && corsIsWideOpenOrEmpty(origins)) {
+    const reason = cleanOrigins(origins).includes('*') ? 'wide-open "*"' : 'empty';
+    throw new Error(
+      `CORS_ORIGINS must be explicit origin(s) in production (got ${reason}). ` +
+        `Set e.g. CORS_ORIGINS=https://reef.example.com.`,
+    );
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ import { registerStatsRoutes } from './routes/stats.js';
 import { registerMetricsRoutes } from './routes/metrics.js';
 import { SimWorker, SnapshotWorker } from './sim.js';
 import { installSecurityHeaders } from './security.js';
+import { resolveCorsOrigin } from './cors.js';
 import { TreeDb } from './tree/db.js';
 import { registerTreeRoutes } from './tree/routes.js';
 import { seedRootIfEmpty } from './tree/seed.js';
@@ -59,9 +60,13 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
   // default lets unauthenticated callers make Zod walk a megabyte before
   // rejecting.
   const app = Fastify({ logger: useLogger, trustProxy: true, bodyLimit: 8192 });
-  const corsOrigin: boolean | string[] =
-    corsOriginsList.length === 1 && corsOriginsList[0] === '*' ? true : corsOriginsList;
+  const corsOrigin = resolveCorsOrigin(corsOriginsList);
   await app.register(cors, { origin: corsOrigin });
+  if (corsOrigin === true) {
+    app.log.warn(
+      'CORS is wide open (CORS_ORIGINS=*). Set explicit origins before exposing the server publicly.',
+    );
+  }
   await app.register(websocket, { options: { maxPayload: 64 * 1024 } });
   installSecurityHeaders(app);
 


### PR DESCRIPTION
## Summary
Closes #42. `CORS_ORIGINS` defaulted to `*` (→ `origin: true`), so once the site is public any website could drive writes to the reef from a visitor's browser.

## What changed
Keep `*` as the convenient dev/test default, but **fail closed in production**: with `NODE_ENV=production`, a wide-open (`*`) or empty `CORS_ORIGINS` is a fatal misconfig and the server refuses to start, forcing the operator to pin explicit origins (which `fly.toml` already documents via `fly secrets set CORS_ORIGINS=...`).

- New `cors.ts`: `resolveCorsOrigin` (`*` → `true`, else the cleaned allowlist, empty → `[]` = deny all cross-origin) and `assertProductionCorsSafe` (throws in production on wide-open/empty).
- `config.ts` asserts at boot; `index.ts` uses the resolver and logs a warn when CORS is wide open.
- `docs/runbook.md` documents the production requirement.

## Test plan
- [x] `resolveCorsOrigin`: `*` → true, explicit list preserved (trimmed), empty/whitespace → `[]` (deny-all, verified fail-closed at the @fastify/cors level)
- [x] `assertProductionCorsSafe`: throws in production on `*`/empty, passes with explicit origins, never throws outside production
- [x] Manual: `NODE_ENV=production` with default CORS refuses to boot; with `CORS_ORIGINS=https://x.com` boots
- [x] No test runs under `NODE_ENV=production`, so the boot assertion doesn't break the suite (136 green); lint + typecheck clean

Closes #42