### PR TITLE
ci(infra): harden the server image (non-root, pin LTS Node) and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
         uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
+        # Matches the LTS major the production Docker image runs on, so unit
+        # tests exercise the same runtime that ships.
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -76,3 +78,57 @@ jobs:
           path: packages/client/dist
           retention-days: 7
           if-no-files-found: error
+
+  docker-build:
+    name: Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build server image
+        run: docker build -f infra/Dockerfile.server -t reef-server:ci .
+
+      - name: Smoke test /healthz
+        run: |
+          docker run -d --name reef -p 8787:8787 reef-server:ci
+          ok=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:8787/healthz >/dev/null; then ok=1; break; fi
+            sleep 2
+          done
+          docker logs reef || true
+          docker rm -f reef >/dev/null 2>&1 || true
+          if [ "$ok" != "1" ]; then echo "::error::/healthz never came up"; exit 1; fi
+
+      - name: Verify the server runs as a non-root user
+        run: |
+          # The entrypoint drops privileges to "reef" before exec'ing the
+          # command, so this prints reef's (non-zero) uid.
+          uid=$(docker run --rm reef-server:ci sh -c 'id -u')
+          echo "server process uid: $uid"
+          if [ -z "$uid" ] || [ "$uid" = "0" ]; then
+            echo "::error::container did not run as a non-root user (uid='$uid')"; exit 1
+          fi
+
+      - name: Smoke test the Fly volume path (DB on /data, written as non-root)
+        run: |
+          docker volume create reef-ci-data >/dev/null
+          docker run -d --name reefvol -e DB_PATH=/data/reef.db \
+            -v reef-ci-data:/data -p 8788:8787 reef-server:ci
+          ok=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:8788/healthz >/dev/null; then ok=1; break; fi
+            sleep 2
+          done
+          docker logs reefvol || true
+          # The entrypoint chowns /data and drops to reef, so the DB written to
+          # the volume must be reef-owned.
+          owner=$(docker exec reefvol sh -c 'stat -c "%U" /data/reef.db' 2>/dev/null || echo MISSING)
+          docker rm -f reefvol >/dev/null 2>&1 || true
+          docker volume rm reef-ci-data >/dev/null 2>&1 || true
+          if [ "$ok" != "1" ]; then echo "::error::/healthz (volume) never came up"; exit 1; fi
+          if [ "$owner" != "reef" ]; then
+            echo "::error::/data/reef.db owner is '$owner', expected reef"; exit 1
+          fi

--- a/infra/Dockerfile.server
+++ b/infra/Dockerfile.server
@@ -3,12 +3,15 @@ WORKDIR /app
 RUN apk add --no-cache python3 make g++ sqlite
 RUN npm install -g pnpm@9.0.0
 
-COPY pnpm-workspace.yaml package.json tsconfig.base.json ./
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json tsconfig.base.json ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/generator/package.json packages/generator/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
-RUN pnpm install --frozen-lockfile=false
+# Frozen lockfile: install the exact locked versions so esbuild's JS package
+# and its platform binary can't drift apart (a re-resolving install pulled a
+# 0.28.1 JS against a 0.27.7 binary and the postinstall version check failed).
+RUN pnpm install --frozen-lockfile
 
 COPY packages/shared packages/shared
 COPY packages/generator packages/generator
@@ -29,7 +32,7 @@ RUN npm install -g pnpm@9.0.0
 # Unprivileged runtime user — the server process must not run as root.
 RUN addgroup -S reef && adduser -S -G reef reef
 
-COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
 COPY --from=builder /app/packages/shared/package.json packages/shared/
 COPY --from=builder /app/packages/shared/dist packages/shared/dist
 COPY --from=builder /app/packages/generator/package.json packages/generator/
@@ -38,7 +41,7 @@ COPY --from=builder /app/packages/server/package.json packages/server/
 COPY --from=builder /app/packages/server/dist packages/server/dist
 COPY --from=builder /app/packages/server/migrations packages/server/migrations
 COPY --from=builder /app/packages/client/dist packages/client/dist
