### PR TITLE
refactor(tree): extract shared sea-life subsystem into installSeaLife

### DIFF
--- a/packages/client/src/tree.ts
+++ b/packages/client/src/tree.ts
@@ -24,10 +24,7 @@ import { TreePlacement } from './tree/placement.js';
 import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
 import { TREE_VARIANTS, TreePicker } from './ui/treePicker.js';
 import { computeOrbitPose } from './playground/autoOrbit.js';
-import { Shark } from './tree/shark.js';
-import { Clownfish } from './tree/clownfish.js';
-import { Jellyfish } from './tree/jellyfish.js';
-import { SeaTurtle } from './tree/seaTurtle.js';
+import { installSeaLife } from './tree/seaLife.js';
 import {
   addedPolypsInvalidateUndo,
   initialState,
@@ -123,84 +120,8 @@ function addPiecesAndRefresh(polyps: PublicTreePolyp[]): void {
 // ------------------------------------------------------------------
 // Spawnable sea life — empty by default.
 // ------------------------------------------------------------------
-type CreatureType = 'shark' | 'clownfish' | 'jellyfish' | 'seaTurtle';
-interface SwimmingCreature { update: (clockSec: number) => void; }
-interface TrackedCreature {
-  type: CreatureType;
-  instance: SwimmingCreature;
-  group: import('three').Group;
-}
-const creatures: TrackedCreature[] = [];
-
-function removeCreature(type: CreatureType): boolean {
-  const idx = [...creatures].map((c, i) => ({ c, i })).reverse()
-    .find(({ c }) => c.type === type)?.i ?? -1;
-  if (idx === -1) return false;
-  const [removed] = creatures.splice(idx, 1);
-  if (!removed) return false;
-  treeReef.anchor.remove(removed.group);
-  removed.group.traverse((obj) => {
-    const mesh = obj as import('three').Mesh;
-    if (mesh.isMesh) {
-      mesh.geometry?.dispose();
-      if (Array.isArray(mesh.material)) {
-        for (const m of mesh.material) (m as import('three').Material).dispose();
-      } else {
-        (mesh.material as import('three').Material | undefined)?.dispose();
-      }
-    }
-  });
-  return true;
-}
-
-function countCreatures(type: CreatureType): number {
-  return creatures.filter((c) => c.type === type).length;
-}
-
-function spawnShark(): void {
-  const s = new Shark({
-    orbitRadius: 0.25 + Math.random() * 0.15,
-    orbitHeight: 0.05 + Math.random() * 0.2,
-    orbitPeriodSec: 14 + Math.random() * 10,
-    phaseRad: Math.random() * Math.PI * 2,
-    direction: Math.random() < 0.5 ? 1 : -1,
-  });
-  treeReef.anchor.add(s.group);
-  creatures.push({ type: 'shark', instance: s, group: s.group });
-}
-function spawnClownfish(): void {
-  const c = new Clownfish({
-    orbitRadius: 0.15 + Math.random() * 0.15,
-    orbitHeight: 0.04 + Math.random() * 0.2,
-    orbitPeriodSec: 5 + Math.random() * 6,
-    phaseRad: Math.random() * Math.PI * 2,
-    direction: Math.random() < 0.5 ? 1 : -1,
-  });
-  treeReef.anchor.add(c.group);
-  creatures.push({ type: 'clownfish', instance: c, group: c.group });
-}
-function spawnJellyfish(): void {
-  const j = new Jellyfish({
-    orbitRadius: 0.18 + Math.random() * 0.14,
-    orbitHeight: 0.1 + Math.random() * 0.2,
-    orbitPeriodSec: 20 + Math.random() * 12,
-    phaseRad: Math.random() * Math.PI * 2,
-    direction: Math.random() < 0.5 ? 1 : -1,
-  });
-  treeReef.anchor.add(j.group);
-  creatures.push({ type: 'jellyfish', instance: j, group: j.group });
-}
-function spawnSeaTurtle(): void {
-  const t = new SeaTurtle({
-    orbitRadius: 0.28 + Math.random() * 0.12,
-    orbitHeight: 0.04 + Math.random() * 0.12,
-    orbitPeriodSec: 28 + Math.random() * 12,
-    phaseRad: Math.random() * Math.PI * 2,
-    direction: Math.random() < 0.5 ? 1 : -1,
-  });
-  treeReef.anchor.add(t.group);
-  creatures.push({ type: 'seaTurtle', instance: t, group: t.group });
-}
+// Spawnable sea life + its panel UI (shared with the AR tree entry).
+const seaLife = installSeaLife(treeReef.anchor);
 
 // ------------------------------------------------------------------
 // Picker + state machine
@@ -253,76 +174,10 @@ picker.onCommit(() => dispatch({ type: 'GROW_CLICKED' }));
 // ------------------------------------------------------------------
 const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
 const undoBtn = document.getElementById('undoBtn') as HTMLButtonElement | null;
-const seaLifeBtn = document.getElementById('seaLifeBtn') as HTMLButtonElement | null;
-const seaLifePanel = document.getElementById('sea-life-panel') as HTMLElement | null;
-const seaLifeCloseBtn = document.getElementById('sea-life-close-btn') as HTMLButtonElement | null;
-
-const addSharkBtn = document.getElementById('addSharkBtn') as HTMLButtonElement | null;
-const removeSharkBtn = document.getElementById('removeSharkBtn') as HTMLButtonElement | null;
-const addClownfishBtn = document.getElementById('addClownfishBtn') as HTMLButtonElement | null;
-const removeClownfishBtn = document.getElementById('removeClownfishBtn') as HTMLButtonElement | null;
-const addJellyfishBtn = document.getElementById('addJellyfishBtn') as HTMLButtonElement | null;
-const removeJellyfishBtn = document.getElementById('removeJellyfishBtn') as HTMLButtonElement | null;
-const addSeaTurtleBtn = document.getElementById('addSeaTurtleBtn') as HTMLButtonElement | null;
-const removeSeaTurtleBtn = document.getElementById('removeSeaTurtleBtn') as HTMLButtonElement | null;
 
 if (clearBtn) clearBtn.addEventListener('click', () => dispatch({ type: 'CLEAR_CLICKED' }));
 if (undoBtn) undoBtn.addEventListener('click', () => dispatch({ type: 'UNDO_CLICKED' }));
-
-// Sea life panel toggle
-function setPanelOpen(open: boolean): void {
-  if (!seaLifePanel || !seaLifeBtn) return;
-  if (open) {
-    seaLifePanel.classList.add('open');
-    seaLifeBtn.setAttribute('aria-expanded', 'true');
-    seaLifeBtn.setAttribute('aria-pressed', 'true');
-  } else {
-    seaLifePanel.classList.remove('open');
-    seaLifeBtn.setAttribute('aria-expanded', 'false');
-    seaLifeBtn.removeAttribute('aria-pressed');
-  }
-}
-if (seaLifeBtn) seaLifeBtn.addEventListener('click', () => {
-  const isOpen = seaLifePanel?.classList.contains('open') ?? false;
-  setPanelOpen(!isOpen);
-});
-if (seaLifeCloseBtn) seaLifeCloseBtn.addEventListener('click', () => setPanelOpen(false));
-
-// Close panel on Escape or click-outside
-document.addEventListener('keydown', (ev) => {
-  if (ev.key === 'Escape') setPanelOpen(false);
-});
-document.addEventListener('click', (ev) => {
-  if (!seaLifePanel?.classList.contains('open')) return;
-  const target = ev.target as Node;
-  if (!seaLifePanel.contains(target) && target !== seaLifeBtn && !seaLifeBtn?.contains(target)) {
-    setPanelOpen(false);
-  }
-});
-
-// Panel creature counts — call after every spawn/remove
-function refreshPanel(): void {
-  const types: CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
-  const ids: Record<CreatureType, string> = {
-    shark: 'shark', clownfish: 'clownfish', jellyfish: 'jellyfish', seaTurtle: 'seaTurtle',
-  };
-  for (const type of types) {
-    const n = countCreatures(type);
-    const countEl = document.getElementById(`count-${ids[type]}`);
-    if (countEl) countEl.textContent = String(n);
-    const removeBtn = document.getElementById(`remove${type.charAt(0).toUpperCase()}${type.slice(1)}Btn`) as HTMLButtonElement | null;
-    if (removeBtn) removeBtn.disabled = n === 0;
-  }
-}
-
-if (addSharkBtn) addSharkBtn.addEventListener('click', () => { spawnShark(); refreshPanel(); });
-if (removeSharkBtn) removeSharkBtn.addEventListener('click', () => { removeCreature('shark'); refreshPanel(); });
-if (addClownfishBtn) addClownfishBtn.addEventListener('click', () => { spawnClownfish(); refreshPanel(); });
-if (removeClownfishBtn) removeClownfishBtn.addEventListener('click', () => { removeCreature('clownfish'); refreshPanel(); });
-if (addJellyfishBtn) addJellyfishBtn.addEventListener('click', () => { spawnJellyfish(); refreshPanel(); });
-if (removeJellyfishBtn) removeJellyfishBtn.addEventListener('click', () => { removeCreature('jellyfish'); refreshPanel(); });
-if (addSeaTurtleBtn) addSeaTurtleBtn.addEventListener('click', () => { spawnSeaTurtle(); refreshPanel(); });
-if (removeSeaTurtleBtn) removeSeaTurtleBtn.addEventListener('click', () => { removeCreature('seaTurtle'); refreshPanel(); });
+// The sea-life panel + spawnable creatures are wired by installSeaLife above.
 
 // Undo button enabled/disabled: update after every dispatch
 function refreshUndoBtn(): void {
@@ -458,7 +313,7 @@ socket.connect();
 function loop(t: number): void {
   const tSec = t / 1000;
   swayClock.value = tSec;
-  for (const c of creatures) c.instance.update(tSec);
+  seaLife.update(tSec);
 
   if (config.mode === 'screen') {
     const pose = computeOrbitPose(tSec);

--- a/packages/client/src/tree/seaLife.test.ts
+++ b/packages/client/src/tree/seaLife.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { Group } from 'three';
+import { installSeaLife, type CreatureType } from './seaLife.js';
+
+const TYPES: CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
+const cap = (t: string): string => t.charAt(0).toUpperCase() + t.slice(1);
+
+function mountPanelDom(): void {
+  document.body.replaceChildren();
+  const panel = document.createElement('div');
+  panel.id = 'sea-life-panel';
+  document.body.appendChild(panel);
+
+  const seaLifeBtn = document.createElement('button');
+  seaLifeBtn.id = 'seaLifeBtn';
+  document.body.appendChild(seaLifeBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.id = 'sea-life-close-btn';
+  panel.appendChild(closeBtn);
+
+  for (const t of TYPES) {
+    for (const verb of ['add', 'remove']) {
+      const b = document.createElement('button');
+      b.id = `${verb}${cap(t)}Btn`;
+      panel.appendChild(b);
+    }
+    const count = document.createElement('span');
+    count.id = `count-${t}`;
+    panel.appendChild(count);
+  }
+}
+
+const $ = (id: string): HTMLElement => document.getElementById(id)!;
+
+describe('installSeaLife', () => {
+  let anchor: Group;
+
+  beforeEach(() => {
+    mountPanelDom();
+    anchor = new Group();
+  });
+
+  test('add button spawns a creature into the anchor and updates the count + remove button', () => {
+    installSeaLife(anchor);
+    const removeBtn = $('removeSharkBtn') as HTMLButtonElement;
+    expect(removeBtn.disabled).toBe(false); // refresh only runs after a click
+
+    ($('addSharkBtn') as HTMLButtonElement).click();
+    expect(anchor.children.length).toBe(1);
+    expect($('count-shark').textContent).toBe('1');
+    expect(removeBtn.disabled).toBe(false);
+  });
+
+  test('remove button despawns the creature and disables when none remain', () => {
+    installSeaLife(anchor);
+    ($('addSharkBtn') as HTMLButtonElement).click();
+    ($('removeSharkBtn') as HTMLButtonElement).click();
+    expect(anchor.children.length).toBe(0);
+    expect($('count-shark').textContent).toBe('0');
+    expect(($('removeSharkBtn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('each creature type spawns independently', () => {
+    installSeaLife(anchor);
+    for (const t of TYPES) ($(`add${cap(t)}Btn`) as HTMLButtonElement).click();
+    expect(anchor.children.length).toBe(4);
+    for (const t of TYPES) expect($(`count-${t}`).textContent).toBe('1');
+  });
+
+  test('update() advances without throwing when creatures exist', () => {
+    const ctrl = installSeaLife(anchor);
+    ($('addJellyfishBtn') as HTMLButtonElement).click();
+    expect(() => ctrl.update(1.5)).not.toThrow();
+  });
+
+  test('panel toggles open/closed via the toggle and close buttons', () => {
+    installSeaLife(anchor);
+    const panel = $('sea-life-panel');
+    ($('seaLifeBtn') as HTMLButtonElement).click();
+    expect(panel.classList.contains('open')).toBe(true);
+    ($('sea-life-close-btn') as HTMLButtonElement).click();
+    expect(panel.classList.contains('open')).toBe(false);
+  });
+
+  test('Escape closes the panel, but not after dispose() removes the listener', () => {
+    const ctrl = installSeaLife(anchor);
+    const panel = $('sea-life-panel');
+    ($('seaLifeBtn') as HTMLButtonElement).click();
+    expect(panel.classList.contains('open')).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(panel.classList.contains('open')).toBe(false);
+
+    // Re-open, dispose, then Escape must no longer close it (listener gone).
+    ($('seaLifeBtn') as HTMLButtonElement).click();
+    ctrl.dispose();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(panel.classList.contains('open')).toBe(true);
+  });
+});

--- a/packages/client/src/tree/seaLife.ts
+++ b/packages/client/src/tree/seaLife.ts
@@ -1,0 +1,175 @@
+import type { Group, Material, Mesh } from 'three';
+import { Shark } from './shark.js';
+import { Clownfish } from './clownfish.js';
+import { Jellyfish } from './jellyfish.js';
+import { SeaTurtle } from './seaTurtle.js';
+
+export type CreatureType = 'shark' | 'clownfish' | 'jellyfish' | 'seaTurtle';
+
+interface SwimmingCreature {
+  readonly group: Group;
+  update: (clockSec: number) => void;
+}
+
+interface OrbitOptions {
+  orbitRadius: number;
+  orbitHeight: number;
+  orbitPeriodSec: number;
+  phaseRad: number;
+  direction: 1 | -1;
+}
+
+// [base, span] for `base + Math.random() * span` — preserves the exact random
+// distribution the inline tree.ts / treeApp.ts spawners used.
+const SPECS: Record<
+  CreatureType,
+  {
+    make: (o: OrbitOptions) => SwimmingCreature;
+    radius: [number, number];
+    height: [number, number];
+    period: [number, number];
+  }
+> = {
+  shark: { make: (o) => new Shark(o), radius: [0.25, 0.15], height: [0.05, 0.2], period: [14, 10] },
+  clownfish: { make: (o) => new Clownfish(o), radius: [0.15, 0.15], height: [0.04, 0.2], period: [5, 6] },
+  jellyfish: { make: (o) => new Jellyfish(o), radius: [0.18, 0.14], height: [0.1, 0.2], period: [20, 12] },
+  seaTurtle: { make: (o) => new SeaTurtle(o), radius: [0.28, 0.12], height: [0.04, 0.12], period: [28, 12] },
+};
+
+const ORDER: readonly CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
+
+export interface SeaLifeController {
+  /** Advance every creature's animation. Call once per render frame. */
+  update(clockSec: number): void;
+  /** Remove the document-level panel listeners (Escape / click-outside). */
+  dispose(): void;
+}
+
+/**
+ * Wire the sea-life subsystem — the spawnable orbiting creatures plus the
+ * sea-life panel UI. Extracted from the tree.ts and treeApp.ts entries, which
+ * each carried a verbatim copy. `anchor` is the group creatures are parented to
+ * (treeReef.anchor). Returns a controller with `update` (drive the animation
+ * each frame) and `dispose` (drop document listeners, for the AR entry that has
+ * a teardown path).
+ */
+export function installSeaLife(anchor: Group): SeaLifeController {
+  interface Tracked {
+    type: CreatureType;
+    instance: SwimmingCreature;
+    group: Group;
+  }
+  const creatures: Tracked[] = [];
+
+  const span = ([base, s]: [number, number]): number => base + Math.random() * s;
+
+  const spawn = (type: CreatureType): void => {
+    const spec = SPECS[type];
+    const instance = spec.make({
+      orbitRadius: span(spec.radius),
+      orbitHeight: span(spec.height),
+      orbitPeriodSec: span(spec.period),
+      phaseRad: Math.random() * Math.PI * 2,
+      direction: Math.random() < 0.5 ? 1 : -1,
+    });
+    anchor.add(instance.group);
+    creatures.push({ type, instance, group: instance.group });
+  };
+
+  const removeOne = (type: CreatureType): boolean => {
+    // Remove the most recently added creature of this type.
+    const idx =
+      [...creatures]
+        .map((c, i) => ({ c, i }))
+        .reverse()
+        .find(({ c }) => c.type === type)?.i ?? -1;
+    if (idx === -1) return false;
+    const [removed] = creatures.splice(idx, 1);
+    if (!removed) return false;
+    anchor.remove(removed.group);
+    removed.group.traverse((obj) => {
+      const mesh = obj as Mesh;
+      if (mesh.isMesh) {
+        mesh.geometry?.dispose();
+        if (Array.isArray(mesh.material)) {
+          for (const m of mesh.material) (m as Material).dispose();
+        } else {
+          (mesh.material as Material | undefined)?.dispose();
+        }
+      }
+    });
+    return true;
+  };
+
+  const count = (type: CreatureType): number => creatures.filter((c) => c.type === type).length;
+
+  const byId = <T extends HTMLElement>(id: string): T | null =>
+    document.getElementById(id) as T | null;
+  const cap = (t: CreatureType): string => t.charAt(0).toUpperCase() + t.slice(1);
+
+  const seaLifeBtn = byId<HTMLButtonElement>('seaLifeBtn');
+  const seaLifePanel = byId<HTMLElement>('sea-life-panel');
+  const seaLifeCloseBtn = byId<HTMLButtonElement>('sea-life-close-btn');
+
+  const setPanelOpen = (open: boolean): void => {
+    if (!seaLifePanel || !seaLifeBtn) return;
+    if (open) {
+      seaLifePanel.classList.add('open');
+      seaLifeBtn.setAttribute('aria-expanded', 'true');
+      seaLifeBtn.setAttribute('aria-pressed', 'true');
+    } else {
+      seaLifePanel.classList.remove('open');
+      seaLifeBtn.setAttribute('aria-expanded', 'false');
+      seaLifeBtn.removeAttribute('aria-pressed');
+    }
+  };
+
+  seaLifeBtn?.addEventListener('click', () => {
+    setPanelOpen(!(seaLifePanel?.classList.contains('open') ?? false));
+  });
+  seaLifeCloseBtn?.addEventListener('click', () => setPanelOpen(false));
+
+  const onKeydown = (ev: KeyboardEvent): void => {
+    if (ev.key === 'Escape') setPanelOpen(false);
+  };
+  const onDocClick = (ev: MouseEvent): void => {
+    if (!seaLifePanel?.classList.contains('open')) return;
+    const target = ev.target as Node;
+    if (!seaLifePanel.contains(target) && target !== seaLifeBtn && !seaLifeBtn?.contains(target)) {
+      setPanelOpen(false);
+    }
+  };
+  document.addEventListener('keydown', onKeydown);
+  document.addEventListener('click', onDocClick);
+
+  const refreshPanel = (): void => {
+    for (const type of ORDER) {
+      const n = count(type);
+      const countEl = document.getElementById(`count-${type}`);
+      if (countEl) countEl.textContent = String(n);
+      const removeBtn = byId<HTMLButtonElement>(`remove${cap(type)}Btn`);
+      if (removeBtn) removeBtn.disabled = n === 0;
+    }
+  };
+
+  for (const type of ORDER) {
+    byId<HTMLButtonElement>(`add${cap(type)}Btn`)?.addEventListener('click', () => {
+      spawn(type);
+      refreshPanel();
+    });
+    byId<HTMLButtonElement>(`remove${cap(type)}Btn`)?.addEventListener('click', () => {
+      removeOne(type);
+      refreshPanel();
+    });
+  }
+
+  return {
+    update(clockSec: number): void {
+      for (const c of creatures) c.instance.update(clockSec);
+    },
+    dispose(): void {
+      document.removeEventListener('keydown', onKeydown);
+      document.removeEventListener('click', onDocClick);
+    },
+  };
+}

--- a/packages/client/src/treeApp.ts
+++ b/packages/client/src/treeApp.ts
@@ -6,10 +6,7 @@ import { TreePlacement } from './tree/placement.js';
 import { installUnderwaterLighting } from './tree/scene.js';
 import { fetchTree, TreeSocket, defaultTreeWsUrl } from './tree/api.js';
 import { TreePicker, TREE_VARIANTS } from './ui/treePicker.js';
-import { Shark } from './tree/shark.js';
-import { Clownfish } from './tree/clownfish.js';
-import { Jellyfish } from './tree/jellyfish.js';
-import { SeaTurtle } from './tree/seaTurtle.js';
+import { installSeaLife, type SeaLifeController } from './tree/seaLife.js';
 import { installSway } from './scene/currentSway.js';
 import { installTreePulse } from './tree/pulse.js';
 import {
@@ -48,14 +45,6 @@ function readScaleFromUrl(): number {
 const SWAY_INSTALLED = Symbol('sway-installed');
 const PULSE_INSTALLED = Symbol('pulse-installed');
 
-type CreatureType = 'shark' | 'clownfish' | 'jellyfish' | 'seaTurtle';
-interface SwimmingCreature { update: (clockSec: number) => void; }
-interface TrackedCreature {
-  type: CreatureType;
-  instance: SwimmingCreature;
-  group: import('three').Group;
-}
-
 export class TreeApp {
   private readonly scene = new Scene();
   private readonly camera: PerspectiveCamera;
@@ -70,7 +59,7 @@ export class TreeApp {
   private effects!: ReturnType<typeof createEffects>;
   private state: TreeState;
   private running = false;
-  private readonly creatures: TrackedCreature[] = [];
+  private seaLife?: SeaLifeController;
   private readonly hintEl: HTMLElement;
   private readonly statusEl: HTMLElement;
   private readonly apiBase: string;
@@ -176,71 +165,16 @@ export class TreeApp {
     this.running = false;
     if (this.socket) this.socket.close();
     if (this.tracker) void this.tracker.destroy();
+    this.seaLife?.dispose();
   }
 
   wireToolbar(): void {
     const clearBtn = document.getElementById('clearBtn') as HTMLButtonElement | null;
     const undoBtn = document.getElementById('undoBtn') as HTMLButtonElement | null;
-    const seaLifeBtn = document.getElementById('seaLifeBtn') as HTMLButtonElement | null;
-    const seaLifePanel = document.getElementById('sea-life-panel') as HTMLElement | null;
-    const seaLifeCloseBtn = document.getElementById('sea-life-close-btn') as HTMLButtonElement | null;
-
     if (clearBtn) clearBtn.addEventListener('click', () => this.dispatch({ type: 'CLEAR_CLICKED' }));
     if (undoBtn) undoBtn.addEventListener('click', () => this.dispatch({ type: 'UNDO_CLICKED' }));
-
-    const setPanelOpen = (open: boolean): void => {
-      if (!seaLifePanel || !seaLifeBtn) return;
-      if (open) {
-        seaLifePanel.classList.add('open');
-        seaLifeBtn.setAttribute('aria-expanded', 'true');
-        seaLifeBtn.setAttribute('aria-pressed', 'true');
-      } else {
-        seaLifePanel.classList.remove('open');
-        seaLifeBtn.setAttribute('aria-expanded', 'false');
-        seaLifeBtn.removeAttribute('aria-pressed');
-      }
-    };
-
-    if (seaLifeBtn) seaLifeBtn.addEventListener('click', () => {
-      const isOpen = seaLifePanel?.classList.contains('open') ?? false;
-      setPanelOpen(!isOpen);
-    });
-    if (seaLifeCloseBtn) seaLifeCloseBtn.addEventListener('click', () => setPanelOpen(false));
-
-    document.addEventListener('keydown', (ev) => {
-      if (ev.key === 'Escape') setPanelOpen(false);
-    });
-    document.addEventListener('click', (ev) => {
-      if (!seaLifePanel?.classList.contains('open')) return;
-      const target = ev.target as Node;
-      if (!seaLifePanel.contains(target) && target !== seaLifeBtn && !seaLifeBtn?.contains(target)) {
-        setPanelOpen(false);
-      }
-    });
-
-    const refreshPanel = (): void => {
-      const types: CreatureType[] = ['shark', 'clownfish', 'jellyfish', 'seaTurtle'];
-      for (const type of types) {
-        const n = this.countCreatures(type);
-        const countEl = document.getElementById(`count-${type}`);
-        if (countEl) countEl.textContent = String(n);
-        const capType = type.charAt(0).toUpperCase() + type.slice(1);
-        const removeBtn = document.getElementById(`remove${capType}Btn`) as HTMLButtonElement | null;
-        if (removeBtn) removeBtn.disabled = n === 0;
-      }
-    };
-
-    const wire = (addId: string, removeId: string, type: CreatureType, spawn: () => void): void => {
-      const addBtn = document.getElementById(addId) as HTMLButtonElement | null;
-      const removeBtn = document.getElementById(removeId) as HTMLButtonElement | null;
-      if (addBtn) addBtn.addEventListener('click', () => { spawn(); refreshPanel(); });
-      if (removeBtn) removeBtn.addEventListener('click', () => { this.removeCreature(type); refreshPanel(); });
-    };
-
-    wire('addSharkBtn', 'removeSharkBtn', 'shark', () => this.spawnShark());
-    wire('addClownfishBtn', 'removeClownfishBtn', 'clownfish', () => this.spawnClownfish());
-    wire('addJellyfishBtn', 'removeJellyfishBtn', 'jellyfish', () => this.spawnJellyfish());
-    wire('addSeaTurtleBtn', 'removeSeaTurtleBtn', 'seaTurtle', () => this.spawnSeaTurtle());
+    // Sea-life panel + spawnable creatures, shared with the desktop tree entry.
+    this.seaLife = installSeaLife(this.treeReef.anchor);
   }
 
   private dispatch(action: TreeAction): void {
@@ -386,79 +320,6 @@ export class TreeApp {
     undoBtn.disabled = !(this.state.kind === 'idle' && this.state.lastCommittedId !== null);
   }
 
-  private spawnShark(): void {
-    const s = new Shark({
-      orbitRadius: 0.25 + Math.random() * 0.15,
-      orbitHeight: 0.05 + Math.random() * 0.2,
-      orbitPeriodSec: 14 + Math.random() * 10,
-      phaseRad: Math.random() * Math.PI * 2,
-      direction: Math.random() < 0.5 ? 1 : -1,
-    });
-    this.treeReef.anchor.add(s.group);
-    this.creatures.push({ type: 'shark', instance: s, group: s.group });
-  }
-
-  private spawnClownfish(): void {
-    const c = new Clownfish({
-      orbitRadius: 0.15 + Math.random() * 0.15,
-      orbitHeight: 0.04 + Math.random() * 0.2,
-      orbitPeriodSec: 5 + Math.random() * 6,
-      phaseRad: Math.random() * Math.PI * 2,
-      direction: Math.random() < 0.5 ? 1 : -1,
-    });
-    this.treeReef.anchor.add(c.group);
-    this.creatures.push({ type: 'clownfish', instance: c, group: c.group });
-  }
-
-  private spawnJellyfish(): void {
-    const j = new Jellyfish({
-      orbitRadius: 0.18 + Math.random() * 0.14,
-      orbitHeight: 0.1 + Math.random() * 0.2,
-      orbitPeriodSec: 20 + Math.random() * 12,
-      phaseRad: Math.random() * Math.PI * 2,
-      direction: Math.random() < 0.5 ? 1 : -1,
-    });
-    this.treeReef.anchor.add(j.group);
-    this.creatures.push({ type: 'jellyfish', instance: j, group: j.group });
-  }
-
-  private spawnSeaTurtle(): void {
-    const t = new SeaTurtle({
-      orbitRadius: 0.28 + Math.random() * 0.12,
-      orbitHeight: 0.04 + Math.random() * 0.12,
-      orbitPeriodSec: 28 + Math.random() * 12,
-      phaseRad: Math.random() * Math.PI * 2,
-      direction: Math.random() < 0.5 ? 1 : -1,
-    });
-    this.treeReef.anchor.add(t.group);
-    this.creatures.push({ type: 'seaTurtle', instance: t, group: t.group });
-  }
-
-  private removeCreature(type: CreatureType): boolean {
-    const idx = [...this.creatures].map((c, i) => ({ c, i })).reverse()
-      .find(({ c }) => c.type === type)?.i ?? -1;
-    if (idx === -1) return false;
-    const [removed] = this.creatures.splice(idx, 1);
-    if (!removed) return false;
-    this.treeReef.anchor.remove(removed.group);
-    removed.group.traverse((obj) => {
-      const mesh = obj as import('three').Mesh;
-      if (mesh.isMesh) {
-        mesh.geometry?.dispose();
-        if (Array.isArray(mesh.material)) {
-          for (const m of mesh.material) (m as import('three').Material).dispose();
-        } else {
-          (mesh.material as import('three').Material | undefined)?.dispose();
-        }
-      }
-    });
-    return true;
-  }
-
-  private countCreatures(type: CreatureType): number {
-    return this.creatures.filter((c) => c.type === type).length;
-  }
-
   private async startCamera(): Promise<void> {
     if (!navigator.mediaDevices?.getUserMedia) return;
     const stream = await navigator.mediaDevices.getUserMedia({
@@ -485,7 +346,7 @@ export class TreeApp {
     if (!this.running) return;
     const tSec = t / 1000;
     this.swayClock.value = tSec;
-    for (const c of this.creatures) c.instance.update(tSec);
+    this.seaLife?.update(tSec);
     this.renderer.render(this.scene, this.camera);
     requestAnimationFrame((tt) => this.loop(tt));
   }


### PR DESCRIPTION
## Summary

The `tree.ts` (screen/interactive) and `treeApp.ts` (AR) entries each carried a verbatim copy of the spawnable-creature definitions and the sea-life panel wiring (~150 lines each). This pulls both into a single `installSeaLife(anchor)` installer in `tree/seaLife.ts` that returns an `{ update, dispose }` controller, removing ~295 lines of duplication across the two entries.

## Why

Two byte-identical copies of the same subsystem is a maintenance hazard: a fix to one entry silently skips the other. The AR entry also leaked its document-level panel listeners because `stop()` had no teardown for them. Centralizing the subsystem fixes both.

## What changed

- New `packages/client/src/tree/seaLife.ts`: `installSeaLife(anchor)` with a `SPECS` table holding the `[base, span]` orbit-parameter ranges, `spawn`/`removeOne`/`count`, and the panel DOM wiring.
- New `packages/client/src/tree/seaLife.test.ts`: 6 happy-dom cases.
- `tree.ts` / `treeApp.ts`: replaced the inline copies with a single `installSeaLife` call; AR `stop()` now calls `seaLife.dispose()`.

## Behavior preservation

- The `SPECS` `[base, span]` ranges reproduce the exact `base + Math.random()*span` distribution the inline spawners used.
- Creatures parent to the same `treeReef.anchor`.
- All panel DOM ids are unchanged (verified present in both `tree.html` and `treeAr.html`).
- The entry files remain script-vs-class by design; only the duplicated subsystem moved.

## Test plan

- [x] `pnpm lint` (0 errors, 5 pre-existing warnings)
- [x] `pnpm --filter @reef/client typecheck`
- [x] `pnpm --filter @reef/client test` (366 pass)
- [x] dispose() removes keydown + click listeners (covered by the Escape-after-dispose test)

Closes #103