### PR TITLE
ci: dependabot ignores node major bumps (pinned LTS base image)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,10 @@ updates:
     labels: [dependencies, docker]
     commit-message:
       prefix: docker
+    ignore:
+      # Dockerfile.server deliberately pins the current LTS major (22): a
+      # floating odd/non-LTS tag silently advances and can break the
+      # better-sqlite3 native binding between smoke runs. Node major bumps
+      # are a deliberate manual change, not a dependabot PR (see closed #84).
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Follow-up to closing #84: `Dockerfile.server` deliberately pins node 22 LTS (the in-file comment explains the better-sqlite3 native-binding risk of floating tags), but dependabot's docker ecosystem kept proposing node major bumps against it. This adds an `ignore` rule for node semver-major updates only — minor/patch base-image updates still flow.