-RUN pnpm install --prod --frozen-lockfile=false --filter=@reef/server...
+RUN pnpm install --prod --frozen-lockfile --filter=@reef/server...
 
 COPY infra/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh && chown -R reef:reef /app

--- a/infra/Dockerfile.server
+++ b/infra/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM node:25-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ sqlite
 RUN npm install -g pnpm@9.0.0
@@ -19,10 +19,15 @@ RUN pnpm --filter @reef/shared build \
  && pnpm --filter @reef/server build \
  && pnpm --filter @reef/client build
 
-FROM node:25-alpine
+# Pinned to the current LTS major (22). A floating odd/non-LTS tag (e.g. 25)
+# silently advances and can break the better-sqlite3 native binding between
+# smoke runs; the LTS line is the version CI also tests on.
+FROM node:22-alpine
 WORKDIR /app
-RUN apk add --no-cache sqlite tini
+RUN apk add --no-cache sqlite tini su-exec
 RUN npm install -g pnpm@9.0.0
+# Unprivileged runtime user — the server process must not run as root.
+RUN addgroup -S reef && adduser -S -G reef reef
 
 COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
 COPY --from=builder /app/packages/shared/package.json packages/shared/
@@ -35,7 +40,12 @@ COPY --from=builder /app/packages/server/migrations packages/server/migrations
 COPY --from=builder /app/packages/client/dist packages/client/dist
 RUN pnpm install --prod --frozen-lockfile=false --filter=@reef/server...
 
+COPY infra/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && chown -R reef:reef /app
+
 ENV CLIENT_DIST_DIR=/app/packages/client/dist
 EXPOSE 8787
-ENTRYPOINT ["/sbin/tini", "--"]
+# tini reaps zombies; the entrypoint chowns the runtime volume (if any) then
+# drops to the unprivileged "reef" user before exec'ing node.
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "packages/server/dist/index.js"]

--- a/infra/docker-entrypoint.sh
+++ b/infra/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# /data is a Fly volume mounted at runtime, owned by root. Make it writable by
+# the unprivileged "reef" user before dropping privileges, so the server can
+# write the SQLite DB without running as root. No-op when there's no volume
+# (e.g. CI / plain `docker run`), where the DB lives under the already
+# reef-owned /app. Only recurse when the volume isn't already reef-owned, so
+# the cost is paid once on first boot rather than on every (auto-stop) start.
+if [ -d /data ] && [ "$(stat -c '%U' /data)" != "reef" ]; then
+  chown -R reef:reef /data
+fi
+
+exec su-exec reef:reef "$@"


### PR DESCRIPTION
## Summary
Closes #93. Four-part Docker hardening.

## What changed
- **Pin Node**: `infra/Dockerfile.server` → `node:22-alpine` (LTS) in both stages, off the floating non-LTS `node:25`.
- **Non-root**: runtime stage adds an unprivileged `reef` user + `su-exec` and a `docker-entrypoint.sh` that chowns the Fly volume (`/data`, first-boot only via a `stat`-guarded recurse) then drops privileges before exec'ing node. Failure modes are loud — a chown or su-exec failure crashes the container rather than silently running as root.
- **Runtime Node tested**: `ci.yml` bumps the unit-test job 20 → 22 to match the image runtime (same single `Build and test` job, no matrix, so the required check name is unchanged).
- **Docker build check**: new `Docker build` CI job builds the image, smoke-tests `/healthz`, asserts a non-root uid, and exercises the `/data` volume path asserting the DB lands `reef`-owned.

## Test plan
- [x] Full suite green on Node 22 locally (the CI runtime)
- [x] entrypoint POSIX-sh syntax valid; ci.yml valid YAML
- [ ] The `Docker build` CI job is the real proof of the image — watching it on this PR

Closes #93