### PR TITLE
refactor(generator): unify Mulberry32 + deterministic tree root seed

### DIFF
--- a/packages/generator/src/rng.test.ts
+++ b/packages/generator/src/rng.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { RNG } from './rng.js';
+import { mulberry32, RNG } from './rng.js';
+import { seededRand } from './tree/variant.js';
 
 test('RNG is deterministic across instances for the same seed', () => {
   const a = new RNG(12345);
@@ -35,4 +36,19 @@ test('RNG handles seed 0 by falling through to 1', () => {
   const a = new RNG(0);
   const b = new RNG(1);
   for (let i = 0; i < 10; i++) assert.equal(a.next(), b.next());
+});
+
+test('seededRand is the canonical mulberry32 (single implementation)', () => {
+  assert.equal(seededRand, mulberry32);
+});
+
+test('RNG wraps mulberry32 with its seed-0 guard', () => {
+  // RNG(seed) is mulberry32(seed || 1); for nonzero seeds the streams match.
+  for (const seed of [1, 42, 2_147_483_647, 3_000_000_000]) {
+    const viaRng = new RNG(seed);
+    const viaFn = mulberry32(seed);
+    for (let i = 0; i < 50; i++) assert.equal(viaRng.next(), viaFn());
+  }
+  // Seed 0 is where they diverge by design: RNG remaps to 1, the raw fn does not.
+  assert.notEqual(new RNG(0).next(), mulberry32(0)());
 });

--- a/packages/generator/src/rng.ts
+++ b/packages/generator/src/rng.ts
@@ -1,19 +1,38 @@
 /**
- * Deterministic PRNG. Given the same seed, emits the same sequence across
- * client + server. Mulberry32 is plenty for procedural art.
+ * Canonical Mulberry32. Given the same seed, emits the same sequence across
+ * client + server — plenty for procedural art. Every step is bitwise or
+ * `Math.imul`, so how the accumulator is stored (signed `| 0` vs unsigned
+ * `>>> 0`) never changes the stream; the streams only ever diverged on seed 0,
+ * which callers that care guard explicitly (see RNG below).
+ *
+ * Single source of truth for the algorithm. `seededRand` in the tree generator
+ * re-exports this; do not fork a second copy.
+ */
+export function mulberry32(seed: number): () => number {
+  let state = (seed | 0) >>> 0;
+  return (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 0x1_0000_0000;
+  };
+}
+
+/**
+ * Deterministic PRNG with sampling helpers (range/int/pick/chance) over the
+ * canonical {@link mulberry32} stream. Maps seed 0 → 1 so a 0 seed doesn't pin
+ * the stream to its fixed point.
  */
 export class RNG {
-  private state: number;
+  private readonly _next: () => number;
 
   constructor(seed: number) {
-    this.state = (seed | 0) || 1;
+    this._next = mulberry32((seed | 0) || 1);
   }
 
   next(): number {
-    let t = (this.state = (this.state + 0x6d2b79f5) | 0);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    return this._next();
   }
 
   range(min: number, max: number): number {

--- a/packages/generator/src/tree/variant.ts
+++ b/packages/generator/src/tree/variant.ts
@@ -1,5 +1,6 @@
 import type { MeshData } from '../meshdata.js';
 import type { AttachPoint } from '@reef/shared';
+import { mulberry32 } from '../rng.js';
 
 export interface VariantGenerateInput {
   seed: number;
@@ -49,22 +50,16 @@ function colorG(c: ColorInput): number { return Array.isArray(c) ? (c as readonl
 function colorB(c: ColorInput): number { return Array.isArray(c) ? (c as readonly number[])[2]! : (c as Vec3Obj).z; }
 
 /**
- * Deterministic PRNG (mulberry32). Takes an integer seed, returns a stateful
- * function that yields floats in [0, 1). Used to give each piece a unique but
- * reproducible shape — variant geometry used to be identical across pieces
- * because `seed` was ignored; now it drives dimensional jitter and surface
- * noise so the reef doesn't read as repeated stamps.
+ * Per-piece PRNG: takes an integer seed, returns a stateful function yielding
+ * floats in [0, 1). Used to give each piece a unique but reproducible shape —
+ * variant geometry used to be identical across pieces because `seed` was
+ * ignored; now it drives dimensional jitter and surface noise so the reef
+ * doesn't read as repeated stamps.
+ *
+ * This is the canonical {@link mulberry32} — re-exported here so existing tree
+ * callers keep importing `seededRand` while there is only one implementation.
  */
-export function seededRand(seed: number): () => number {
-  let state = (seed | 0) >>> 0;
-  return (): number => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 0x1_0000_0000;
-  };
-}
+export const seededRand = mulberry32;
 
 /**
  * Returns `base` multiplied by a random factor in [1 - pct, 1 + pct]. Handy

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -38,6 +38,14 @@ export const config = {
   // separately). 0 = unlimited. Bounds a connection flood from exhausting
   // memory / file descriptors before the heartbeat reaps idle sockets.
   wsMaxClients: Number(process.env.WS_MAX_CLIENTS ?? 1000),
+  // Fixed seed for the first-boot Starburst root. Unset (or blank) = random per
+  // fresh volume (the chosen seed is logged, so the root is reproducible after
+  // the fact). Set an integer in [0, 2^32) to make the root identical across
+  // boots — handy for golden-style testing or a branded default reef.
+  treeRootSeed:
+    (process.env.TREE_ROOT_SEED ?? '').trim() === ''
+      ? undefined
+      : Number(process.env.TREE_ROOT_SEED),
   corsOrigins: (process.env.CORS_ORIGINS ?? '*').split(',').map((s) => s.trim()),
   // Absolute path to the built Vite client bundle. When set, the server
   // serves the static files and SPA index fallbacks. Leave unset in dev so
@@ -73,6 +81,23 @@ if (!Number.isInteger(config.wsMaxClients) || config.wsMaxClients < 0) {
   throw new Error(
     `WS_MAX_CLIENTS must be a non-negative integer (0 = unlimited), ` +
       `got ${JSON.stringify(process.env.WS_MAX_CLIENTS)}`,
+  );
+}
+
+// Fail loud on a malformed TREE_ROOT_SEED rather than seeding with NaN or an
+// out-of-range value. mulberry32 does `(seed | 0) >>> 0`, so an integer outside
+// [0, 2^32) is silently truncated to a different effective seed — which would
+// break the "the logged seed reproduces the root" invariant this knob exists
+// for. Bound it to the same domain the random path uses (0..0xffffffff).
+if (
+  config.treeRootSeed !== undefined &&
+  (!Number.isInteger(config.treeRootSeed) ||
+    config.treeRootSeed < 0 ||
+    config.treeRootSeed > 0xffffffff)
+) {
+  throw new Error(
+    `TREE_ROOT_SEED must be an integer in [0, 4294967295] when set (unset = random root), ` +
+      `got ${JSON.stringify(process.env.TREE_ROOT_SEED)}`,
   );
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -54,7 +54,6 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
   const hub = new Hub(config.wsMaxClients);
   const treeDb = new TreeDb(db);
   const treeHub = new Hub(config.wsMaxClients);
-  seedRootIfEmpty(treeDb);
 
   // 8 KB fits the largest valid polyp (schema-bounded). Fastify's 1 MB
   // default lets unauthenticated callers make Zod walk a megabyte before
@@ -81,6 +80,16 @@ export async function makeServer(opts: MakeServerOptions = {}): Promise<MakeServ
   registerAdminRoutes(app, db, hub);
   registerStatsRoutes(app, db);
   registerMetricsRoutes(app, db, hub);
+  // Seed the first-boot root before the tree routes start serving. Log the
+  // chosen seed/colorKey so a random root (TREE_ROOT_SEED unset) is still
+  // reproducible after the fact.
+  const rootSeed = seedRootIfEmpty(treeDb, { seed: config.treeRootSeed });
+  if (rootSeed.seeded) {
+    app.log.info(
+      { seed: rootSeed.seed, colorKey: rootSeed.colorKey, fixed: config.treeRootSeed !== undefined },
+      'seeded first-boot tree root',
+    );
+  }
   registerTreeRoutes(app, treeDb, treeHub);
 
   // Optional static hosting: serves the built Vite bundle out of the same

--- a/packages/server/src/tree/seed.test.ts
+++ b/packages/server/src/tree/seed.test.ts
@@ -38,4 +38,29 @@ describe('seedRootIfEmpty', () => {
     // Not all five identical — random.
     assert.ok(results.size > 1, `expected randomness, got ${[...results].join(',')}`);
   });
+
+  test('returns the chosen seed + colorKey so a random root is reproducible', () => {
+    const reef = new ReefDb(':memory:');
+    const tree = new TreeDb(reef);
+    const result = seedRootIfEmpty(tree);
+    assert.equal(result.seeded, true);
+    const root = tree.listLive()[0]!;
+    // The values written to the DB are exactly what the caller can log.
+    assert.equal(result.seed, root.seed);
+    assert.equal(result.colorKey, root.colorKey);
+  });
+
+  test('a fixed seed + colorKey make the root deterministic across boots', () => {
+    const seedOne = (): { seed: number; colorKey: string } => {
+      const tree = new TreeDb(new ReefDb(':memory:'));
+      seedRootIfEmpty(tree, { seed: 12345, colorKey: 'neon-cyan' });
+      const root = tree.listLive()[0]!;
+      return { seed: root.seed, colorKey: root.colorKey };
+    };
+    const a = seedOne();
+    const b = seedOne();
+    assert.deepEqual(a, b);
+    assert.equal(a.seed, 12345);
+    assert.equal(a.colorKey, 'neon-cyan');
+  });
 });

--- a/packages/server/src/tree/seed.ts
+++ b/packages/server/src/tree/seed.ts
@@ -3,8 +3,24 @@ import type { TreeDb } from './db.js';
 // Avatar-aesthetic palette — matches the client-side tree material palette.
 const ROOT_COLORS = ['neon-magenta', 'neon-cyan', 'neon-violet', 'neon-lime', 'neon-orange'];
 
+export interface SeedOptions {
+  /**
+   * Fixed root seed. Set this (e.g. from config) to make the first-boot root
+   * reproducible across fresh volumes — useful for golden-style testing. When
+   * omitted, a random seed is chosen and returned in {@link SeedResult} so the
+   * caller can log it and reproduce the root after the fact.
+   */
+  seed?: number | undefined;
+  /** Fixed root colorKey; same determinism trade-off as {@link SeedOptions.seed}. */
+  colorKey?: string | undefined;
+}
+
 export interface SeedResult {
   seeded: boolean;
+  /** The seed actually used (random or supplied) — only present when seeded. */
+  seed?: number;
+  /** The colorKey actually used (random or supplied) — only present when seeded. */
+  colorKey?: string;
 }
 
 /**
@@ -12,12 +28,16 @@ export interface SeedResult {
  * volume) drops in one Starburst at the pedestal origin so visitors always
  * have something to branch from.
  *
+ * The root seed/colorKey are random by default but overridable via `opts` for
+ * deterministic boots; either way the chosen values come back in the result so
+ * the caller can log them (the random root is then reproducible after the fact).
+ *
  * Idempotent — calling repeatedly is safe because of the hasAnyLive check.
  */
-export function seedRootIfEmpty(tree: TreeDb): SeedResult {
+export function seedRootIfEmpty(tree: TreeDb, opts: SeedOptions = {}): SeedResult {
   if (tree.hasAnyLive()) return { seeded: false };
-  const seed = Math.floor(Math.random() * 0xffffffff);
-  const colorKey = ROOT_COLORS[Math.floor(Math.random() * ROOT_COLORS.length)]!;
+  const seed = opts.seed ?? Math.floor(Math.random() * 0xffffffff);
+  const colorKey = opts.colorKey ?? ROOT_COLORS[Math.floor(Math.random() * ROOT_COLORS.length)]!;
   tree.insertRoot({ variant: 'starburst', seed, colorKey });
-  return { seeded: true };
+  return { seeded: true, seed, colorKey };
 }


### PR DESCRIPTION
## Summary

Closes #101. Two parts:

1. **One Mulberry32.** The `RNG` class (`generator/src/rng.ts`) and `seededRand` (`generator/src/tree/variant.ts`) were two copies of the same PRNG. Extracted a canonical `mulberry32(seed)` in rng.ts; `RNG` wraps it (keeping its seed-0 → 1 guard) and `seededRand` re-exports it.
2. **Deterministic-overridable root seed.** `seedRootIfEmpty` no longer hides its only nondeterministic input. It accepts optional `{seed, colorKey}` and returns the chosen values; `index.ts` logs the seeded root. A new `TREE_ROOT_SEED` config knob supplies a fixed seed.

## Why

Two byte-identical PRNG copies are a correctness hazard: any test fixture or future unification that assumes one stream would hit mystery mismatches. The root being chosen with `Math.random()` made it unreproducible across reseeds, which complicates debugging and golden-style testing.

## Behavior preservation

The two streams were verified bit-identical for every seed except 0 (where `RNG` remaps to 1, by design). Every operation is bitwise or `Math.imul`, so the old signed (`| 0`) vs unsigned (`>>> 0`) accumulator never affected the output. The generator goldens suite (59 tests) passes unchanged, confirming no procedural-art drift.

## TREE_ROOT_SEED

- Unset or blank → random root per fresh volume; the chosen seed is logged so the root is reproducible after the fact.
- Set to an integer in `[0, 2^32)` → identical root across boots (golden testing / branded default reef).
- Validated fail-loud: a non-integer, negative, or out-of-range value aborts boot rather than silently truncating (`mulberry32` does `(seed | 0) >>> 0`, so an out-of-range seed would otherwise drive a different effective stream than the one logged).

## Test plan

- [x] `pnpm lint` (0 errors)
- [x] `pnpm --filter @reef/generator test` (59 pass, goldens unchanged)
- [x] `pnpm --filter @reef/server test` (140 pass)
- [x] `pnpm --filter @reef/client test` (366 pass)
- [x] New: `seededRand === mulberry32` identity, RNG/mulberry32 stream parity + seed-0 divergence, seeder determinism + reproducibility

Reviewed by code-reviewer + silent-failure-hunter; the one Recommended finding (TREE_ROOT_SEED range validation) is applied.