### PR TITLE
refactor(ws): type-safe broadcast + zod-validated frame dispatch

### DIFF
--- a/packages/client/src/net/ws.test.ts
+++ b/packages/client/src/net/ws.test.ts
@@ -67,10 +67,11 @@ describe('ReefSocket', () => {
     s.on(h2);
     s.connect();
 
-    FakeWs.created[0]!.fire('message', { data: JSON.stringify({ type: 'hello', polypCount: 3 }) });
+    const hello = { type: 'hello', polypCount: 3, serverTime: 1 };
+    FakeWs.created[0]!.fire('message', { data: JSON.stringify(hello) });
 
-    expect(h1).toHaveBeenCalledWith({ type: 'hello', polypCount: 3 });
-    expect(h2).toHaveBeenCalledWith({ type: 'hello', polypCount: 3 });
+    expect(h1).toHaveBeenCalledWith(hello);
+    expect(h2).toHaveBeenCalledWith(hello);
   });
 
   test('close event schedules a reconnect with exponential backoff', () => {

--- a/packages/client/src/net/ws.ts
+++ b/packages/client/src/net/ws.ts
@@ -23,6 +23,8 @@ export class ReefSocket {
       // parse vs. handler catches) are unit-tested without jsdom.
       dispatchMessage(ev.data as string, this.handlers, {
         onParseError: (err) => console.warn('ws: malformed frame', err),
+        onInvalidMessage: (err, raw) =>
+          console.error('ws: rejected frame (protocol skew?)', raw, err),
         onHandlerError: (err, msg: ServerMessage) => {
           console.error('ws: handler threw on', (msg as { type?: string }).type, err);
         },

--- a/packages/client/src/tree/api.test.ts
+++ b/packages/client/src/tree/api.test.ts
@@ -174,7 +174,7 @@ describe('TreeSocket', () => {
     s.on(cb2);
     s.connect();
 
-    const msg = { type: 'tree_polyp_added', polyp: { id: 1, variant: 'forked', seed: 0, colorKey: 'x', parentId: null, attachIndex: 0, createdAt: 0 } };
+    const msg = { type: 'tree_polyp_added', polyp: { id: 1, variant: 'forked', seed: 0, colorKey: 'x', parentId: null, attachIndex: 0, attachYaw: 0, createdAt: 0 } };
     FakeWs.created[0]!.fire('message', { data: JSON.stringify(msg) });
 
     expect(cb1).toHaveBeenCalledWith(msg);

--- a/packages/client/src/tree/api.ts
+++ b/packages/client/src/tree/api.ts
@@ -1,4 +1,9 @@
-import type { PublicTreePolyp, TreePolypInput, TreeServerMessage } from '@reef/shared';
+import {
+  dispatchTreeMessage,
+  type PublicTreePolyp,
+  type TreePolypInput,
+  type TreeServerMessage,
+} from '@reef/shared';
 
 export async function fetchTree(apiBase = ''): Promise<{ polyps: PublicTreePolyp[]; serverTime: number }> {
   const r = await fetch(`${apiBase}/api/tree`);
@@ -57,20 +62,13 @@ export class TreeSocket {
     this.ws = new WebSocket(this.url);
     this.ws.addEventListener('open', () => { this.retries = 0; });
     this.ws.addEventListener('message', (ev) => {
-      let msg: TreeServerMessage;
-      try {
-        msg = JSON.parse(ev.data as string) as TreeServerMessage;
-      } catch (err) {
-        console.warn('ws/tree: malformed frame', err);
-        return;
-      }
-      for (const cb of this.listeners) {
-        try {
-          cb(msg);
-        } catch (err) {
-          console.error('ws/tree: handler threw on', (msg as { type?: string }).type, err);
-        }
-      }
+      dispatchTreeMessage(ev.data as string, this.listeners, {
+        onParseError: (err) => console.warn('ws/tree: malformed frame', err),
+        onInvalidMessage: (err, raw) =>
+          console.error('ws/tree: rejected frame (protocol skew?)', raw, err),
+        onHandlerError: (err, msg) =>
+          console.error('ws/tree: handler threw on', msg.type, err),
+      });
     });
     this.ws.addEventListener('close', () => this.scheduleReconnect());
     this.ws.addEventListener('error', () => this.ws?.close());

--- a/packages/server/src/hub.ts
+++ b/packages/server/src/hub.ts
@@ -1,4 +1,4 @@
-import type { ServerMessage } from '@reef/shared';
+import type { ServerMessage, TreeServerMessage } from '@reef/shared';
 
 // ws library readyState values — see https://developer.mozilla.org/docs/Web/API/WebSocket/readyState
 const WS_OPEN = 1;
@@ -60,7 +60,7 @@ export class Hub {
     return true;
   }
 
-  broadcast(msg: ServerMessage): void {
+  broadcast(msg: ServerMessage | TreeServerMessage): void {
     const data = JSON.stringify(msg);
     for (const ws of this.clients.keys()) {
       if (ws.readyState !== WS_OPEN) continue;

--- a/packages/server/src/tree/routes.ts
+++ b/packages/server/src/tree/routes.ts
@@ -26,9 +26,9 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
     tree.deleteAll();
     seedRootIfEmpty(tree);
     const polyps = tree.listLive();
-    hub.broadcast({ type: 'tree_reset' } as never);
+    hub.broadcast({ type: 'tree_reset' });
     if (polyps[0]) {
-      hub.broadcast({ type: 'tree_polyp_added', polyp: polyps[0] } as never);
+      hub.broadcast({ type: 'tree_polyp_added', polyp: polyps[0] });
     }
     return { polyps };
   });
@@ -89,7 +89,7 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
     // successfully persisted polyp into a 500 the client would retry — a retry
     // would re-insert and inflate the device's rate-limit count. Mirrors reef.
     try {
-      hub.broadcast({ type: 'tree_polyp_added', polyp } as never);
+      hub.broadcast({ type: 'tree_polyp_added', polyp });
     } catch (err) {
       req.log.warn({ err, polypId: polyp.id }, 'tree hub broadcast failed after insert');
     }
@@ -116,7 +116,7 @@ export function registerTreeRoutes(app: FastifyInstance, tree: TreeDb, hub: Hub)
       reply.code(409);
       return { error: result.reason ?? 'cannot delete' };
     }
-    hub.broadcast({ type: 'tree_polyp_removed', id } as never);
+    hub.broadcast({ type: 'tree_polyp_removed', id });
     return { ok: true };
   });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './tracking.js';
 export * from './palette.js';
 export * from './ws.js';
 export * from './ws-dispatch.js';
+export * from './ws-schema.js';
 export * from './gestures.js';
 export * from './tree/types.js';
 export * from './tree/schema.js';

--- a/packages/shared/src/ws-dispatch.test.ts
+++ b/packages/shared/src/ws-dispatch.test.ts
@@ -1,7 +1,8 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { dispatchMessage } from './ws-dispatch.js';
+import { dispatchMessage, dispatchTreeMessage } from './ws-dispatch.js';
 import type { ServerMessage } from './ws.js';
+import type { TreeServerMessage } from './tree/ws.js';
 
 // Collect calls; optionally throw on a particular message type.
 function recordingHandler(shouldThrow?: (m: ServerMessage) => boolean) {
@@ -45,4 +46,40 @@ test('dispatchMessage: valid JSON with well-formed type passes through to every 
   assert.equal(a.calls.length, 1);
   assert.equal(b.calls.length, 1);
   assert.equal((a.calls[0] as { type: string }).type, 'hello');
+});
+
+test('dispatchMessage: valid JSON with a bad shape goes to onInvalidMessage, not handlers', () => {
+  const h = recordingHandler();
+  const invalid: string[] = [];
+  const parseErrors: unknown[] = [];
+  const cb = {
+    onParseError: (e: unknown) => parseErrors.push(e),
+    onInvalidMessage: (_e: unknown, raw: string) => invalid.push(raw),
+  };
+  // Unknown type, and a known type missing a required field — both rejected.
+  dispatchMessage('{"type":"not_a_real_type"}', [h.fn], cb);
+  dispatchMessage('{"type":"polyp_removed"}', [h.fn], cb);
+  assert.equal(h.calls.length, 0);
+  assert.equal(invalid.length, 2, 'schema mismatches route to onInvalidMessage with the raw frame');
+  assert.equal(parseErrors.length, 0, 'a schema mismatch is not a JSON parse error');
+});
+
+test('dispatchMessage: schema mismatch falls back to onParseError when onInvalidMessage is absent', () => {
+  const h = recordingHandler();
+  const parseErrors: unknown[] = [];
+  dispatchMessage('{"type":"polyp_removed"}', [h.fn], { onParseError: (e) => parseErrors.push(e) });
+  assert.equal(h.calls.length, 0);
+  assert.equal(parseErrors.length, 1);
+});
+
+test('dispatchTreeMessage: valid tree frame reaches handlers; garbage is rejected', () => {
+  const calls: TreeServerMessage[] = [];
+  const fn = (m: TreeServerMessage): void => { calls.push(m); };
+  const invalid: unknown[] = [];
+  const cb = { onInvalidMessage: (e: unknown) => invalid.push(e) };
+  dispatchTreeMessage(JSON.stringify({ type: 'tree_reset' }), [fn], cb);
+  dispatchTreeMessage('{"type":"tree_polyp_removed"}', [fn], cb);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.type, 'tree_reset');
+  assert.equal(invalid.length, 1);
 });

--- a/packages/shared/src/ws-dispatch.ts
+++ b/packages/shared/src/ws-dispatch.ts
@@ -1,32 +1,55 @@
+import type { ZodType } from 'zod';
 import type { ServerMessage } from './ws.js';
+import type { TreeServerMessage } from './tree/ws.js';
+import { ServerMessageSchema, TreeServerMessageSchema } from './ws-schema.js';
 
 export type MessageHandler = (msg: ServerMessage) => void;
+export type TreeMessageHandler = (msg: TreeServerMessage) => void;
 
-export interface DispatchCallbacks {
+export interface DispatchCallbacks<M = ServerMessage> {
+  /** Frame wasn't valid JSON (transport noise). */
   onParseError?: (err: unknown, raw: string) => void;
-  onHandlerError?: (err: unknown, msg: ServerMessage) => void;
+  /**
+   * Frame was valid JSON but didn't match the schema — a structurally invalid
+   * or version-skewed frame (the server sent a shape this client doesn't
+   * recognize). Distinct from onParseError because a skew is a real protocol
+   * problem worth surfacing loudly with the raw frame; falls back to
+   * onParseError when not provided.
+   */
+  onInvalidMessage?: (err: unknown, raw: string) => void;
+  onHandlerError?: (err: unknown, msg: M) => void;
 }
 
 /**
- * Parse a raw WebSocket frame and dispatch to every handler.
+ * Parse + validate a raw WebSocket frame, then dispatch to every handler.
  *
- * The split catch is deliberate: a malformed JSON frame is a framing problem
- * (log once, skip), while a handler throwing is an app bug that must not
- * prevent sibling handlers from running. Lumping both into one catch loses
- * that distinction and turns handler regressions into invisible "junk frames."
+ * Three distinct failure modes, kept separate on purpose:
+ * - Not valid JSON → onParseError (transport noise).
+ * - Valid JSON, fails the schema → onInvalidMessage (protocol skew). Either way
+ *   the frame is dropped — handlers never see a half-formed message with
+ *   `undefined` fields.
+ * - A handler throwing is an app bug routed to onHandlerError; it must not
+ *   prevent sibling handlers from running.
  */
-export function dispatchMessage(
+function dispatch<M>(
   raw: string,
-  handlers: readonly MessageHandler[],
-  cb?: DispatchCallbacks,
+  schema: ZodType<M>,
+  handlers: readonly ((msg: M) => void)[],
+  cb?: DispatchCallbacks<M>,
 ): void {
-  let msg: ServerMessage;
+  let parsed: unknown;
   try {
-    msg = JSON.parse(raw) as ServerMessage;
+    parsed = JSON.parse(raw);
   } catch (err) {
     cb?.onParseError?.(err, raw);
     return;
   }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    (cb?.onInvalidMessage ?? cb?.onParseError)?.(result.error, raw);
+    return;
+  }
+  const msg = result.data;
   for (const h of handlers) {
     try {
       h(msg);
@@ -34,4 +57,22 @@ export function dispatchMessage(
       cb?.onHandlerError?.(err, msg);
     }
   }
+}
+
+/** Dispatch a reef (`/ws`) frame, validated against ServerMessageSchema. */
+export function dispatchMessage(
+  raw: string,
+  handlers: readonly MessageHandler[],
+  cb?: DispatchCallbacks<ServerMessage>,
+): void {
+  dispatch(raw, ServerMessageSchema as ZodType<ServerMessage>, handlers, cb);
+}
+
+/** Dispatch a tree (`/ws/tree`) frame, validated against TreeServerMessageSchema. */
+export function dispatchTreeMessage(
+  raw: string,
+  handlers: readonly TreeMessageHandler[],
+  cb?: DispatchCallbacks<TreeServerMessage>,
+): void {
+  dispatch(raw, TreeServerMessageSchema as ZodType<TreeServerMessage>, handlers, cb);
 }

--- a/packages/shared/src/ws-schema.ts
+++ b/packages/shared/src/ws-schema.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+// Runtime validation for inbound WebSocket frames. Deliberately structural and
+// version-skew tolerant: species / variant / colorKey are validated as strings
+// (not enums) so a newer server adding a value doesn't fail an older client's
+// envelope check. The goal is to reject malformed / missing-field frames, not
+// well-formed frames carrying an unknown-but-valid value.
+
+const vec3 = z.tuple([z.number(), z.number(), z.number()]);
+const quat = z.tuple([z.number(), z.number(), z.number(), z.number()]);
+
+const publicPolyp = z.object({
+  id: z.number(),
+  species: z.string(),
+  seed: z.number(),
+  colorKey: z.string(),
+  position: vec3,
+  orientation: quat,
+  scale: z.number(),
+  createdAt: z.number(),
+});
+
+const simDelta = z.object({
+  polypId: z.number(),
+  kind: z.string(),
+  params: z.record(z.union([z.number(), z.string()])),
+  createdAt: z.number(),
+});
+
+export const ServerMessageSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('hello'), polypCount: z.number(), serverTime: z.number() }),
+  z.object({ type: z.literal('polyp_added'), polyp: publicPolyp }),
+  z.object({ type: z.literal('polyp_removed'), id: z.number() }),
+  z.object({ type: z.literal('sim_update'), updates: z.array(simDelta) }),
+]);
+
+const publicTreePolyp = z.object({
+  id: z.number(),
+  variant: z.string(),
+  seed: z.number(),
+  colorKey: z.string(),
+  parentId: z.number().nullable(),
+  attachIndex: z.number(),
+  attachYaw: z.number(),
+  createdAt: z.number(),
+});
+
+export const TreeServerMessageSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('tree_hello'), polypCount: z.number(), serverTime: z.number() }),
+  z.object({ type: z.literal('tree_polyp_added'), polyp: publicTreePolyp }),
+  z.object({ type: z.literal('tree_polyp_removed'), id: z.number() }),
+  z.object({ type: z.literal('tree_reset') }),
+]);


