### PR TITLE
Pass CORS_ORIGINS through docker-compose so the production deploy boots

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -191,4 +191,4 @@ applied migrations, add new ones.
 | WebSocket connects then disconnects every ~60 s | Cloudflare idle timeout; heartbeat is enabled server-side but verify `ws` upgrade headers pass through any proxy |
 | `polyp_added` arrives on some tabs but not others | Hub evicted the stale client; check `docker compose logs server` for `hub broadcast failed` lines |
 | Client shows "Looking for the reef…" and never advances | Pedestal marker is out of frame, too dim, or at a glancing angle. Good light is non-optional. |
-| Container restarts repeatedly | `ADMIN_TOKEN` missing in `.env` and compose fails the `:?` check; set it and `docker compose up -d` |
+| Container restarts repeatedly | `ADMIN_TOKEN` or `CORS_ORIGINS` missing in `.env` and compose fails the `:?` check; set them and `docker compose up -d`. (`CORS_ORIGINS` is also enforced at server startup under `NODE_ENV=production` — it must be an explicit origin, not `*`.) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - PORT=8787
       - DB_PATH=/data/reef.db
       - ADMIN_TOKEN=${ADMIN_TOKEN:?set ADMIN_TOKEN in .env}
+      # Required under NODE_ENV=production: the server fails closed
+      # (assertProductionCorsSafe) and refuses to start if CORS_ORIGINS is
+      # unset or wide-open "*". The :? guard turns that boot crash-loop into a
+      # clear `docker compose up` error instead.
+      - CORS_ORIGINS=${CORS_ORIGINS:?set CORS_ORIGINS in .env}
       # Rate limits are opt-in and default off while the project is in
       # testing. Uncomment to re-enable for production.
       # - RATE_LIMIT_WINDOW_MS=3600000


### PR DESCRIPTION
## Problem

`docker-compose.yml` sets `NODE_ENV=production` but never passes `CORS_ORIGINS` into the container. `config.ts` then defaults `corsOrigins` to `*`, and `assertProductionCorsSafe` (invoked at `config.ts:106`) throws at startup. With `restart: unless-stopped`, the documented Beelink + Cloudflare-tunnel deploy crash-loops forever, even when `.env` correctly sets `CORS_ORIGINS`.

## Fix

Add `CORS_ORIGINS=${CORS_ORIGINS:?set CORS_ORIGINS in .env}` to the server `environment`, mirroring the existing `ADMIN_TOKEN` guard. A missing value now fails loudly at `docker compose` interpolation time with a clear message, instead of silently crash-looping at server boot.

`.env.example`, `INSTALL.md`, and `docs/runbook.md` already documented `CORS_ORIGINS`; the only gap was the compose passthrough. Also extended INSTALL.md's "container restarts repeatedly" troubleshooting row to name `CORS_ORIGINS` alongside `ADMIN_TOKEN`.

## Verification

```
# unset -> fails at interpolation (no crash-loop)
ADMIN_TOKEN=x CLOUDFLARE_TUNNEL_TOKEN=y docker compose config
# -> error: required variable CORS_ORIGINS is missing a value: set CORS_ORIGINS in .env

# set -> renders
... CORS_ORIGINS=https://reef.example.com docker compose config
# -> CORS_ORIGINS: https://reef.example.com
```

No application source changed (compose + docs only), so the test suite is unaffected. Branched off `main`; PR #87 is untouched.