### PR TITLE
docs: reconcile versioning on the git tag + backfill 0.6.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 All notable changes to this project are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely;
-versions are SemVer.
+versions are SemVer. The canonical version is the **git tag** (`vX.Y.Z`); the
+`version` field in each `package.json` is unused (all packages are private and
+never published) and stays at `0.1.0` on purpose. See CONTRIBUTING for why.
 
 ## [Unreleased]
+
+## [0.6.1] — 2026-04-24
+
+### Fixed
+
+- **`treeAr.html` missing from the production build.** The AR tree surface
+  shipped in 0.6.0 but was never registered as a Vite build entry, so it was
+  absent from `dist/`. Added it to the client's Vite build inputs
+  (`packages/client/vite.config.ts`).
 
 ## [0.6.0] — 2026-04-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,22 @@ git push origin v0.2.0
 Operators who pin to a version get reproducibility; the rest follow
 `:latest`.
 
+### Versioning: the git tag is the source of truth
+
+There is exactly one authoritative version: the **git tag** (`vX.Y.Z`).
+`release.yml` derives the published image tags straight from it
+(`docker/metadata-action` with `type=semver`), so nothing else needs to be
+edited to cut a release.
+
+The `version` field in every `package.json` is **not** the release version. All
+packages are `private` and never published to a registry, so that field has no
+consumer; it stays at `0.1.0` deliberately. Do not bump it per release, and
+don't treat a mismatch between it and the latest tag as a bug.
+
+When tagging a release, the only doc to update is `CHANGELOG.md`: move the
+`[Unreleased]` notes under a new `[X.Y.Z]` heading dated the same day as the
+tag.
+
 After a release, you can verify the published image end-to-end by
 running the `Docker smoke` workflow (Actions → Docker smoke → Run
 workflow). It pulls `:latest`, waits for `/healthz`, and exercises


### PR DESCRIPTION
## Summary

Closes #107. Three version sources disagreed: git tags ran to `v0.6.1`, every `package.json` still said `0.1.0`, and `CHANGELOG.md` stopped at `0.6.0`.

This picks the **git tag as the single source of truth** (it already drives `release.yml` via `docker/metadata-action`'s `type=semver` pattern, so no workflow change is needed) and documents that the `package.json` `version` field is intentionally unused: all packages are `private` and never published, so it stays at `0.1.0` and should not be bumped per release.

## Changes

- **CHANGELOG.md**: backfilled the missing `[0.6.1]` entry (the `treeAr.html` Vite build-entry fix, verified as the only change in `v0.6.0..v0.6.1`). Added a one-line note to the intro pointing at the git tag as canonical.
- **CONTRIBUTING.md**: new "Versioning" subsection under Releasing — one authoritative version (the tag), package.json version is not it, and the only release-time doc edit is moving `[Unreleased]` notes under a dated `[X.Y.Z]` heading.

## Why no package.json bump or release.yml change

The issue offered two options for package.json: bump at tag time, or stop pretending the field is meaningful. Since all packages are private with no registry consumer, bumping would add a commit-back step to the release flow for zero benefit. Documenting the field as unused is the lower-regret path. `release.yml` already derives image tags from the git tag, so it's left untouched.

## Test plan

- [x] Verified `v0.6.0..v0.6.1` contains exactly the `treeAr.html` vite entry commit
- [x] Verified `release.yml` derives versions from the tag (`type=semver`)
- [x] Verified all five `package.json` files are `private: true`
- [x] Docs-only; no code paths touched