### PR TITLE
fix(server): drop unsafe-inline from CSP script-src; nonce the admin script

### DIFF
--- a/packages/server/src/boot.smoke.test.ts
+++ b/packages/server/src/boot.smoke.test.ts
@@ -23,6 +23,15 @@ test('smoke: full app boots with the real plugin load order', async () => {
   const body = JSON.parse(healthz.body) as { ok: boolean; time: number };
   assert.equal(body.ok, true);
   assert.equal(typeof body.time, 'number');
+
+  // Global CSP blocks inline scripts (no 'unsafe-inline' on script-src). The
+  // directive-bounded check ([^;]* stops at the next directive) is order-
+  // independent — it won't false-pass on style-src's unsafe-inline.
+  const csp = healthz.headers['content-security-policy'] as string;
+  assert.match(csp, /script-src 'self'/);
+  assert.ok(!/script-src[^;]*'unsafe-inline'/.test(csp), 'script-src must not allow unsafe-inline');
+  // style-src intentionally keeps 'unsafe-inline' for now.
+  assert.match(csp, /style-src 'self' 'unsafe-inline'/);
 });
 
 test('smoke: DB migrations ran (API/reef serves an empty-state payload)', async () => {

--- a/packages/server/src/routes/admin.test.ts
+++ b/packages/server/src/routes/admin.test.ts
@@ -225,3 +225,19 @@ test('admin: GET /admin returns HTML without auth', async () => {
   assert.match(r.payload, /<title>Reef Admin<\/title>/);
   await app.close();
 });
+
+test('admin: GET /admin sets a nonce CSP and tags its inline script with it', async () => {
+  const { app } = buildApp();
+  const r = await app.inject({ method: 'GET', url: '/admin' });
+  const csp = r.headers['content-security-policy'] as string;
+  const captured = /script-src 'self' 'nonce-([^']+)'/.exec(csp)?.[1];
+  assert.ok(captured, `CSP should carry a script nonce, got: ${csp}`);
+  assert.ok(
+    !/script-src[^;]*'unsafe-inline'/.test(csp),
+    'admin CSP must not allow unsafe-inline scripts',
+  );
+  // The inline <script> carries the same nonce so it runs under the CSP.
+  const nonce = captured.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  assert.match(r.payload, new RegExp(`<script nonce="${nonce}">`));
+  await app.close();
+});

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,7 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { randomBytes } from 'node:crypto';
 import type { ReefDb } from '../db.js';
 import type { Hub } from '../hub.js';
 import { checkAdminAuth } from '../auth.js';
+import { cspWithScriptNonce } from '../security.js';
 
 // Parse admin auth + :id path param. Returns the id on success, or null after
 // writing a 401/400 response — callers should return immediately when null.
@@ -59,12 +61,18 @@ export function registerAdminRoutes(app: FastifyInstance, db: ReefDb, hub: Hub):
   // for a token in memory and uses it only as a Bearer header on API calls.
   // No gating on GET /admin — the delete endpoint is the actual auth boundary.
   app.get('/admin', async (_req, reply) => {
+    // The global CSP blocks inline scripts (no 'unsafe-inline'); this page's
+    // one inline script is allowed via a per-response nonce instead. Setting
+    // the CSP header here pre-empts the global security-headers hook, which
+    // only fills headers that aren't already set.
+    const nonce = randomBytes(16).toString('base64');
+    reply.header('Content-Security-Policy', cspWithScriptNonce(nonce));
     reply.type('text/html');
-    return adminHtml();
+    return adminHtml(nonce);
   });
 }
 
