### PR TITLE
docs: sync SECURITY/INSTALL/NEXT_STEPS/PLAN/README with reality

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,12 @@ CLOUDFLARE_TUNNEL_TOKEN=<paste from Cloudflare Zero Trust UI>
 CORS_ORIGINS=https://reef.example.com
 ```
 
-The `ADMIN_TOKEN` gates `DELETE /api/admin/polyp/:id` and nothing else.
+The `ADMIN_TOKEN` gates the admin moderation routes: `DELETE
+/api/admin/polyp/:id`, `GET /api/admin/deleted` (the soft-deleted list),
+and `POST /api/admin/polyp/:id/restore`. When `ADMIN_TOKEN` is set it
+also gates the destructive tree routes (`POST /api/tree/reset`,
+`DELETE /api/tree/polyp/:id`); with no token set those stay open so the
+in-app Clear/Undo buttons work.
 Pick something you can paste into the admin UI once when moderating and
 forget. `CLOUDFLARE_TUNNEL_TOKEN` comes from the Cloudflare Zero Trust
 dashboard (see step 4).

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -30,8 +30,8 @@ Related docs:
   rationale and `docs/superpowers/plans/2026-04-24-ar-phase-2-migration.md`
   for task breakdown.
 - **Stack**: TypeScript 6 · Vite 7 · Vitest 4 · better-sqlite3 12 ·
-  @fastify/cors 9 (pinned — issue #54 tracks Fastify 5 migration) ·
-  node:25-alpine · happy-dom 19 · Oxlint.
+  Fastify 5 + @fastify/cors 11 (the Fastify 5 migration shipped in
+  v0.3.0) · node:22-alpine · happy-dom 20 · Oxlint.
 - **Live production**: **<https://reef.home.local/>** (LAN) — v0.2.0
   image on LXC 300 behind Nginx Proxy Manager with self-signed TLS.
   See _Managing the deployed LXC_ below.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 A collaborative AR installation where visitors tap an NFC tag, open a web-based AR view of a living, procedurally-generated coral reef anchored to a physical pedestal, and add their own polyp. The reef persists and grows forever, simulates subtle biological activity between visitors, and runs entirely on self-hosted infrastructure.
 
+> **Status:** this is the original design plan. A few details were superseded during implementation and are annotated inline below (the `TrackingProvider` interface gained `name`/`start`/`stop` and DOM-free types; tree mode shipped as its own AR surface rather than migrating the reef AR client; TensorFlow.js was never adopted). The implemented interfaces under `packages/*/src` are the source of truth.
+
 ## What changed from v1
 
 - **Tracking:** 8th Wall open source (free, SLAM-based) instead of MindAR. Real world tracking, not just flat-image targets.
@@ -12,7 +14,7 @@ A collaborative AR installation where visitors tap an NFC tag, open a web-based 
 - **Multiple surfaces:** the installation has three entry points sharing one backend:
   - **AR** (phone tapped to pedestal) — SLAM-tracked reef anchor.
   - **Playground** (`playground.html`) — orbit-camera non-AR view for a wall-mounted display next to the AR pedestal.
-  - **Branching web (tree mode)** (`tree.html`) — a different reef where visitors attach small composable pieces to each other's exposed tips, growing a fractal coral structure. Avatar-bioluminescent styling (bloom, vivid palette). Separate DB table (`tree_polyps`), separate WebSocket namespace (`/ws/tree`). Phase 2 will migrate the AR client to read tree data so the pedestal AR shows the same growing fractal the wall screen shows. See [`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md).
+  - **Branching web (tree mode)** (`tree.html`) — a different reef where visitors attach small composable pieces to each other's exposed tips, growing a fractal coral structure. Avatar-bioluminescent styling (bloom, vivid palette). Separate DB table (`tree_polyps`), separate WebSocket namespace (`/ws/tree`). See [`docs/superpowers/plans/2026-04-22-tree-mode.md`](./docs/superpowers/plans/2026-04-22-tree-mode.md). _(Shipped: rather than migrating the reef AR client to read tree data, tree mode got its own AR surface — `treeAr.html`, added in v0.6.0 — alongside the desktop `tree.html`.)_
 
 ## Goals
 
@@ -31,7 +33,7 @@ A collaborative AR installation where visitors tap an NFC tag, open a web-based 
 - **8th Wall open source XR engine** (free binary, self-hosted) for SLAM + image target tracking
 - **Custom `TrackingProvider` interface** wrapping the engine, with `NoopProvider` as the desktop/dev fallback
 - **Plain DOM + CSS** for UI (picker, confirm button, status overlays)
-- **TensorFlow.js** (optional, v2) for any on-device content checks
+- **TensorFlow.js** (was floated as optional, v2, for on-device content checks — never adopted; not a dependency)
 
 ### Backend (`packages/server`)
 
@@ -90,13 +92,22 @@ We use an image target as the origin anchor, but SLAM extends tracking beyond th
 
 ### Tracking provider abstraction
 
+The interface as implemented (`packages/shared/src/tracking.ts`). It evolved
+from the original sketch: types are structural and DOM-free so `@reef/shared`
+stays importable from the server, frames carry a timestamp, providers expose a
+`name`, and `start`/`stop` bracket the camera/SLAM lifecycle separately from
+one-time `init`.
+
 ```ts
 // packages/shared/src/tracking.ts
 export interface TrackingProvider {
-  init(opts: { markerImage: Blob; videoElement: HTMLVideoElement }): Promise<void>;
-  onAnchorFound(cb: (anchor: { pose: Matrix4; id: string }) => void): void;
+  readonly name: 'eightwall' | 'noop';
+  init(opts: TrackingInitOptions): Promise<void>; // { markerImage: string; videoElement: VideoLike; canvasElement?: CanvasLike }
+  onAnchorFound(cb: (ev: AnchorEvent) => void): void; // AnchorEvent = { id: string; pose: Mat4Like }
   onAnchorLost(cb: (id: string) => void): void;
-  onFrame(cb: (cameraPose: Matrix4) => void): void;
+  onFrame(cb: (cameraPose: Mat4Like, t: number) => void): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
   destroy(): Promise<void>;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Vite serves three entry points in addition to the main AR app:
 
 - `GET  /healthz` — liveness
 - `GET  /api/reef` — full public reef state (no `deviceHash` ever leaves)
-- `POST /api/reef/polyp` — submit a polyp (rate-limited to 1/hour/device)
+- `POST /api/reef/polyp` — submit a polyp (rate-limited to one per device
+  per window when `RATE_LIMIT_MAX` is set; open by default while testing)
 - `GET  /api/stats` — polyp count, unique devices, per-species, last 24h/7d
 - `GET  /api/snapshots` / `GET /api/snapshots/:id` — timelapse data
 - `GET  /admin` — admin shell (no auth on the page; API calls require a Bearer token)
@@ -124,6 +125,6 @@ pnpm --filter @reef/server test      # DB, routes, rate limit, admin auth, sim
 
 ## Tracker
 
-Default is 8th Wall if `window.XR8` is present, otherwise noop (useful on desktop/dev — fixed anchor in front of the camera). Force a specific one with `?tracker=eightwall|noop`.
+Default is 8th Wall if `window.XR8` is present, otherwise noop (useful on desktop/dev — fixed anchor in front of the camera). Force a specific one with `?tracker=eightwall|noop`, or `?tracker=auto` to make the default feature-detection explicit (it's what you get with no param). An unknown value also falls back to `auto`.
 
 The client loads the self-hosted `@8thwall/engine-binary` from jsDelivr — no account, no appKey, no phone-home, and the hosted `apps.8thwall.com` path is gone (retired Feb 28, 2026). See [`NEXT_STEPS.md`](./NEXT_STEPS.md) for the binary-EOL notes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting
 
 If you find a vulnerability, please **do not open a public issue**. Email
-the maintainer at `jcosta@execonline.com` with:
+the maintainer at `costajohnt@gmail.com` with:
 
 - A description of the issue
 - Reproduction steps or a proof-of-concept
@@ -23,8 +23,12 @@ Relevant threats for this project:
   single-installation default) they stay open so the in-app Clear/Undo
   buttons work. Polyp creation is open by design and bounded by the rate
   limits below.
-- **Rate-limit bypass**: one polyp per device per hour is the public
-  contract; deviceHash + per-IP token bucket enforce it.
+- **Rate-limit bypass**: the write rate limit is **off by default**
+  (`RATE_LIMIT_MAX=0`) while the project is in single-installation
+  testing. When an operator sets `RATE_LIMIT_MAX` (e.g. 1), the
+  deviceHash + per-IP token bucket enforce one polyp per device per the
+  configured window. Read-side limiting is likewise opt-in via
+  `READ_RATE_LIMIT_PER_MIN`.
 - **Resource exhaustion**: WebSocket frames have a 64 KB payload cap;
   the server soft-hearbeats and evicts silent clients.
 - **Cross-site leaks**: CORS pins the origin via `CORS_ORIGINS`; no


### PR DESCRIPTION
## Summary

Closes #106. Fixes the doc drift the 2026-06 audit found. Saved for last in the batch so it reflects the changes the other PRs landed (e.g. the new `TREE_ROOT_SEED` / rate-limit posture, the versioning reconcile). Every claim verified against the current code.

## Changes

- **SECURITY.md**: the write rate limit is **off by default** (`RATE_LIMIT_MAX=0`), not the enforced "1 polyp/device/hour" the doc claimed; corrected to opt-in (and noted `READ_RATE_LIMIT_PER_MIN`). Moved the security contact off the soon-expiring work address to the durable personal one already used as the repo's git committer. (The tree-route gating claim was already accurate.)
- **INSTALL.md**: `ADMIN_TOKEN` gates `DELETE /api/admin/polyp/:id` **plus** `GET /api/admin/deleted` and `POST /api/admin/polyp/:id/restore` (and the destructive tree routes when set), not "and nothing else".
- **NEXT_STEPS.md**: the Fastify 5 migration shipped, so it's Fastify 5 + `@fastify/cors` 11, no longer pinned to 9. Same line also corrected `node:22-alpine` (was 25) and `happy-dom` 20 (was 19).
- **README.md**: documented `?tracker=auto` (the no-param default, and the unknown-value fallback); qualified the POST rate-limit note with "when `RATE_LIMIT_MAX` is set".
- **PLAN.md**: added a status banner flagging it as the original plan; updated the `TrackingProvider` snippet to the implemented interface (`name`, `start`/`stop`, DOM-free `Mat4Like`/`VideoLike`, timestamped frames); marked TensorFlow.js as never adopted (not a dependency); noted tree mode shipped as `treeAr.html` rather than migrating the reef AR client.

## Verification

Each claim checked against source: `config.ts` (`RATE_LIMIT_MAX ?? 0`), `routes/admin.ts` (three gated routes), `packages/server/package.json` + `infra/Dockerfile.server` (Fastify 5 / cors 11 / node 22), `tracking/index.ts` (`readTrackerFromUrl` returns `auto` by default and on unknown), `shared/src/tracking.ts` (the live interface), and a repo-wide grep confirming TensorFlow.js is absent.

Docs-only; no code paths touched.