### PR DESCRIPTION
## Summary
Closes #102. Three WS protocol type-safety fixes.

## What changed
- **Hub type**: `broadcast` widened to `ServerMessage | TreeServerMessage`; the three `as never` casts in `tree/routes.ts` are gone (they type-check honestly now).
- **Validated dispatch**: new `ws-schema.ts` with zod discriminated unions. `dispatchMessage` validates inbound frames; a structurally invalid / version-skewed frame is dropped to a callback instead of flowing into handlers as a half-formed object with `undefined` fields. Schemas validate `species`/`variant`/`colorKey` as strings (not enums) for version-skew tolerance.
- **Tree dispatcher**: new `dispatchTreeMessage`; the client `TreeSocket` uses it instead of its hand-rolled parse/dispatch.
- **Review-driven**: a schema mismatch (`onInvalidMessage`, logged loudly with the raw frame as a likely protocol skew) is now distinguished from malformed JSON (`onParseError`) — so the next server-side shape change surfaces instead of hiding in a quiet warn. Falls back to `onParseError` when no `onInvalidMessage` handler is set.

## Verification
Both review agents confirmed all 8 frames the server actually broadcasts (hello, polyp_added, polyp_removed, sim_update, tree_hello, tree_polyp_added, tree_polyp_removed, tree_reset) validate against the schemas, so no legitimate frame is silently dropped.

## Test plan
- [x] Zero `as never` in tree routes
- [x] Schema mismatch → `onInvalidMessage` (with raw frame), not handlers; malformed JSON → `onParseError`; mismatch falls back to `onParseError`
- [x] `dispatchTreeMessage` validates + dispatches
- [x] Two client fixtures corrected (under-specified frames the server never emits)
- [x] All suites green (shared 31, server 138, client 360); lint + typecheck clean

Closes #102