-function adminHtml(): string {
+function adminHtml(nonce: string): string {
   return `<!doctype html><html><head><meta charset="utf-8"/><title>Reef Admin</title>
 <style>
 body{font:14px system-ui;padding:1.5rem;background:#111;color:#eee}
@@ -84,7 +92,7 @@ h2{font-size:1rem;margin:1.5rem 0 0.5rem;color:#bcd}
 <table id=liveTable></table>
 <h2>Deleted <span class=count id=delCount></span></h2>
 <table id=delTable></table>
-<script>
+<script nonce="${nonce}">
 const $ = (id) => document.getElementById(id);
 function rowOf(p, actionText, actionClass, onAction) {
   const tr = document.createElement('tr');

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -1,6 +1,14 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { perIpRateLimit, ttlCache } from './security.js';
+import { perIpRateLimit, ttlCache, cspWithScriptNonce } from './security.js';
+
+test('cspWithScriptNonce: script-src allows the nonce, not unsafe-inline', () => {
+  const csp = cspWithScriptNonce('abc123');
+  assert.match(csp, /script-src 'self' 'nonce-abc123'/);
+  assert.ok(!/script-src[^;]*'unsafe-inline'/.test(csp), 'no unsafe-inline on script-src');
+  // style-src still permits inline for now.
+  assert.match(csp, /style-src 'self' 'unsafe-inline'/);
+});
 
 test('ttlCache: reuses the cached value within the TTL (one production)', () => {
   let calls = 0;

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -1,12 +1,34 @@
 import type { FastifyInstance } from 'fastify';
 
+// script-src is 'self' with NO 'unsafe-inline' — inline scripts are blocked
+// globally. The only server-rendered page with an inline script (the admin
+// panel) sets its own per-response CSP with a nonce. style-src keeps
+// 'unsafe-inline' for now (runtime-set styles); tightening it is a follow-up.
+function buildCsp(scriptNonce?: string): string {
+  const scriptSrc = scriptNonce ? `script-src 'self' 'nonce-${scriptNonce}'` : "script-src 'self'";
+  return [
+    "default-src 'self'",
+    "img-src 'self' blob: data:",
+    "connect-src 'self' ws: wss:",
+    "media-src 'self' blob:",
+    "style-src 'self' 'unsafe-inline'",
+    scriptSrc,
+    "frame-ancestors 'none'",
+    "base-uri 'none'",
+  ].join('; ');
+}
+
+/** CSP that allows one inline script tagged with `nonce`. Used by /admin. */
+export function cspWithScriptNonce(nonce: string): string {
+  return buildCsp(nonce);
+}
+
 const HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'no-referrer',
   'Cross-Origin-Opener-Policy': 'same-origin',
-  'Content-Security-Policy':
-    "default-src 'self'; img-src 'self' blob: data:; connect-src 'self' ws: wss:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'",
+  'Content-Security-Policy': buildCsp(),
 };
 
 export function installSecurityHeaders(app: FastifyInstance): void {


### PR DESCRIPTION
## Summary
Closes #105. The global CSP carried `script-src 'self' 'unsafe-inline'` only to accommodate the admin page's one inline script, which defeats the XSS protection CSP gives on every server-rendered response.

## What changed
- Drop `'unsafe-inline'` from the global `script-src` (now `script-src 'self'`).
- The admin page (`GET /admin`) sets its own per-response CSP with a fresh `randomBytes(16)` nonce (`script-src 'self' 'nonce-X'`) and tags its inline `<script nonce="X">`. The global security-headers hook only fills headers that aren't already set, so the admin CSP wins and exactly one CSP header is emitted (verified header precedence in review).
- The built client HTML (`packages/client/dist/*.html`) is external-script-only, so the global drop doesn't affect it.

## ⚠️ Deferred (deliberate half-fix)
`style-src` **keeps `'unsafe-inline'`**. Runtime-set/injected styles are hard to verify safe without a browser, and the issue lists style-src as secondary ("can follow if cheap"). Tightening style-src is a follow-up; this PR closes the script-src XSS hole, which is the meaningful one.

## Test plan
- [x] Global CSP (via boot smoke `/healthz`): `script-src 'self'` with no `'unsafe-inline'`; `style-src 'self' 'unsafe-inline'` retained
- [x] `GET /admin`: CSP carries `script-src 'self' 'nonce-X'`, no unsafe-inline, and the inline `<script>` carries the matching nonce
- [x] `cspWithScriptNonce` unit test
- [x] Server suite green (138), lint + typecheck clean

Closes #105