### PR TITLE
fix(generator): correct fan back-face and tilted-tube normals

### DIFF
--- a/packages/generator/src/goldens.test.ts
+++ b/packages/generator/src/goldens.test.ts
@@ -19,8 +19,8 @@ const EXPECTED: Record<Species, {
 }> = {
   branching:  { vertexCount: 2560, triangleCount: 2560, sha256: '2864cad3ae042d0d83678606a47318c1d8b09b6da09ec21d586d5388388fbab7' },
   bulbous:    { vertexCount:  551, triangleCount: 1008, sha256: '1f9fced98e063ca3cbf574ed55a0beb5d506246b96910b5d3fd946b91088462a' },
-  fan:        { vertexCount:  324, triangleCount:  324, sha256: '925d9133a6e01eda453f75b07467a5a4769aef08c58a5048a4eefa416a9b43a3' },
-  tube:       { vertexCount:  168, triangleCount:  240, sha256: '899c22f91f5d70ea333a8821575da1c2578781bff2f26195bc42ccf4b845b788' },
+  fan:        { vertexCount:  648, triangleCount:  324, sha256: '66f98c627ab62e817c592ea4b64a1cf55b44bde7c37261a53d347c940854a4ae' },
+  tube:       { vertexCount:  168, triangleCount:  240, sha256: '3eaeaed9d2081df23ebcf15cbc70e0f55fd9dafd3b2de406aeb7e84709ae4e4c' },
   encrusting: { vertexCount:  121, triangleCount:  220, sha256: '367c65f2120dcf610a65ce6e58391d03ae8c052863a2f364650f571694e98b27' },
 };
 
@@ -69,6 +69,42 @@ for (const species of SPECIES) {
     }
   });
 }
+
+// Orientation invariants — the unit-length check above passes a normal that is
+// unit length but points the wrong way. These catch the two orientation bugs
+// fixed in #99: the fan back face was lit as if it faced front, and tube side
+// normals ignored the cylinder's tilt.
+
+test('orientation: fan back faces carry the negated (-Z) normal of the front faces', () => {
+  const { mesh } = generatePolyp({ species: 'fan', seed: FIXED_SEED, colorKey: FIXED_COLOR });
+  let front = 0;
+  let back = 0;
+  for (let v = 0; v < mesh.normals.length / 3; v++) {
+    const nz = mesh.normals[v * 3 + 2]!;
+    if (nz > 0.5) front++;
+    else if (nz < -0.5) back++;
+  }
+  assert.ok(front > 0, 'expected +Z front-face normals');
+  // Every front quad has a matching reversed-winding back quad with -Z normals.
+  assert.equal(back, front, 'each front face must have a matching -Z back face');
+});
+
+test('orientation: tilted tube side normals account for the tilt (non-zero Y)', () => {
+  const { mesh } = generatePolyp({ species: 'tube', seed: FIXED_SEED, colorKey: FIXED_COLOR });
+  let tiltedSide = false;
+  for (let v = 0; v < mesh.normals.length / 3; v++) {
+    const nx = mesh.normals[v * 3]!;
+    const ny = mesh.normals[v * 3 + 1]!;
+    const nz = mesh.normals[v * 3 + 2]!;
+    // A side-wall normal (radial component present, so not the (0,1,0) cap).
+    // The old code forced ny = 0 on every side; a tilted cylinder must not.
+    if (Math.hypot(nx, nz) > 0.01 && Math.abs(ny) > 0.01) {
+      tiltedSide = true;
+      break;
+    }
+  }
+  assert.ok(tiltedSide, 'a tilted cylinder must produce side normals with a Y component');
+});
 
 // Bootstrap: compute hashes the first time, print them so they can be pasted
 // into EXPECTED. After that the test asserts they stay stable.

--- a/packages/generator/src/species/fan.ts
+++ b/packages/generator/src/species/fan.ts
@@ -77,17 +77,31 @@ function addQuad(
   thickness: number,
   color: Rgb,
 ): void {
-  const base = positions.length / 3;
   const t = thickness;
   const verts: [number, number, number][] = [
     [x1, y1, z1 - t], [x2, y2, z2 - t],
     [x2, y2, z2 + t], [x1, y1, z1 + t],
   ];
+
+  // Front face: +Z normal, original winding.
+  const front = positions.length / 3;
   for (const v of verts) {
     positions.push(v[0], v[1], v[2]);
     normals.push(0, 0, 1);
     colors.push(color[0], color[1], color[2]);
   }
-  indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
-  indices.push(base, base + 2, base + 1, base, base + 3, base + 2);
+  indices.push(front, front + 1, front + 2, front, front + 2, front + 3);
+
+  // Back face: reversed winding on its OWN vertices with a -Z normal. The quad
+  // used to be double-sided off a single 4-vertex set with [0,0,1] everywhere,
+  // so the back face (which fans render unculled, being translucent) was lit as
+  // if it faced the camera. Duplicating the verts lets the back carry the
+  // opposite normal so its lighting is correct.
+  const backWind = positions.length / 3;
+  for (const v of verts) {
+    positions.push(v[0], v[1], v[2]);
+    normals.push(0, 0, -1);
+    colors.push(color[0], color[1], color[2]);
+  }
+  indices.push(backWind, backWind + 2, backWind + 1, backWind, backWind + 3, backWind + 2);
 }

