### PR TITLE
test: ws/tree round-trip + client-server contract coverage (#109 items 2-3)

### DIFF
--- a/packages/client/src/timelapse/player.test.ts
+++ b/packages/client/src/timelapse/player.test.ts
@@ -166,20 +166,23 @@ describe('createTimelapsePlayer — playback', () => {
       loadList: async () => [meta(10), meta(20), meta(30)],
       loadSnapshot: async (id) => body(id),
       applySnapshot: vi.fn(),
-      frameDelayMs: 1,
+      // Long frame delay so the loop sets the first frame synchronously and
+      // then suspends on the timer for the rest of the test — no real-timer
+      // race, and the pending timer never re-dispatches before dispose().
+      frameDelayMs: 100_000,
     });
     await player.init(); // value = '2'
     const d = dom();
 
+    // click() runs onPlay → tick(), which advances the scrub synchronously
+    // (value set before the first await), so no waiting is needed.
     d.playBtn.click();
     expect(d.playBtn.textContent).toBe('Pause');
-    // One frame: 2 → (2+1)%3 = 0.
-    await new Promise((r) => setTimeout(r, 5));
-    expect(Number(d.scrubEl.value)).not.toBe(2);
+    expect(d.scrubEl.value).toBe('0'); // 2 → (2+1)%3 = 0
 
     d.playBtn.click();
     expect(d.playBtn.textContent).toBe('Play');
-    player.dispose();
+    player.dispose(); // disposed → the suspended loop exits at its next check, no dispatch
   });
 
   test('dispose() removes the listeners — a later scrub is a no-op', async () => {

--- a/packages/server/src/ws.integration.test.ts
+++ b/packages/server/src/ws.integration.test.ts
@@ -4,56 +4,44 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AddressInfo } from 'node:net';
-import Fastify, { type FastifyInstance } from 'fastify';
-import websocket from '@fastify/websocket';
+import { z } from 'zod';
 import WebSocket from 'ws';
-import { ReefDb } from './db.js';
-import { Hub } from './hub.js';
-import { registerReefRoutes } from './routes/reef.js';
-import { registerAdminRoutes } from './routes/admin.js';
+import {
+  ServerMessageSchema,
+  TreeServerMessageSchema,
+  PublicPolypSchema,
+  PublicTreePolypSchema,
+} from '@reef/shared';
+import type { ReefDb } from './db.js';
+import type { TreeDb } from './tree/db.js';
+import { makeServer } from './index.js';
 import { config } from './config.js';
 
+// Drive the *real* server (makeServer) rather than a hand-rolled /ws route, so
+// the production hello payload + every registered route is what's under test.
+// makeServer builds the app but does not listen; we bind to an ephemeral port.
 async function buildApp(): Promise<{
-  app: FastifyInstance;
   db: ReefDb;
+  treeDb: TreeDb;
   url: string;
   wsUrl: string;
+  treeWsUrl: string;
   close: () => Promise<void>;
 }> {
   const dir = mkdtempSync(join(tmpdir(), 'reef-ws-integ-'));
-  const db = new ReefDb(join(dir, 'reef.db'));
-  const hub = new Hub();
-  const app = Fastify({ logger: false });
-  await app.register(websocket, { options: { maxPayload: 64 * 1024 } });
-
-  registerReefRoutes(app, db, hub);
-  registerAdminRoutes(app, db, hub);
-
-  app.get('/ws', { websocket: true }, (sock) => {
-    const ws = sock as unknown as {
-      readyState: number;
-      send: (data: string) => void;
-      on: (event: 'close', cb: () => void) => void;
-    };
-    hub.add(ws);
-    ws.send(JSON.stringify({
-      type: 'hello',
-      polypCount: db.listPublicPolyps().length,
-      serverTime: Date.now(),
-    }));
-  });
+  const { app, db, treeDb } = await makeServer({ dbPath: join(dir, 'reef.db'), logger: false });
 
   // Bind to 127.0.0.1:0 so the OS picks a free port and tests can run in parallel.
   await app.listen({ host: '127.0.0.1', port: 0 });
   const addr = app.server.address() as AddressInfo;
-  const url = `http://127.0.0.1:${addr.port}`;
-  const wsUrl = `ws://127.0.0.1:${addr.port}/ws`;
+  const base = `127.0.0.1:${addr.port}`;
 
   return {
-    app,
     db,
-    url,
-    wsUrl,
+    treeDb,
+    url: `http://${base}`,
+    wsUrl: `ws://${base}/ws`,
+    treeWsUrl: `ws://${base}/ws/tree`,
     close: async () => { await app.close(); },
   };
 }
@@ -129,13 +117,17 @@ interface Hello { type: 'hello'; polypCount: number; serverTime: number }
 interface PolypAdded { type: 'polyp_added'; polyp: { id: number; species: string } }
 interface PolypRemoved { type: 'polyp_removed'; id: number }
 
-test('integration: WS upgrade delivers hello', async () => {
+test('integration: WS upgrade delivers a schema-valid hello', async () => {
   const { wsUrl, close } = await buildApp();
   const probe = new WsProbe(wsUrl);
   try {
     await probe.open();
     const hello = await probe.next<Hello>((m: any) => m.type === 'hello');
-    assert.equal(hello.type, 'hello');
+    // Contract check: the live hello frame must satisfy the same schema the
+    // client validates inbound frames with (dispatchMessage). This is the real
+    // production hello payload now that buildApp goes through makeServer.
+    const parsed = ServerMessageSchema.parse(hello);
+    assert.equal(parsed.type, 'hello');
     assert.equal(hello.polypCount, 0);
     assert.ok(typeof hello.serverTime === 'number');
   } finally {
@@ -289,6 +281,107 @@ test('integration: Hub evicts clients whose sockets closed', async () => {
     assert.equal(added.polyp.species, 'tube');
   } finally {
     await a.close();
+    await close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// /ws/tree round-trip — the tree socket had no integration coverage at all.
+// ---------------------------------------------------------------------------
+
+interface TreeHello { type: 'tree_hello'; polypCount: number; serverTime: number }
+interface TreePolypAdded { type: 'tree_polyp_added'; polyp: { id: number; parentId: number | null } }
+
+test('integration: /ws/tree delivers a schema-valid tree_hello, and planting broadcasts tree_polyp_added', async () => {
+  const { treeWsUrl, url, close } = await buildApp();
+  const probe = new WsProbe(treeWsUrl);
+  try {
+    await probe.open();
+    const hello = await probe.next<TreeHello>((m: any) => m.type === 'tree_hello');
+    const parsedHello = TreeServerMessageSchema.parse(hello);
+    assert.equal(parsedHello.type, 'tree_hello');
+    // makeServer seeds one Starburst root at boot.
+    assert.equal(hello.polypCount, 1);
+
+    // Find the seeded root to attach to.
+    const treeRes = await fetch(`${url}/api/tree`);
+    assert.equal(treeRes.status, 200);
+    const tree = await treeRes.json() as { polyps: Array<{ id: number }> };
+    const rootId = tree.polyps[0]!.id;
+
+    const plantPromise = fetch(`${url}/api/tree/polyp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        variant: 'forked', seed: 4242, colorKey: 'neon-cyan',
+        parentId: rootId, attachIndex: 0, attachYaw: 0,
+      }),
+    });
+
+    const [added, plantRes] = await Promise.all([
+      probe.next<TreePolypAdded>((m: any) => m.type === 'tree_polyp_added' && m.polyp.parentId === rootId),
+      plantPromise,
+    ]);
+    assert.equal(plantRes.status, 200);
+    // Contract check: the broadcast frame satisfies the client's tree schema.
+    const parsedAdded = TreeServerMessageSchema.parse(added);
+    assert.equal(parsedAdded.type, 'tree_polyp_added');
+    assert.equal(added.polyp.parentId, rootId);
+  } finally {
+    await probe.close();
+    await close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// HTTP contract — the client blind-casts r.json() in net/api.ts + tree/api.ts.
+// These parse the live route responses with the shared schemas so a drift
+// between server output and the client's assumed shape fails here.
+// ---------------------------------------------------------------------------
+
+const ReefStateContract = z.object({
+  polyps: z.array(PublicPolypSchema),
+  serverTime: z.number(),
+});
+const TreeStateContract = z.object({
+  polyps: z.array(PublicTreePolypSchema),
+  serverTime: z.number(),
+});
+
+test('contract: GET /api/reef and POST /api/reef/polyp responses match the shared schema', async () => {
+  const { url, close } = await buildApp();
+  try {
+    const empty = ReefStateContract.parse(await (await fetch(`${url}/api/reef`)).json());
+    assert.equal(empty.polyps.length, 0);
+
+    const postRes = await fetch(`${url}/api/reef/polyp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        species: 'branching', seed: 7, colorKey: 'coral-pink',
+        position: [0, 0, 0], orientation: [0, 0, 0, 1], scale: 1,
+      }),
+    });
+    assert.equal(postRes.status, 201);
+    // The POST response is a single public polyp; same shape the WS frame carries.
+    const created = PublicPolypSchema.parse(await postRes.json());
+
+    const after = ReefStateContract.parse(await (await fetch(`${url}/api/reef`)).json());
+    assert.equal(after.polyps.length, 1);
+    assert.equal(after.polyps[0]!.id, created.id);
+  } finally {
+    await close();
+  }
+});
+
+test('contract: GET /api/tree response matches the shared schema', async () => {
+  const { url, close } = await buildApp();
+  try {
+    const state = TreeStateContract.parse(await (await fetch(`${url}/api/tree`)).json());
+    // The seeded Starburst root: a parentless polyp.
+    assert.equal(state.polyps.length, 1);
+    assert.equal(state.polyps[0]!.parentId, null);
+  } finally {
     await close();
   }
 });

--- a/packages/shared/src/ws-schema.ts
+++ b/packages/shared/src/ws-schema.ts
@@ -9,7 +9,11 @@ import { z } from 'zod';
 const vec3 = z.tuple([z.number(), z.number(), z.number()]);
 const quat = z.tuple([z.number(), z.number(), z.number(), z.number()]);
 
-const publicPolyp = z.object({
+// The reef polyp shape as it crosses the wire — embedded in `polyp_added`
+// frames and returned verbatim by GET /api/reef and POST /api/reef/polyp.
+// Exported so a test (or any caller) can validate a live HTTP response against
+// the same contract the WS layer enforces, instead of blind-casting r.json().
+export const PublicPolypSchema = z.object({
   id: z.number(),
   species: z.string(),
   seed: z.number(),
@@ -29,12 +33,15 @@ const simDelta = z.object({
 
 export const ServerMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('hello'), polypCount: z.number(), serverTime: z.number() }),
-  z.object({ type: z.literal('polyp_added'), polyp: publicPolyp }),
+  z.object({ type: z.literal('polyp_added'), polyp: PublicPolypSchema }),
   z.object({ type: z.literal('polyp_removed'), id: z.number() }),
   z.object({ type: z.literal('sim_update'), updates: z.array(simDelta) }),
 ]);
 
-const publicTreePolyp = z.object({
+// The tree polyp shape as it crosses the wire — embedded in `tree_polyp_added`
+// frames and returned verbatim by GET /api/tree and POST /api/tree/polyp.
+// Exported for the same reason as PublicPolypSchema.
+export const PublicTreePolypSchema = z.object({
   id: z.number(),
   variant: z.string(),
   seed: z.number(),
@@ -47,7 +54,7 @@ const publicTreePolyp = z.object({
 
 export const TreeServerMessageSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('tree_hello'), polypCount: z.number(), serverTime: z.number() }),
-  z.object({ type: z.literal('tree_polyp_added'), polyp: publicTreePolyp }),
+  z.object({ type: z.literal('tree_polyp_added'), polyp: PublicTreePolypSchema }),
   z.object({ type: z.literal('tree_polyp_removed'), id: z.number() }),
   z.object({ type: z.literal('tree_reset') }),
 ]);


### PR DESCRIPTION
## Summary

Addresses the priority items (2 and 3) of #109. Item 1 is quest-blocked; items 4-5 are follow-ups (see below).

### Item 2: integration test goes through the real server

`ws.integration.test.ts`'s `buildApp` helper re-implemented the `/ws` route inline, so the production hello payload could drift untested, and `/ws/tree` had no coverage at all. `buildApp` now routes through the real `makeServer` (binds to an ephemeral port; `makeServer` builds the app but doesn't listen), so every registered route and the actual hello payloads are what's under test. Added a `/ws/tree` round-trip test: `tree_hello` plus planting a child broadcasts `tree_polyp_added`.

### Item 3: contract tests against the shared schemas

The client blind-casts `r.json()` in `net/api.ts` and `tree/api.ts`. Exported the polyp shapes already embedded in the WS discriminated unions as `PublicPolypSchema` / `PublicTreePolypSchema`, and:

- the WS frame tests now validate live `hello` / `tree_hello` / `tree_polyp_added` frames against `ServerMessageSchema` / `TreeServerMessageSchema` (the same schemas the client validates inbound frames with), and
- two HTTP contract tests parse the live `GET /api/reef`, `POST /api/reef/polyp`, and `GET /api/tree` responses against the shared schemas.

A drift between server output and the client's assumed shape now fails in CI instead of at runtime.

## Not in this PR

- **Item 1 (questApp.onXRFrame orchestration):** the quest code lives only on the unmerged `quest3-mr-surface` branch, so it can't be tested against main yet. Belongs with that branch's merge.
- **Items 4-5 (broader orchestrator coverage, localStorage/env shims):** lower priority; left for a follow-up. Leaving #109 open for them.

## Test plan

- [x] `pnpm lint` (0 errors)
- [x] `pnpm --filter @reef/shared test` (31 pass)
- [x] `pnpm --filter @reef/server test` (145 pass, +3 integration/contract)
- [x] `pnpm --filter @reef/client test` (375 pass, unaffected)
- [x] Reviewed by code-reviewer + silent-failure-hunter: both clean. Confirmed the buildApp refactor preserves admin-auth gating (auth reads config.adminToken live), no socket races (WsProbe buffers from construction), clean teardown (makeServer starts no workers/heartbeat), and zod throws loudly on any contract drift.