--- a/packages/generator/src/species/tube.ts
+++ b/packages/generator/src/species/tube.ts
@@ -45,15 +45,31 @@ function emitCylinder(
   const sides = 10;
   const base = positions.length / 3;
   const tx = Math.sin(tilt) * height;
+  // The cylinder is sheared so its axis runs from (cx,cy,cz) to
+  // (cx+tx, cy+height, cz). The side surface is ruled along that axis, so the
+  // true outward normal at angle theta is perpendicular to BOTH the ring
+  // tangent (-sin, 0, cos) and the axis (tx, height, 0):
+  //   n = normalize(cos t, -sin(tilt) * cos t, sin t)
+  // which is exactly the old radial normal (cos t, 0, sin t) tilted by the
+  // shear. dot(n, axis) = 0, so it's correctly perpendicular to the tilted
+  // axis; the old [x/r, 0, z/r] ignored the tilt and was off by ~tilt rad.
+  const sinTilt = Math.sin(tilt);
   for (let i = 0; i < sides; i++) {
     const theta = (i / sides) * Math.PI * 2;
-    const x = Math.cos(theta) * radius;
-    const z = Math.sin(theta) * radius;
+    const ct = Math.cos(theta);
+    const st = Math.sin(theta);
+    const x = ct * radius;
+    const z = st * radius;
+    const nx = ct;
+    const ny = -sinTilt * ct;
+    const nz = st;
+    const nlen = Math.hypot(nx, ny, nz) || 1;
+    const unx = nx / nlen, uny = ny / nlen, unz = nz / nlen;
     positions.push(cx + x, cy, cz + z);
-    normals.push(x / radius, 0, z / radius);
+    normals.push(unx, uny, unz);
     colors.push(color[0], color[1], color[2]);
     positions.push(cx + x + tx, cy + height, cz + z);
-    normals.push(x / radius, 0, z / radius);
+    normals.push(unx, uny, unz);
     colors.push(color[0], color[1], color[2]);
   }
   for (let i = 0; i < sides; i++) {


### PR DESCRIPTION
## Summary

Closes #99. Two lighting-normal correctness bugs, both verified by math and guarded by new orientation tests.

### Tube: tilted side normals

The cylinder is sheared (its top is shifted by `sin(tilt)*height` in X), but the side normals were the untilted radial `[x/r, 0, z/r]`, off by ~`tilt` rad and visibly wrong under directional light. Replaced with the true outward normal of the sheared side surface:

```
n = normalize(cos θ, -sin(tilt)·cos θ, sin θ)
```

which is perpendicular to the tilted axis (`dot(n, axis) = 0`, verified to machine epsilon) and parallel to `ringTangent × axis`. **Positions are untouched**, so the tube shape is byte-identical; only the normal bytes change.

### Fan: back-face normals

The quad was double-sided off a single 4-vertex set with `[0,0,1]` everywhere, so the reversed-winding back face (fans render unculled, being translucent) was lit as if it faced the camera. The back face now gets its own vertices with the negated `[0,0,-1]` normal. Fan vertex count doubles (324→648); triangle count unchanged. (The `[0,0,±1]` is the deliberate stylistic shading normal — the ribbons' true geometric normal lies in the XY plane — so the fix flips back relative to front, per the issue.)

### Goldens

Both fan and tube golden hashes regenerated deliberately (recomputed and pinned). Two new orientation invariants added, both of which **fail against the pre-fix code**:

- fan has equal +Z and −Z normal counts (pre-fix: all +Z)
- a tilted tube produces side normals with a non-zero Y (pre-fix: every side normal forced `ny=0`)

## Test plan

- [x] `pnpm --filter @reef/generator test` (61 pass, incl. 2 new orientation tests + regenerated goldens)
- [x] `pnpm --filter @reef/generator typecheck`
- [x] `pnpm --filter @reef/client test` (381) + `@reef/server test` (145) — generator-only change, unaffected
- [x] `pnpm lint` (0 errors)
- [x] Reviewed by code-reviewer: math verified independently (perpendicularity, outward orientation, winding reversal), goldens justified, orientation tests confirmed to guard the fix